### PR TITLE
docs: sync all documentation with v0.1.1 codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Native AOT binary. No runtime required. ~9 MB.
 
 ## Features
 
-- **7 commands** — login, config, libraries, items, series, authors, search
+- **8 commands** — login, config, libraries, items, series, authors, search, self-test
 - **JSON-only output** — stdout is always valid JSON matching the ABS API, errors go to stderr
 - **Native AOT** — single self-contained binary, no .NET runtime needed
 - **Config precedence** — CLI flags > environment variables > config file
@@ -141,7 +141,7 @@ dotnet run --project src/AbsCli/AbsCli.csproj -- self-test
 # Full smoke test against a live ABS instance
 docker compose -f docker/docker-compose.yml up -d
 bash docker/seed.sh
-bash docker/smoke-test.sh                          # builds AOT binary + runs 37 assertions
+bash docker/smoke-test.sh                          # builds AOT binary + runs 71 assertions
 docker compose -f docker/docker-compose.yml down -v
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,12 +22,18 @@ CLI  →  Service  →  API Client  →  DTOs
 ```
 
 - **CLI** — Command parsing, argument validation, help text, output to stdout/stderr.
-  Uses System.CommandLine.
-- **Service** — Business logic and orchestration. Coordinates API calls.
+  Uses System.CommandLine. `HelpExtensions` adds custom help sections (Examples,
+  Filter groups, Sort fields) via `HelpBuilder.CustomizeLayout`. `CommandHelper`
+  provides shared client/config resolution for all commands.
+- **Service** — Business logic and orchestration. Returns typed DTOs (not raw strings)
+  to validate the API contract at the service boundary.
 - **API Client** — HTTP communication with Audiobookshelf. Single `AbsApiClient` class
-  wrapping `HttpClient`. Handles auth headers, base URL, filter encoding.
-- **DTOs** — Explicit data transfer objects. Serialized with System.Text.Json source
-  generators (AOT-compatible, no reflection).
+  wrapping `HttpClient`. Handles auth headers, token refresh, base URL. Generic
+  `GetAsync<T>` overloads deserialize responses through `JsonTypeInfo<T>`.
+- **DTOs** — Explicit data transfer objects. All types that cross the serialization
+  boundary are registered in `JsonContext.cs` (`[JsonSerializable]` attributes)
+  for AOT source-generated serialization. This is critical — missing a type causes
+  runtime crashes under AOT.
 
 ## Project Structure
 
@@ -44,6 +50,9 @@ abs-cli/
         SearchCommand.cs
         ConfigCommand.cs
         LoginCommand.cs
+        SelfTestCommand.cs         # AOT integrity verification
+        CommandHelper.cs           # Shared client/config resolution
+        HelpExtensions.cs          # Custom help sections (Examples, Filter groups, etc.)
       Services/
         ItemsService.cs
         LibrariesService.cs
@@ -53,18 +62,23 @@ abs-cli/
       Api/
         AbsApiClient.cs
         ApiEndpoints.cs
+        FilterEncoder.cs           # Base64 filter encoding for ABS API
+        TokenHelper.cs             # JWT expiry decoding
       Models/
+        JsonContext.cs              # Source-generated serialization (AOT-critical)
         LibraryItem.cs
         Library.cs
         Series.cs
         Author.cs
         SearchResult.cs
+        UpdateMediaResponse.cs
+        BatchGetResponse.cs
         ...
       Configuration/
         AppConfig.cs
         ConfigManager.cs
       Output/
-        JsonOutput.cs
+        ConsoleOutput.cs
   tests/
     AbsCli.Tests/
 ```
@@ -74,9 +88,10 @@ abs-cli/
 - No Newtonsoft.Json — incompatible with AOT trimming
 - No `dynamic` — breaks AOT compilation
 - No reflection — breaks AOT trimming
-- Explicit DTOs — every API response has a typed model
+- Explicit DTOs — every API response deserializes through a typed model (contract validation)
+- Every serialized type must be registered in `JsonContext.cs` — untested types crash under AOT
 - JSON is the only output format in v1
-- JSON output matches ABS API response structure exactly — no transformation
+- JSON output is re-serialized from typed DTOs (validates contract, may drop unknown fields)
 
 ## Stack
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -10,6 +10,12 @@ ABS supports access + refresh token pairs. Both are fully implemented:
 The old non-expiring `user.token` still works but is deprecated in the ABS source
 (`@deprecated` annotation, `isOldToken` tracking flag). API keys are also being deprecated.
 
+## HTTP Headers
+
+All requests include a `User-Agent: abs-cli/{version}` header. Some ABS
+deployments behind reverse proxies (e.g. Cosmos) reject requests without a
+User-Agent, returning 403. Added in v0.1.1.
+
 ## Auth Flow
 
 1. **Login:** `POST /login` with `X-Return-Tokens: true` header — response includes

--- a/docs/build.md
+++ b/docs/build.md
@@ -49,6 +49,7 @@ The `self-test` command verifies all registered types work correctly.
 
 - **unit-test** — xUnit tests
 - **smoke-test** — AOT binary against live ABS Docker instance (linux-x64)
-- **build** — 5-platform AOT matrix, each runs `self-test` (except osx-x64 cross-compile)
+- **build** — 6-platform AOT matrix, each runs `self-test` (osx-x64 via Rosetta 2)
+- Binaries auto-attached to GitHub Releases on release events
 - Artifacts uploaded per platform
 - Triggered on pull requests and releases

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,7 @@ Highest wins:
 |---------|-------------|
 | `abs-cli config get` | Shows current config (tokens masked) |
 | `abs-cli config set <key> <value>` | Generic config setter |
-| `abs-cli config set default-library <id\|name>` | Sets default library. Validates it exists on the server. |
+| `abs-cli config set default-library <id\|name>` | Sets default library (stored locally, not validated against server) |
 
 ## Error Messages
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -11,106 +11,100 @@ Semantic versioning: `MAJOR.MINOR.PATCH`
 ## Release Workflow — Agentic Flow with Human Gates
 
 The release process is a multi-step agentic workflow. An agent drives each
-step, but pauses at human gates for review before proceeding. This will be
-implemented as a `/release` slash command (`.claude/commands/release.md`)
-after the v0.1.0 PR is merged.
+step, but pauses at human gates for review before proceeding. Invoked via
+`/release` in Claude Code.
 
 ### Step 1: Preflight (agent)
 
 Agent verifies prerequisites:
 - On `main` branch, working tree clean
+- Format check (`dotnet format --verify-no-changes`)
 - All unit tests pass (`dotnet test`)
-- Determine version: agent proposes based on commits since last tag, human confirms
+- AOT build + self-test (25 checks)
+- Smoke test against ABS if Docker available (71 assertions)
+- Determine version based on commits since last tag
 
 **Human gate:** Confirm the version number.
 
-### Step 2: Generate release notes (agent)
-
-Agent generates release notes with two sections:
-
-**Highlights** — 3-5 bullet points in plain language. Agent writes these
-by reading the commits and summarizing what users care about.
-
-**Changes** — auto-grouped from conventional commits since last tag:
+### Step 2: Create release branch (agent)
 
 ```bash
-git log --oneline $(git describe --tags --abbrev=0)..HEAD --pretty="- %s" \
-    | grep -E "^- (feat|fix|refactor|docs|ci|test):" | sort
+git checkout -b release/v{version}
 ```
 
-Format:
-```markdown
-## Highlights
-- First release of abs-cli with full audiobook metadata management
-- Native AOT binaries for 6 platforms — no runtime required
-- ...
+### Step 3: Generate release notes (agent)
 
-## Features
-- feat: add login command with access+refresh token storage
-- ...
+Agent writes `release-notes.md` with two sections:
 
-## Fixes
-- fix: resolve AOT reflection errors in ConfigManager and AbsApiClient
-- ...
-```
+**Highlights** — 3-5 bullet points in plain language.
 
-Agent saves notes to `release-notes.md` (gitignored).
+**Changes** — auto-grouped from conventional commits since last tag.
 
-**Human gate:** Review and approve the release notes. Edit if needed.
+**Human gate:** Review and approve the release notes.
 
-### Step 3: Create GitHub Release (agent)
+Agent then prepends the notes to `CHANGELOG.md` and commits.
+
+### Step 4: Open PR for CI validation (agent)
 
 ```bash
+git push -u origin release/v{version}
+gh pr create --title "release: v{version}" --base main
+```
+
+CI runs the full pipeline (unit tests, 6-platform AOT builds + self-test,
+smoke test against live ABS). Agent monitors and reports results.
+
+**Human gate:** CI passed — review and merge the PR.
+
+### Step 5: Tag and create GitHub Release (agent)
+
+After merge, agent switches to main and creates the release using the
+same `release-notes.md` from step 3:
+
+```bash
+git checkout main && git pull
 gh release create v{version} --title "v{version}" --notes-file release-notes.md
 ```
 
-This creates the tag, publishes the release with notes, and triggers CI.
+**Human gate:** Confirm the release was created.
 
-**Human gate:** Confirm the release was created. Agent shows the URL.
+### Step 6: Wait for release CI (agent)
 
-### Step 4: Wait for CI (agent)
+The release event triggers CI which builds all 6 platforms and
+**automatically attaches binaries** to the GitHub Release.
 
-Agent monitors the CI run:
-```bash
-gh run watch <run-id> --exit-status
-```
+Agent monitors the run and reports results.
 
-Reports status. If CI fails, agent diagnoses and stops — no further steps
-until the failure is resolved.
+### Step 7: Verify (agent + human)
 
-**Human gate:** CI passed — confirm before attaching binaries.
-
-### Step 5: Attach binaries (agent)
-
-```bash
-gh run download <run-id> --dir ./release-artifacts
-gh release upload v{version} ./release-artifacts/abs-cli-*/*
-rm -rf release-artifacts release-notes.md
-```
-
-### Step 6: Verify (agent + human)
-
-Agent downloads one binary and runs `self-test`. Reports result.
+Agent downloads one binary and runs `self-test`.
 
 **Human gate:** Check the GitHub Release page — all 6 binaries attached,
-notes render correctly, everything looks right.
+notes render correctly.
 
-### Step 7: Done
+### Step 8: Done
 
-Agent reports the release URL and a summary.
+Agent cleans up (`release-notes.md`, any temp files) and reports summary.
 
 ## Human Gates Summary
 
 | After step | Agent pauses for | Why |
 |------------|-----------------|-----|
 | 1. Preflight | Version confirmation | Human decides the version |
-| 2. Release notes | Notes review | Human quality-checks what users see |
-| 3. Create release | Release URL confirmation | Point of no return for the tag |
-| 4. CI completion | CI result acknowledgement | Don't attach to a broken release |
-| 6. Verify | Final visual check | Human confirms the public-facing page |
+| 3. Release notes | Notes review | Human quality-checks what users see |
+| 4. CI validation | Merge approval | Full CI must pass before tagging |
+| 5. Create release | Release URL confirmation | Point of no return for the tag |
+| 7. Verify | Final visual check | Human confirms the public-facing page |
 
 ## Implementation
 
 Implemented as `.claude/skills/release/SKILL.md` — a project-local skill
 invoked via `/release` in Claude Code. The skill is human-invocable only
 (`disable-model-invocation: true`) to prevent accidental releases.
+
+`CHANGELOG.md` is the permanent record. GitHub Release notes mirror it.
+`release-notes.md` is the working document (gitignored) — written by agent,
+reviewed by human, prepended to CHANGELOG.md, passed to `gh release create`.
+
+CI auto-attaches binaries to GitHub Releases via `gh release upload` in
+the build job (`permissions: contents: write`).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,13 +22,17 @@ dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj
 
 ### 2. Self-Test (built-in command)
 
-14 assertions exercising all AOT-sensitive code paths without network access:
+25 checks exercising all AOT-sensitive code paths without network access:
 
-- Source-generated JSON serialization (all types in `JsonContext`)
-- Config save/load round-trip
-- Filter encoder
-- Token helper
-- Console output
+- Source-generated JSON round-trips for all 15 types in `JsonContext`
+  (AppConfig, LoginRequest, LoginResponse, Dictionary, LibraryListResponse,
+  Library, PaginatedResponse, LibraryItemMinified, SearchResult,
+  UpdateMediaResponse, BatchUpdateResponse, BatchGetResponse, SeriesItem,
+  AuthorItem, AuthorListResponse)
+- Config save/load round-trip and precedence resolution
+- Filter encoder (encode, pass-through, reject)
+- Token helper (JWT parse, no-exp, garbage input)
+- Console output (WriteJson, WriteRawJson)
 
 ```bash
 abs-cli self-test
@@ -39,10 +43,11 @@ attributes, broken source generators, and platform-specific AOT issues.
 
 ### 3. Smoke Tests (bash, against live ABS)
 
-67 assertions running the AOT binary against a real Audiobookshelf Docker
+71 assertions running the AOT binary against a real Audiobookshelf Docker
 instance seeded with 15 books, 6 authors, and 3 series:
 
-- All 23 help screens render correctly
+- All help screens render correctly (parent commands + leaf commands with examples)
+- Filter groups and sort fields sections present in `items list --help`
 - Config set/get round-trip
 - Libraries list/get — correct count, correct library by ID and name
 - Items list — 15 items, pagination (5 per page, total preserved)
@@ -73,8 +78,8 @@ CLI=./path/to/abs-cli bash docker/smoke-test.sh
 | Job | What | Platforms |
 |-----|------|-----------|
 | unit-test | xUnit tests | ubuntu (any) |
-| smoke-test | AOT binary + live ABS (67 assertions) | linux-x64 only (Docker required) |
-| build | AOT publish + self-test (14 assertions) | linux-x64, linux-arm64, osx-arm64, osx-x64, win-x64, win-arm64 |
+| smoke-test | AOT binary + live ABS (71 assertions) | linux-x64 only (Docker required) |
+| build | AOT publish + self-test (25 checks) | linux-x64, linux-arm64, osx-arm64, osx-x64, win-x64, win-arm64 |
 
 The smoke test is Linux-only because it needs a Docker ABS container.
 Self-test runs on all platforms to validate AOT integrity everywhere.


### PR DESCRIPTION
## Summary

Deep audit of all docs against current code found 7 files with discrepancies.

- **releasing.md** — rewritten entirely, old flow didn't match the actual skill (no release branch, no CHANGELOG.md, manual binary attach)
- **build.md** — "5-platform" → 6, removed incorrect "except osx-x64" self-test exclusion
- **configuration.md** — removed false claim that `config set default-library` validates against server
- **testing.md** — self-test 14→25 checks, smoke test 67→71 assertions
- **authentication.md** — added User-Agent header documentation (v0.1.1 fix)
- **architecture.md** — added HelpExtensions, CommandHelper, JsonContext, FilterEncoder, TokenHelper to project structure; updated layer descriptions
- **README.md** — 7→8 commands, 37→71 smoke assertions

Also persisted 5 new learnings to MemPalace (typed DTO contract, HelpExtensions, User-Agent, release workflow, self-test coverage rule).