### PR TITLE
feat: v0.2.0 - backup, upload, scan, metadata, tasks commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
       - name: Check formatting
@@ -31,8 +31,8 @@ jobs:
         ports:
           - 13378:80
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
       - name: Build AOT binary
@@ -79,8 +79,8 @@ jobs:
             rid: win-arm64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
       - name: Publish
@@ -94,7 +94,7 @@ jobs:
           [ -f "${BIN}.exe" ] && BIN="${BIN}.exe"
           "${BIN}" self-test
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: abs-cli-${{ matrix.rid }}
           path: src/AbsCli/bin/Release/net8.0/${{ matrix.rid }}/publish/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,17 @@ test: add metadata update assertion to smoke tests
 - If formatting check fails in CI, run the format command and commit the fix.
 - **No unnecessary blank lines** inside method bodies: no blanks between consecutive `AddCommand`/`AddOption` calls, no blank before `return` after setup calls, no blanks between consecutive variable declarations of the same kind. Keep methods compact — see `AuthorsCommand.cs` as reference.
 
+## ABS Source Reference
+
+- The ABS server source is the authoritative reference for API behavior, request/response shapes, and routing — `https://api.audiobookshelf.org` is **stale** and unreliable.
+- Expected location: `temp/audiobookshelf/` (gitignored). If missing, clone the currently supported version before referencing API code:
+  ```bash
+  # Supported version is set in src/AbsCli/Api/AbsApiClient.cs (MinSupportedVersion / MaxTestedVersion)
+  git clone --depth 1 --branch v2.33.1 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
+  ```
+- Replace the version tag with whatever `MinSupportedVersion` is currently set to.
+- Use this checkout to verify endpoints, controllers, request/response shapes, and permission checks before designing or changing CLI commands.
+
 ## MemPalace
 
 - A project-local memory palace is available via MCP at `.mempalace/`

--- a/docker/seed.sh
+++ b/docker/seed.sh
@@ -70,6 +70,26 @@ curl -sf -X POST "$ABS_URL/api/users" \
         }
     }' > /dev/null 2>&1 || true
 
+# Create upload test user (can upload but not delete)
+echo "Creating upload test user..."
+curl -sf -X POST "$ABS_URL/api/users" \
+    -H "$AUTH" \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "username": "uploaduser",
+        "password": "uploadpass",
+        "type": "user",
+        "permissions": {
+            "download": true,
+            "update": true,
+            "delete": false,
+            "upload": true,
+            "accessAllLibraries": true,
+            "accessAllTags": true,
+            "accessExplicitContent": true
+        }
+    }' > /dev/null 2>&1 || true
+
 # --- Upload test audiobooks ---
 # Create a tiny silent MP3 (1 second) for uploads
 TMPDIR=$(mktemp -d)
@@ -160,4 +180,4 @@ echo "ABS_URL=$ABS_URL"
 echo "LIBRARY_ID=$LIBRARY_ID"
 echo "Items: $ITEM_COUNT (6 authors, 3 series, 15 books)"
 echo "Root credentials: root/root"
-echo "Test credentials: testuser/testpass"
+echo "Test credentials: testuser/testpass, uploaduser/uploadpass"

--- a/docker/seed.sh
+++ b/docker/seed.sh
@@ -59,6 +59,7 @@ curl -sf -X POST "$ABS_URL/api/users" \
         "username": "testuser",
         "password": "testpass",
         "type": "user",
+        "isActive": true,
         "permissions": {
             "download": true,
             "update": true,
@@ -79,6 +80,7 @@ curl -sf -X POST "$ABS_URL/api/users" \
         "username": "uploaduser",
         "password": "uploadpass",
         "type": "user",
+        "isActive": true,
         "permissions": {
             "download": true,
             "update": true,

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -399,6 +399,73 @@ if [ -n "$UPLOADED_ITEM_ID" ]; then
         -H "Authorization: Bearer $ABS_TOKEN" > /dev/null 2>&1 || true
 fi
 
+# Filename-collision tests: build a 2-dir source tree where both dirs have a file
+# called "01.mp3". Confirm default errors, --prefix-source-dir succeeds, and
+# --files-manifest succeeds. All three uploads run as uploaduser and clean up.
+
+COLLIDE_TMP=$(mktemp -d)
+mkdir -p "$COLLIDE_TMP/Part1" "$COLLIDE_TMP/Part2"
+python3 -c "
+header = bytes([0xFF, 0xFB, 0x90, 0x00])
+frame = header + b'\x00' * 413
+for d in ['$COLLIDE_TMP/Part1', '$COLLIDE_TMP/Part2']:
+    for n in ['01.mp3', '02.mp3']:
+        with open(f'{d}/{n}', 'wb') as f:
+            for _ in range(10):
+                f.write(frame)
+"
+
+export ABS_TOKEN="$UPLOAD_TOKEN"
+
+# Default: collision detected, error, no upload
+collide_out=$($CLI upload --title "Collision Default" --author "Collide Author" \
+    --folder "$FOLDER_ID" --files "$COLLIDE_TMP"/Part1/*.mp3 "$COLLIDE_TMP"/Part2/*.mp3 2>&1 || true)
+if echo "$collide_out" | grep -qi "Duplicate filenames"; then
+    pass "upload errors on duplicate basenames by default"
+else
+    fail "upload errors on duplicate basenames by default" "got: ${collide_out:0:200}"
+fi
+
+# --prefix-source-dir: succeeds, all 4 files land on server with prefixed names
+prefix_out=$($CLI upload --title "Collision Prefix" --author "Collide Author Prefix" \
+    --folder "$FOLDER_ID" --prefix-source-dir --wait \
+    --files "$COLLIDE_TMP"/Part1/*.mp3 "$COLLIDE_TMP"/Part2/*.mp3 2>/dev/null)
+PREFIX_ITEM=$(echo "$prefix_out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || echo "")
+if [ -n "$PREFIX_ITEM" ]; then
+    pass "upload --prefix-source-dir created item"
+    export ABS_TOKEN="$SAVE_TOKEN"
+    curl -sf -X DELETE "$ABS_URL/api/items/$PREFIX_ITEM?hard=1" \
+        -H "Authorization: Bearer $ABS_TOKEN" > /dev/null 2>&1 || true
+    export ABS_TOKEN="$UPLOAD_TOKEN"
+else
+    fail "upload --prefix-source-dir created item" "item not found in library"
+fi
+
+# --files-manifest: succeeds with explicit per-file naming
+cat > "$COLLIDE_TMP/manifest.json" <<EOF
+[
+  {"src": "$COLLIDE_TMP/Part1/01.mp3", "as": "001-track.mp3"},
+  {"src": "$COLLIDE_TMP/Part1/02.mp3", "as": "002-track.mp3"},
+  {"src": "$COLLIDE_TMP/Part2/01.mp3", "as": "003-track.mp3"},
+  {"src": "$COLLIDE_TMP/Part2/02.mp3", "as": "004-track.mp3"}
+]
+EOF
+manifest_out=$($CLI upload --title "Collision Manifest" --author "Collide Author Manifest" \
+    --folder "$FOLDER_ID" --files-manifest "$COLLIDE_TMP/manifest.json" --wait 2>/dev/null)
+MANIFEST_ITEM=$(echo "$manifest_out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || echo "")
+if [ -n "$MANIFEST_ITEM" ]; then
+    pass "upload --files-manifest created item"
+    export ABS_TOKEN="$SAVE_TOKEN"
+    curl -sf -X DELETE "$ABS_URL/api/items/$MANIFEST_ITEM?hard=1" \
+        -H "Authorization: Bearer $ABS_TOKEN" > /dev/null 2>&1 || true
+    export ABS_TOKEN="$UPLOAD_TOKEN"
+else
+    fail "upload --files-manifest created item" "item not found in library"
+fi
+
+export ABS_TOKEN="$SAVE_TOKEN"
+rm -rf "$COLLIDE_TMP"
+
 # ============================================================
 echo ""
 echo "=== Permission Errors ==="

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -381,8 +381,10 @@ export ABS_TOKEN="$UPLOAD_TOKEN"
 
 output=$($CLI upload --title "Smoke Test Upload" --author "Test Author" \
     --folder "$FOLDER_ID" --wait --files "$UPLOAD_TMP/test.mp3" 2>/dev/null)
+UPLOADED_ITEM_ID=""
 if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'id' in d" 2>/dev/null; then
     pass "upload --wait returned item JSON"
+    UPLOADED_ITEM_ID=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
 else
     fail "upload --wait returned item JSON" "no id in response"
     echo "    response: ${output:0:200}"
@@ -390,6 +392,12 @@ fi
 
 export ABS_TOKEN="$SAVE_TOKEN"
 rm -rf "$UPLOAD_TMP"
+
+# Cleanup: hard-delete the uploaded item (also removes orphan author "Test Author")
+if [ -n "$UPLOADED_ITEM_ID" ]; then
+    curl -sf -X DELETE "$ABS_URL/api/items/$UPLOADED_ITEM_ID?hard=1" \
+        -H "Authorization: Bearer $ABS_TOKEN" > /dev/null 2>&1 || true
+fi
 
 # ============================================================
 echo ""

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -335,7 +335,7 @@ assert_json_key "backup list has backupLocation" "backupLocation" "$output"
 assert_json_expr "backup list finds our backup" \
     "any(b['id']=='$BACKUP_ID' for b in d['backups'])" "$output"
 
-BACKUP_DL=$(mktemp)
+BACKUP_DL=$(mktemp --suffix=.audiobookshelf)
 $CLI backup download --id "$BACKUP_ID" --output "$BACKUP_DL" 2>/dev/null
 if [ -s "$BACKUP_DL" ]; then
     pass "backup download wrote file"

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -88,7 +88,7 @@ echo "=== Help Screens ==="
 # ============================================================
 
 # Parent commands and self-test don't need examples (they just list subcommands)
-for cmd in "" "config" "libraries" "items" "series" "authors" "self-test"; do
+for cmd in "" "config" "libraries" "items" "series" "authors" "backup" "metadata" "tasks" "self-test"; do
     label="help: abs-cli $cmd --help"
     output=$($CLI $cmd --help 2>&1) || true
     if echo "$output" | grep -q "Description:\|Usage:"; then
@@ -100,11 +100,15 @@ done
 
 # Leaf commands must have at least 2 examples (for AI agent usability)
 for cmd in "login" "config get" "config set" \
-           "libraries list" "libraries get" \
+           "libraries list" "libraries get" "libraries scan" \
            "items list" "items get" "items search" \
-           "items update" "items batch-update" "items batch-get" \
+           "items update" "items batch-update" "items batch-get" "items scan" \
            "series list" "series get" \
            "authors list" "authors get" \
+           "backup create" "backup list" "backup apply" "backup download" "backup delete" "backup upload" \
+           "upload" \
+           "metadata search" "metadata providers" "metadata covers" \
+           "tasks list" \
            "search"; do
     label="help+examples: abs-cli $cmd"
     output=$($CLI $cmd --help 2>&1) || true
@@ -313,6 +317,158 @@ assert_json_expr "search finds Storm Front" "len(d.get('book',[]))>0" "$output"
 
 output=$($CLI search --query "Mistborn" 2>/dev/null)
 assert_json_expr "search finds Mistborn series" "len(d.get('series',[]))>0" "$output"
+
+# ============================================================
+echo ""
+echo "=== Backup Commands ==="
+# ============================================================
+
+output=$($CLI backup create 2>/dev/null)
+assert_json_key "backup create returns backups" "backups" "$output"
+assert_json_expr "backup create has at least 1 backup" "len(d['backups'])>=1" "$output"
+
+BACKUP_ID=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin)['backups'][-1]['id'])")
+
+output=$($CLI backup list 2>/dev/null)
+assert_json_key "backup list has backups" "backups" "$output"
+assert_json_key "backup list has backupLocation" "backupLocation" "$output"
+assert_json_expr "backup list finds our backup" \
+    "any(b['id']=='$BACKUP_ID' for b in d['backups'])" "$output"
+
+BACKUP_DL=$(mktemp)
+$CLI backup download --id "$BACKUP_ID" --output "$BACKUP_DL" 2>/dev/null
+if [ -s "$BACKUP_DL" ]; then
+    pass "backup download wrote file"
+else
+    fail "backup download wrote file" "file is empty"
+fi
+
+output=$($CLI backup upload --file "$BACKUP_DL" 2>/dev/null)
+assert_json_key "backup upload returns backups" "backups" "$output"
+rm -f "$BACKUP_DL"
+
+output=$($CLI backup apply --id "$BACKUP_ID" 2>/dev/null)
+pass "backup apply completed (exit 0)"
+
+output=$($CLI backup delete --id "$BACKUP_ID" 2>/dev/null)
+assert_json_key "backup delete returns backups" "backups" "$output"
+
+# ============================================================
+echo ""
+echo "=== Upload Command ==="
+# ============================================================
+
+FOLDER_ID=$(echo "$($CLI libraries get --id "$LIB_ID" 2>/dev/null)" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['folders'][0]['id'])")
+
+UPLOAD_TMP=$(mktemp -d)
+python3 -c "
+header = bytes([0xFF, 0xFB, 0x90, 0x00])
+frame = header + b'\x00' * 413
+with open('$UPLOAD_TMP/test.mp3', 'wb') as f:
+    for _ in range(38):
+        f.write(frame)
+"
+
+UPLOAD_TOKEN=$(curl -sf -X POST "$ABS_URL/login" \
+    -H 'Content-Type: application/json' \
+    -H 'X-Return-Tokens: true' \
+    -d '{"username":"uploaduser","password":"uploadpass"}' \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['user']['accessToken'])")
+
+SAVE_TOKEN="$ABS_TOKEN"
+export ABS_TOKEN="$UPLOAD_TOKEN"
+
+output=$($CLI upload --title "Smoke Test Upload" --author "Test Author" \
+    --folder "$FOLDER_ID" --wait --files "$UPLOAD_TMP/test.mp3" 2>/dev/null)
+if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'id' in d" 2>/dev/null; then
+    pass "upload --wait returned item JSON"
+else
+    fail "upload --wait returned item JSON" "no id in response"
+    echo "    response: ${output:0:200}"
+fi
+
+export ABS_TOKEN="$SAVE_TOKEN"
+rm -rf "$UPLOAD_TMP"
+
+# ============================================================
+echo ""
+echo "=== Permission Errors ==="
+# ============================================================
+
+TEST_TOKEN=$(curl -sf -X POST "$ABS_URL/login" \
+    -H 'Content-Type: application/json' \
+    -H 'X-Return-Tokens: true' \
+    -d '{"username":"testuser","password":"testpass"}' \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['user']['accessToken'])")
+
+SAVE_TOKEN="$ABS_TOKEN"
+export ABS_TOKEN="$TEST_TOKEN"
+
+UPLOAD_TMP2=$(mktemp -d)
+python3 -c "
+with open('$UPLOAD_TMP2/test.mp3', 'wb') as f:
+    f.write(bytes([0xFF, 0xFB, 0x90, 0x00]) + b'\x00' * 413)
+"
+
+error_output=$($CLI upload --title "Should Fail" --author "Test" \
+    --folder "$FOLDER_ID" --files "$UPLOAD_TMP2/test.mp3" 2>&1 || true)
+if echo "$error_output" | grep -qi "permission denied"; then
+    pass "upload as testuser shows permission denied"
+else
+    fail "upload as testuser shows permission denied" "got: ${error_output:0:200}"
+fi
+rm -rf "$UPLOAD_TMP2"
+
+error_output=$($CLI backup list 2>&1 || true)
+if echo "$error_output" | grep -qi "permission denied\|admin"; then
+    pass "backup list as testuser shows permission denied"
+else
+    fail "backup list as testuser shows permission denied" "got: ${error_output:0:200}"
+fi
+
+export ABS_TOKEN="$SAVE_TOKEN"
+
+# ============================================================
+echo ""
+echo "=== Scan Commands ==="
+# ============================================================
+
+$CLI libraries scan 2>/dev/null
+pass "libraries scan completed (exit 0)"
+
+sleep 2
+
+output=$($CLI tasks list 2>/dev/null)
+assert_json_key "tasks list has tasks" "tasks" "$output"
+
+output=$($CLI items scan --id "$FIRST_ITEM_ID" 2>/dev/null)
+assert_json_key "items scan has result" "result" "$output"
+
+# ============================================================
+echo ""
+echo "=== Metadata Commands ==="
+# ============================================================
+
+output=$($CLI metadata providers 2>/dev/null)
+assert_json_key "metadata providers has providers" "providers" "$output"
+assert_json_expr "metadata providers has books" "len(d['providers']['books'])>0" "$output"
+assert_json_expr "metadata providers has google" \
+    "any(p['value']=='google' for p in d['providers']['books'])" "$output"
+
+if [ "${SMOKE_TEST_EXTERNAL:-}" = "1" ]; then
+    echo "  (external provider tests enabled)"
+    output=$($CLI metadata search --provider google --title "Storm Front" --author "Jim Butcher" 2>/dev/null)
+    if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert len(d)>0" 2>/dev/null; then
+        pass "metadata search returns results"
+    else
+        fail "metadata search returns results" "empty or invalid response"
+    fi
+    output=$($CLI metadata covers --provider google --title "Storm Front" 2>/dev/null)
+    assert_json_key "metadata covers has results" "results" "$output"
+else
+    echo "  (skipping external provider tests — set SMOKE_TEST_EXTERNAL=1 to enable)"
+fi
 
 # ============================================================
 echo ""

--- a/docs/plans/2026-04-12-v0.2.0-implementation.md
+++ b/docs/plans/2026-04-12-v0.2.0-implementation.md
@@ -1,0 +1,1884 @@
+# v0.2.0 Implementation Plan: Backup, Upload & Metadata Commands
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add backup, upload, scan, metadata search, and tasks commands to abs-cli, plus improved error handling.
+
+**Architecture:** Follows existing four-layer pattern (Command → Service → ApiClient → DTOs). New multipart upload and file download capabilities added to AbsApiClient. All new DTOs registered in JsonContext.cs for AOT source-gen. No reflection, no dynamic, no Newtonsoft.
+
+**Tech Stack:** C# / .NET 8 / System.CommandLine / System.Text.Json source-gen / Native AOT
+
+**Spec:** `docs/specs/2026-04-12-v0.2.0-upload-metadata-backup.md`
+
+---
+
+## File Map
+
+**New files:**
+- `src/AbsCli/Models/Backup.cs` — BackupItem, BackupListResponse DTOs
+- `src/AbsCli/Models/TaskItem.cs` — TaskItem, TaskListResponse DTOs
+- `src/AbsCli/Models/ScanResult.cs` — ScanResult DTO
+- `src/AbsCli/Models/MetadataProvider.cs` — ProviderEntry, MetadataProviderGroups, MetadataProvidersResponse, CoverSearchResponse DTOs
+- `src/AbsCli/Services/BackupService.cs` — backup CRUD operations
+- `src/AbsCli/Services/UploadService.cs` — multipart upload + wait-for-item
+- `src/AbsCli/Services/MetadataService.cs` — provider search, covers
+- `src/AbsCli/Services/TasksService.cs` — task listing
+- `src/AbsCli/Commands/BackupCommand.cs` — 6 subcommands
+- `src/AbsCli/Commands/UploadCommand.cs` — upload with sequence/wait
+- `src/AbsCli/Commands/MetadataCommand.cs` — search, providers, covers
+- `src/AbsCli/Commands/TasksCommand.cs` — tasks list
+
+**Modified files:**
+- `src/AbsCli/Api/ApiEndpoints.cs` — new endpoint constants
+- `src/AbsCli/Api/AbsApiClient.cs` — multipart, file download, delete, improved errors
+- `src/AbsCli/Models/JsonContext.cs` — register new DTOs
+- `src/AbsCli/Program.cs` — register new commands
+- `src/AbsCli/Commands/LibrariesCommand.cs` — add scan subcommand
+- `src/AbsCli/Commands/ItemsCommand.cs` — add scan subcommand
+- `src/AbsCli/Services/LibrariesService.cs` — add ScanAsync
+- `src/AbsCli/Services/ItemsService.cs` — add ScanAsync
+- `src/AbsCli/Commands/SelfTestCommand.cs` — round-trip tests for new DTOs
+- `docker/seed.sh` — add uploaduser
+- `docker/smoke-test.sh` — new test sections
+
+---
+
+## Task 1: API Endpoints
+
+**Files:**
+- Modify: `src/AbsCli/Api/ApiEndpoints.cs`
+
+- [ ] **Step 1: Add all new endpoints**
+
+```csharp
+// Add to ApiEndpoints.cs after existing endpoints:
+
+// Backup
+public const string Backups = "/api/backups";
+public static string Backup(string id) => $"/api/backups/{id}";
+public static string BackupApply(string id) => $"/api/backups/{id}/apply";
+public static string BackupDownload(string id) => $"/api/backups/{id}/download";
+public const string BackupUpload = "/api/backups/upload";
+
+// Upload
+public const string Upload = "/api/upload";
+
+// Scan
+public static string LibraryScan(string libraryId) => $"/api/libraries/{libraryId}/scan";
+public static string ItemScan(string id) => $"/api/items/{id}/scan";
+
+// Metadata search
+public const string SearchBooks = "/api/search/books";
+public const string SearchProviders = "/api/search/providers";
+public const string SearchCovers = "/api/search/covers";
+
+// Tasks
+public const string Tasks = "/api/tasks";
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `dotnet build src/AbsCli/AbsCli.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/AbsCli/Api/ApiEndpoints.cs
+git commit -m "feat: add API endpoints for backup, upload, scan, metadata, tasks"
+```
+
+---
+
+## Task 2: Improved Error Handling
+
+**Files:**
+- Modify: `src/AbsCli/Api/AbsApiClient.cs`
+
+- [ ] **Step 1: Add permissionHint parameter to error handler**
+
+Replace the existing `EnsureSuccessOrHandleAuthAsync` method and update all call sites. The method gains an optional `permissionHint` parameter for contextual 403 messages.
+
+Replace in `AbsApiClient.cs`:
+
+```csharp
+private async Task EnsureSuccessOrHandleAuthAsync(
+    HttpResponseMessage response, HttpMethod method, string endpoint,
+    string? permissionHint = null)
+{
+    if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+    {
+        await RefreshTokenAsync();
+        var retryRequest = new HttpRequestMessage(method, endpoint);
+        var retryResponse = await _http.SendAsync(retryRequest);
+        if (!retryResponse.IsSuccessStatusCode)
+        {
+            ConsoleOutput.WriteError($"API request failed after token refresh: {(int)retryResponse.StatusCode} {retryResponse.ReasonPhrase}");
+            Environment.Exit(2);
+        }
+    }
+    else if (!response.IsSuccessStatusCode)
+    {
+        var body = await response.Content.ReadAsStringAsync();
+        var status = (int)response.StatusCode;
+        var message = status switch
+        {
+            403 when permissionHint != null =>
+                $"Permission denied. This operation requires {permissionHint}.",
+            403 => $"Permission denied.{(string.IsNullOrWhiteSpace(body) ? "" : $" {body.Trim()}")}",
+            400 => $"Bad request.{(string.IsNullOrWhiteSpace(body) ? "" : $" {body.Trim()}")}",
+            404 => $"Not found.{(string.IsNullOrWhiteSpace(body) ? "" : $" {body.Trim()}")}",
+            _ => $"API request failed: {status} {response.ReasonPhrase}{(string.IsNullOrWhiteSpace(body) ? "" : $"\n{body.Trim()}")}"
+        };
+        ConsoleOutput.WriteError(message);
+        Environment.Exit(2);
+    }
+}
+```
+
+Existing call sites (`GetAsync`, `PatchAsync`, `PostAsync`) remain unchanged — the new parameter is optional with default `null`.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `dotnet build src/AbsCli/AbsCli.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Run self-test to confirm no regressions**
+
+Run: `dotnet run --project src/AbsCli/AbsCli.csproj -- self-test`
+Expected: All checks pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/AbsCli/Api/AbsApiClient.cs
+git commit -m "fix: improve error messages for 403, 400, 404 responses"
+```
+
+---
+
+## Task 3: AbsApiClient — New HTTP Methods
+
+**Files:**
+- Modify: `src/AbsCli/Api/AbsApiClient.cs`
+
+The client needs three new capabilities: multipart POST (for upload), file download (for backup download), and DELETE.
+
+- [ ] **Step 1: Add DeleteAsync method**
+
+Add after the existing `PostAsync` methods:
+
+```csharp
+public async Task<string> DeleteAsync(string endpoint, string? permissionHint = null)
+{
+    await EnsureValidTokenAsync();
+    var response = await _http.DeleteAsync(endpoint);
+    await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Delete, endpoint, permissionHint);
+    return await response.Content.ReadAsStringAsync();
+}
+
+public async Task<T> DeleteAsync<T>(string endpoint, JsonTypeInfo<T> typeInfo, string? permissionHint = null)
+{
+    var json = await DeleteAsync(endpoint, permissionHint);
+    return JsonSerializer.Deserialize(json, typeInfo)
+        ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
+}
+```
+
+- [ ] **Step 2: Add PostMultipartAsync method**
+
+Add after `DeleteAsync`:
+
+```csharp
+public async Task PostMultipartAsync(string endpoint, MultipartFormDataContent content,
+    string? permissionHint = null)
+{
+    await EnsureValidTokenAsync();
+    var response = await _http.PostAsync(endpoint, content);
+    await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Post, endpoint, permissionHint);
+}
+```
+
+- [ ] **Step 3: Add DownloadFileAsync method**
+
+Add after `PostMultipartAsync`:
+
+```csharp
+public async Task DownloadFileAsync(string endpoint, string outputPath, string? permissionHint = null)
+{
+    await EnsureValidTokenAsync();
+    var response = await _http.GetAsync(endpoint, HttpCompletionOption.ResponseHeadersRead);
+    await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Get, endpoint, permissionHint);
+    await using var stream = await response.Content.ReadAsStreamAsync();
+    await using var fileStream = new FileStream(outputPath, FileMode.Create, FileAccess.Write);
+    await stream.CopyToAsync(fileStream);
+}
+```
+
+- [ ] **Step 4: Add PostEmptyAsync method (for scan, backup create)**
+
+```csharp
+public async Task<string> PostEmptyAsync(string endpoint, string? permissionHint = null)
+{
+    await EnsureValidTokenAsync();
+    var response = await _http.PostAsync(endpoint, null);
+    await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Post, endpoint, permissionHint);
+    return await response.Content.ReadAsStringAsync();
+}
+
+public async Task<T> PostEmptyAsync<T>(string endpoint, JsonTypeInfo<T> typeInfo, string? permissionHint = null)
+{
+    var json = await PostEmptyAsync(endpoint, permissionHint);
+    return JsonSerializer.Deserialize(json, typeInfo)
+        ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
+}
+```
+
+- [ ] **Step 5: Add permissionHint overloads to existing methods**
+
+Add overloads to existing `GetAsync`, `PatchAsync`, `PostAsync` that accept `permissionHint`. Keep existing methods as-is (they call the private handler with `null`).
+
+```csharp
+public async Task<string> GetAsync(string endpoint, string? permissionHint)
+{
+    await EnsureValidTokenAsync();
+    var response = await _http.GetAsync(endpoint);
+    await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Get, endpoint, permissionHint);
+    return await response.Content.ReadAsStringAsync();
+}
+
+public async Task<T> GetAsync<T>(string endpoint, JsonTypeInfo<T> typeInfo, string? permissionHint)
+{
+    var json = await GetAsync(endpoint, permissionHint);
+    return JsonSerializer.Deserialize(json, typeInfo)
+        ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
+}
+
+public async Task<string> PatchAsync(string endpoint, string jsonBody, string? permissionHint)
+{
+    await EnsureValidTokenAsync();
+    var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+    var response = await _http.PatchAsync(endpoint, content);
+    await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Patch, endpoint, permissionHint);
+    return await response.Content.ReadAsStringAsync();
+}
+
+public async Task<T> PatchAsync<T>(string endpoint, string jsonBody, JsonTypeInfo<T> typeInfo, string? permissionHint)
+{
+    var json = await PatchAsync(endpoint, jsonBody, permissionHint);
+    return JsonSerializer.Deserialize(json, typeInfo)
+        ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
+}
+
+public async Task<string> PostAsync(string endpoint, string jsonBody, string? permissionHint)
+{
+    await EnsureValidTokenAsync();
+    var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+    var response = await _http.PostAsync(endpoint, content);
+    await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Post, endpoint, permissionHint);
+    return await response.Content.ReadAsStringAsync();
+}
+
+public async Task<T> PostAsync<T>(string endpoint, string jsonBody, JsonTypeInfo<T> typeInfo, string? permissionHint)
+{
+    var json = await PostAsync(endpoint, jsonBody, permissionHint);
+    return JsonSerializer.Deserialize(json, typeInfo)
+        ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
+}
+```
+
+- [ ] **Step 6: Verify it compiles and self-test passes**
+
+Run: `dotnet build src/AbsCli/AbsCli.csproj && dotnet run --project src/AbsCli/AbsCli.csproj -- self-test`
+Expected: Build succeeded, all self-test checks pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/AbsCli/Api/AbsApiClient.cs
+git commit -m "feat: add delete, multipart, download, and empty-post methods to API client"
+```
+
+---
+
+## Task 4: Backup DTOs + Service + Command
+
+**Files:**
+- Create: `src/AbsCli/Models/Backup.cs`
+- Create: `src/AbsCli/Services/BackupService.cs`
+- Create: `src/AbsCli/Commands/BackupCommand.cs`
+- Modify: `src/AbsCli/Models/JsonContext.cs`
+- Modify: `src/AbsCli/Program.cs`
+
+- [ ] **Step 1: Create Backup DTOs**
+
+Create `src/AbsCli/Models/Backup.cs`:
+
+```csharp
+using System.Text.Json.Serialization;
+
+namespace AbsCli.Models;
+
+public class BackupItem
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = "";
+
+    [JsonPropertyName("backupDirPath")]
+    public string? BackupDirPath { get; set; }
+
+    [JsonPropertyName("datePretty")]
+    public string? DatePretty { get; set; }
+
+    [JsonPropertyName("fullPath")]
+    public string? FullPath { get; set; }
+
+    [JsonPropertyName("path")]
+    public string? Path { get; set; }
+
+    [JsonPropertyName("filename")]
+    public string? Filename { get; set; }
+
+    [JsonPropertyName("fileSize")]
+    public long? FileSize { get; set; }
+
+    [JsonPropertyName("createdAt")]
+    public long CreatedAt { get; set; }
+
+    [JsonPropertyName("serverVersion")]
+    public string? ServerVersion { get; set; }
+}
+
+public class BackupListResponse
+{
+    [JsonPropertyName("backups")]
+    public List<BackupItem> Backups { get; set; } = new();
+
+    [JsonPropertyName("backupLocation")]
+    public string? BackupLocation { get; set; }
+
+    [JsonPropertyName("backupPathEnvSet")]
+    public bool? BackupPathEnvSet { get; set; }
+}
+```
+
+- [ ] **Step 2: Register in JsonContext**
+
+Add to `src/AbsCli/Models/JsonContext.cs` before the `[JsonSourceGenerationOptions]` line:
+
+```csharp
+[JsonSerializable(typeof(BackupItem))]
+[JsonSerializable(typeof(BackupListResponse))]
+```
+
+- [ ] **Step 3: Create BackupService**
+
+Create `src/AbsCli/Services/BackupService.cs`:
+
+```csharp
+using AbsCli.Api;
+using AbsCli.Models;
+
+namespace AbsCli.Services;
+
+public class BackupService
+{
+    private readonly AbsApiClient _client;
+
+    public BackupService(AbsApiClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<BackupListResponse> ListAsync()
+    {
+        return await _client.GetAsync(ApiEndpoints.Backups,
+            AppJsonContext.Default.BackupListResponse, "'admin' access");
+    }
+
+    public async Task<BackupListResponse> CreateAsync()
+    {
+        return await _client.PostEmptyAsync(ApiEndpoints.Backups,
+            AppJsonContext.Default.BackupListResponse, "'admin' access");
+    }
+
+    public async Task<string> ApplyAsync(string id)
+    {
+        return await _client.GetAsync(ApiEndpoints.BackupApply(id), "'admin' access");
+    }
+
+    public async Task DownloadAsync(string id, string outputPath)
+    {
+        await _client.DownloadFileAsync(ApiEndpoints.BackupDownload(id), outputPath, "'admin' access");
+    }
+
+    public async Task<BackupListResponse> DeleteAsync(string id)
+    {
+        return await _client.DeleteAsync(ApiEndpoints.Backup(id),
+            AppJsonContext.Default.BackupListResponse, "'admin' access");
+    }
+
+    public async Task<BackupListResponse> UploadAsync(string filePath)
+    {
+        var content = new MultipartFormDataContent();
+        var fileBytes = await File.ReadAllBytesAsync(filePath);
+        var fileContent = new ByteArrayContent(fileBytes);
+        fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
+        content.Add(fileContent, "file", System.IO.Path.GetFileName(filePath));
+
+        // PostMultipartAsync doesn't return typed — we do a manual call
+        await _client.PostMultipartAsync(ApiEndpoints.BackupUpload, content, "'admin' access");
+
+        // Fetch current backup list to return consistent response
+        return await ListAsync();
+    }
+}
+```
+
+- [ ] **Step 4: Create BackupCommand**
+
+Create `src/AbsCli/Commands/BackupCommand.cs`:
+
+```csharp
+using System.CommandLine;
+using AbsCli.Models;
+using AbsCli.Output;
+using AbsCli.Services;
+
+namespace AbsCli.Commands;
+
+public static class BackupCommand
+{
+    public static Command Create()
+    {
+        var command = new Command("backup", "Manage server backups (admin-only)");
+        command.AddCommand(CreateCreateCommand());
+        command.AddCommand(CreateListCommand());
+        command.AddCommand(CreateApplyCommand());
+        command.AddCommand(CreateDownloadCommand());
+        command.AddCommand(CreateDeleteCommand());
+        command.AddCommand(CreateUploadCommand());
+        return command;
+    }
+
+    private static Command CreateCreateCommand()
+    {
+        var command = new Command("create", "Create a new backup");
+        command.AddExamples(
+            "abs-cli backup create",
+            "abs-cli backup create | jq '.backups[-1].id'");
+
+        command.SetHandler(async () =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new BackupService(client);
+            var result = await service.CreateAsync();
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.BackupListResponse);
+        });
+
+        return command;
+    }
+
+    private static Command CreateListCommand()
+    {
+        var command = new Command("list", "List available backups");
+        command.AddExamples(
+            "abs-cli backup list",
+            "abs-cli backup list | jq '.backups[] | {id, filename, fileSize}'");
+
+        command.SetHandler(async () =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new BackupService(client);
+            var result = await service.ListAsync();
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.BackupListResponse);
+        });
+
+        return command;
+    }
+
+    private static Command CreateApplyCommand()
+    {
+        var idOption = new Option<string>("--id", "Backup ID") { IsRequired = true };
+        var command = new Command("apply", "Restore from a backup (replaces current state)") { idOption };
+        command.AddExamples(
+            "abs-cli backup apply --id \"2024-03-15T1430\"",
+            "abs-cli backup list | jq '.backups[-1].id' | xargs -I{} abs-cli backup apply --id {}");
+
+        command.SetHandler(async (string id) =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new BackupService(client);
+            await service.ApplyAsync(id);
+            ConsoleOutput.WriteRawJson("{\"success\":true}");
+        }, idOption);
+
+        return command;
+    }
+
+    private static Command CreateDownloadCommand()
+    {
+        var idOption = new Option<string>("--id", "Backup ID") { IsRequired = true };
+        var outputOption = new Option<string>("--output", "Output file path") { IsRequired = true };
+        var command = new Command("download", "Download a backup file to disk") { idOption, outputOption };
+        command.AddExamples(
+            "abs-cli backup download --id \"2024-03-15T1430\" --output ./backup.audiobookshelf",
+            "abs-cli backup download --id \"2024-03-15T1430\" --output /tmp/abs-backup.audiobookshelf");
+
+        command.SetHandler(async (string id, string output) =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new BackupService(client);
+            await service.DownloadAsync(id, output);
+        }, idOption, outputOption);
+
+        return command;
+    }
+
+    private static Command CreateDeleteCommand()
+    {
+        var idOption = new Option<string>("--id", "Backup ID") { IsRequired = true };
+        var command = new Command("delete", "Delete a backup") { idOption };
+        command.AddExamples(
+            "abs-cli backup delete --id \"2024-03-15T1430\"",
+            "abs-cli backup list | jq '.backups[0].id' | xargs -I{} abs-cli backup delete --id {}");
+
+        command.SetHandler(async (string id) =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new BackupService(client);
+            var result = await service.DeleteAsync(id);
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.BackupListResponse);
+        }, idOption);
+
+        return command;
+    }
+
+    private static Command CreateUploadCommand()
+    {
+        var fileOption = new Option<string>("--file", "Path to backup file") { IsRequired = true };
+        var command = new Command("upload", "Upload a backup file") { fileOption };
+        command.AddExamples(
+            "abs-cli backup upload --file ./backup.audiobookshelf",
+            "abs-cli backup upload --file /tmp/abs-backup.audiobookshelf");
+
+        command.SetHandler(async (string file) =>
+        {
+            if (!File.Exists(file))
+            {
+                ConsoleOutput.WriteError($"File not found: {file}");
+                Environment.Exit(1);
+                return;
+            }
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new BackupService(client);
+            var result = await service.UploadAsync(file);
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.BackupListResponse);
+        }, fileOption);
+
+        return command;
+    }
+}
+```
+
+- [ ] **Step 5: Register in Program.cs**
+
+Add after the existing `SelfTestCommand` registration:
+
+```csharp
+rootCommand.AddCommand(BackupCommand.Create());
+```
+
+- [ ] **Step 6: Build and verify**
+
+Run: `dotnet build src/AbsCli/AbsCli.csproj`
+Expected: Build succeeded.
+
+Run: `dotnet run --project src/AbsCli/AbsCli.csproj -- backup --help`
+Expected: Shows backup subcommands (create, list, apply, download, delete, upload).
+
+- [ ] **Step 7: Format**
+
+Run: `dotnet format AbsCli.sln`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/AbsCli/Models/Backup.cs src/AbsCli/Services/BackupService.cs \
+  src/AbsCli/Commands/BackupCommand.cs src/AbsCli/Models/JsonContext.cs \
+  src/AbsCli/Program.cs
+git commit -m "feat: add backup create, list, apply, download, delete, upload commands"
+```
+
+---
+
+## Task 5: Upload DTOs + Service + Command
+
+**Files:**
+- Create: `src/AbsCli/Services/UploadService.cs`
+- Create: `src/AbsCli/Commands/UploadCommand.cs`
+- Modify: `src/AbsCli/Program.cs`
+
+Upload uses raw JSON (`WriteRawJson`) for the `--wait` response since it returns a library item (already typed as `LibraryItemMinified`). The upload itself returns no body (HTTP 200).
+
+- [ ] **Step 1: Create UploadService**
+
+Create `src/AbsCli/Services/UploadService.cs`:
+
+```csharp
+using System.Web;
+using AbsCli.Api;
+using AbsCli.Models;
+using AbsCli.Output;
+
+namespace AbsCli.Services;
+
+public class UploadService
+{
+    private readonly AbsApiClient _client;
+
+    public UploadService(AbsApiClient client)
+    {
+        _client = client;
+    }
+
+    public async Task UploadAsync(string libraryId, string folderId, string title,
+        string? author, string? series, int? sequence, string[] filePaths)
+    {
+        // Compose title with sequence prefix if provided
+        var uploadTitle = sequence.HasValue ? $"{sequence.Value}. - {title}" : title;
+
+        var content = new MultipartFormDataContent();
+        content.Add(new StringContent(libraryId), "library");
+        content.Add(new StringContent(folderId), "folder");
+        content.Add(new StringContent(uploadTitle), "title");
+        if (author != null)
+            content.Add(new StringContent(author), "author");
+        if (series != null)
+            content.Add(new StringContent(series), "series");
+
+        for (int i = 0; i < filePaths.Length; i++)
+        {
+            var fileBytes = await File.ReadAllBytesAsync(filePaths[i]);
+            var fileContent = new ByteArrayContent(fileBytes);
+            content.Add(fileContent, i.ToString(), Path.GetFileName(filePaths[i]));
+        }
+
+        await _client.PostMultipartAsync(ApiEndpoints.Upload, content, "'upload' permission");
+    }
+
+    public async Task<string> ResolveFolderIdAsync(string libraryId)
+    {
+        var library = await _client.GetAsync(ApiEndpoints.Library(libraryId),
+            AppJsonContext.Default.Library);
+
+        if (library.Folders.Count == 0)
+        {
+            ConsoleOutput.WriteError("Library has no folders configured.");
+            Environment.Exit(1);
+        }
+
+        if (library.Folders.Count > 1)
+        {
+            ConsoleOutput.WriteError(
+                $"Library has {library.Folders.Count} folders. Specify --folder <id>.\n" +
+                "Use 'abs-cli libraries get --id <id>' to see folder IDs.");
+            Environment.Exit(1);
+        }
+
+        return library.Folders[0].Id;
+    }
+
+    public async Task<LibraryItemMinified?> WaitForItemAsync(string libraryId, string title,
+        int timeoutSeconds = 60, int pollIntervalMs = 3000)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            var query = HttpUtility.ParseQueryString("");
+            query["q"] = title;
+            query["limit"] = "5";
+            var url = ApiEndpoints.LibrarySearch(libraryId) + "?" + query;
+            var result = await _client.GetAsync(url, AppJsonContext.Default.SearchResult);
+
+            if (result.Book != null && result.Book.Count > 0)
+            {
+                // Return the first match as a raw JSON element — deserialize to LibraryItemMinified
+                var itemJson = result.Book[0].GetProperty("libraryItem").GetRawText();
+                return System.Text.Json.JsonSerializer.Deserialize(itemJson,
+                    AppJsonContext.Default.LibraryItemMinified);
+            }
+
+            await Task.Delay(pollIntervalMs);
+        }
+
+        return null;
+    }
+}
+```
+
+- [ ] **Step 2: Create UploadCommand**
+
+Create `src/AbsCli/Commands/UploadCommand.cs`:
+
+```csharp
+using System.CommandLine;
+using AbsCli.Models;
+using AbsCli.Output;
+using AbsCli.Services;
+
+namespace AbsCli.Commands;
+
+public static class UploadCommand
+{
+    public static Command Create()
+    {
+        var libraryOption = new Option<string?>("--library", "Library ID (or default from config)");
+        var folderOption = new Option<string?>("--folder",
+            "Folder ID within library (auto-resolved if library has one folder)");
+        var titleOption = new Option<string>("--title", "Book title") { IsRequired = true };
+        var authorOption = new Option<string?>("--author", "Author name");
+        var seriesOption = new Option<string?>("--series", "Series name");
+        var sequenceOption = new Option<int?>("--sequence", "Series position (requires --series)");
+        var waitOption = new Option<bool>("--wait", "Poll until item appears in library");
+        var filesOption = new Option<string[]>("--files", "File paths to upload") { IsRequired = true, AllowMultipleArgumentsPerToken = true };
+
+        var command = new Command("upload",
+            "Upload audiobook or ebook files to a library")
+        {
+            libraryOption, folderOption, titleOption, authorOption,
+            seriesOption, sequenceOption, waitOption, filesOption
+        };
+        command.AddHelpSection("Folder ID",
+            "Found in output of 'abs-cli libraries get --id <id>' under 'folders' array.",
+            "If omitted, auto-resolved when library has exactly one folder.");
+        command.AddHelpSection("Folder structure created",
+            "Author/Title                        (no series)",
+            "Author/Series/Title                 (with series)",
+            "Author/Series/{N}. - {Title}        (with series + sequence)");
+        command.AddExamples(
+            "abs-cli upload --title \"Warbreaker\" --author \"Brandon Sanderson\" --files ./book.m4b",
+            "abs-cli upload --title \"The Final Empire\" --author \"Brandon Sanderson\" --series \"Mistborn\" --sequence 1 --wait --files ./book.m4b",
+            "abs-cli upload --title \"My Book\" --author \"Author\" --files ./part1.mp3 ./part2.mp3 ./part3.mp3");
+
+        command.SetHandler(async (string? library, string? folder, string title, string? author,
+            string? series, int? sequence, bool wait, string[] files) =>
+        {
+            if (sequence.HasValue && series == null)
+            {
+                ConsoleOutput.WriteError("--sequence requires --series");
+                Environment.Exit(1);
+                return;
+            }
+
+            foreach (var file in files)
+            {
+                if (!File.Exists(file))
+                {
+                    ConsoleOutput.WriteError($"File not found: {file}");
+                    Environment.Exit(1);
+                    return;
+                }
+            }
+
+            var (client, config) = CommandHelper.BuildClient(libraryOverride: library);
+            var libraryId = CommandHelper.RequireLibrary(config);
+            var service = new UploadService(client);
+
+            var folderId = folder ?? await service.ResolveFolderIdAsync(libraryId);
+
+            await service.UploadAsync(libraryId, folderId, title, author, series, sequence, files);
+
+            if (wait)
+            {
+                var searchTitle = sequence.HasValue ? $"{sequence.Value}. - {title}" : title;
+                var item = await service.WaitForItemAsync(libraryId, searchTitle);
+                if (item != null)
+                {
+                    ConsoleOutput.WriteJson(item, AppJsonContext.Default.LibraryItemMinified);
+                }
+                else
+                {
+                    ConsoleOutput.WriteError("Timed out waiting for item to appear in library.");
+                    Environment.Exit(1);
+                }
+            }
+        }, libraryOption, folderOption, titleOption, authorOption,
+           seriesOption, sequenceOption, waitOption, filesOption);
+
+        return command;
+    }
+}
+```
+
+- [ ] **Step 3: Register in Program.cs**
+
+Add after `BackupCommand`:
+
+```csharp
+rootCommand.AddCommand(UploadCommand.Create());
+```
+
+- [ ] **Step 4: Build and verify help**
+
+Run: `dotnet build src/AbsCli/AbsCli.csproj`
+Expected: Build succeeded.
+
+Run: `dotnet run --project src/AbsCli/AbsCli.csproj -- upload --help`
+Expected: Shows all options including --files, --wait, --sequence, and help sections.
+
+- [ ] **Step 5: Format**
+
+Run: `dotnet format AbsCli.sln`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/AbsCli/Services/UploadService.cs src/AbsCli/Commands/UploadCommand.cs \
+  src/AbsCli/Program.cs
+git commit -m "feat: add upload command with sequence prefix and --wait polling"
+```
+
+---
+
+## Task 6: Scan — Libraries + Items
+
+**Files:**
+- Modify: `src/AbsCli/Services/LibrariesService.cs`
+- Modify: `src/AbsCli/Services/ItemsService.cs`
+- Modify: `src/AbsCli/Commands/LibrariesCommand.cs`
+- Modify: `src/AbsCli/Commands/ItemsCommand.cs`
+- Create: `src/AbsCli/Models/ScanResult.cs`
+- Modify: `src/AbsCli/Models/JsonContext.cs`
+
+- [ ] **Step 1: Create ScanResult DTO**
+
+Create `src/AbsCli/Models/ScanResult.cs`:
+
+```csharp
+using System.Text.Json.Serialization;
+
+namespace AbsCli.Models;
+
+public class ScanResult
+{
+    [JsonPropertyName("result")]
+    public string Result { get; set; } = "";
+}
+```
+
+- [ ] **Step 2: Register in JsonContext**
+
+Add to `JsonContext.cs`:
+
+```csharp
+[JsonSerializable(typeof(ScanResult))]
+```
+
+- [ ] **Step 3: Add ScanAsync to LibrariesService**
+
+Add to `src/AbsCli/Services/LibrariesService.cs`:
+
+```csharp
+public async Task ScanAsync(string libraryId, bool force)
+{
+    var url = ApiEndpoints.LibraryScan(libraryId);
+    if (force) url += "?force=1";
+    await _client.PostEmptyAsync(url, "'admin' access");
+}
+```
+
+- [ ] **Step 4: Add ScanAsync to ItemsService**
+
+Add to `src/AbsCli/Services/ItemsService.cs`:
+
+```csharp
+public async Task<ScanResult> ScanAsync(string id)
+{
+    return await _client.PostEmptyAsync(ApiEndpoints.ItemScan(id),
+        AppJsonContext.Default.ScanResult, "'admin' access");
+}
+```
+
+- [ ] **Step 5: Add scan subcommand to LibrariesCommand**
+
+Add a new `CreateScanCommand()` method in `LibrariesCommand.cs` and register it in `Create()`:
+
+In `Create()`, add:
+```csharp
+command.AddCommand(CreateScanCommand());
+```
+
+Add the method:
+```csharp
+private static Command CreateScanCommand()
+{
+    var idOption = new Option<string?>("--id", "Library ID (or default from config)");
+    var forceOption = new Option<bool>("--force", "Force full rescan");
+    var command = new Command("scan", "Trigger a library scan (admin-only, async)") { idOption, forceOption };
+    command.AddExamples(
+        "abs-cli libraries scan",
+        "abs-cli libraries scan --force",
+        "abs-cli libraries scan --id \"lib_abc123\"");
+
+    command.SetHandler(async (string? id, bool force) =>
+    {
+        var (client, config) = CommandHelper.BuildClient(libraryOverride: id);
+        var libraryId = CommandHelper.RequireLibrary(config);
+        var service = new LibrariesService(client);
+        await service.ScanAsync(libraryId, force);
+    }, idOption, forceOption);
+
+    return command;
+}
+```
+
+- [ ] **Step 6: Add scan subcommand to ItemsCommand**
+
+In `Create()`, add:
+```csharp
+command.AddCommand(CreateScanCommand());
+```
+
+Add the method:
+```csharp
+private static Command CreateScanCommand()
+{
+    var idOption = new Option<string>("--id", "Item ID") { IsRequired = true };
+    var command = new Command("scan", "Scan a single library item (admin-only, sync)") { idOption };
+    command.AddExamples(
+        "abs-cli items scan --id \"li_abc123\"",
+        "abs-cli items scan --id \"li_abc123\" | jq '.result'");
+
+    command.SetHandler(async (string id) =>
+    {
+        var (client, _) = CommandHelper.BuildClient();
+        var service = new ItemsService(client);
+        var result = await service.ScanAsync(id);
+        ConsoleOutput.WriteJson(result, AppJsonContext.Default.ScanResult);
+    }, idOption);
+
+    return command;
+}
+```
+
+- [ ] **Step 7: Build and verify**
+
+Run: `dotnet build src/AbsCli/AbsCli.csproj`
+
+Run: `dotnet run --project src/AbsCli/AbsCli.csproj -- libraries scan --help`
+Expected: Shows scan help with --id and --force options.
+
+Run: `dotnet run --project src/AbsCli/AbsCli.csproj -- items scan --help`
+Expected: Shows scan help with --id option.
+
+- [ ] **Step 8: Format and commit**
+
+```bash
+dotnet format AbsCli.sln
+git add src/AbsCli/Models/ScanResult.cs src/AbsCli/Models/JsonContext.cs \
+  src/AbsCli/Services/LibrariesService.cs src/AbsCli/Services/ItemsService.cs \
+  src/AbsCli/Commands/LibrariesCommand.cs src/AbsCli/Commands/ItemsCommand.cs
+git commit -m "feat: add libraries scan and items scan commands"
+```
+
+---
+
+## Task 7: Tasks Command
+
+**Files:**
+- Create: `src/AbsCli/Models/TaskItem.cs`
+- Create: `src/AbsCli/Services/TasksService.cs`
+- Create: `src/AbsCli/Commands/TasksCommand.cs`
+- Modify: `src/AbsCli/Models/JsonContext.cs`
+- Modify: `src/AbsCli/Program.cs`
+
+- [ ] **Step 1: Create TaskItem DTOs**
+
+Create `src/AbsCli/Models/TaskItem.cs`:
+
+```csharp
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AbsCli.Models;
+
+public class TaskItem
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = "";
+
+    [JsonPropertyName("action")]
+    public string? Action { get; set; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("isFailed")]
+    public bool IsFailed { get; set; }
+
+    [JsonPropertyName("isFinished")]
+    public bool IsFinished { get; set; }
+
+    [JsonPropertyName("showSuccess")]
+    public bool ShowSuccess { get; set; }
+
+    [JsonPropertyName("startedAt")]
+    public long? StartedAt { get; set; }
+
+    [JsonPropertyName("finishedAt")]
+    public long? FinishedAt { get; set; }
+
+    [JsonPropertyName("data")]
+    public JsonElement? Data { get; set; }
+}
+
+public class TaskListResponse
+{
+    [JsonPropertyName("tasks")]
+    public List<TaskItem> Tasks { get; set; } = new();
+}
+```
+
+Note: `Data` uses `JsonElement?` (not `dynamic`) to stay AOT-safe while preserving the flexible shape (scan results, error details, etc.).
+
+- [ ] **Step 2: Register in JsonContext**
+
+Add to `JsonContext.cs`:
+
+```csharp
+[JsonSerializable(typeof(TaskItem))]
+[JsonSerializable(typeof(TaskListResponse))]
+```
+
+- [ ] **Step 3: Create TasksService**
+
+Create `src/AbsCli/Services/TasksService.cs`:
+
+```csharp
+using AbsCli.Api;
+using AbsCli.Models;
+
+namespace AbsCli.Services;
+
+public class TasksService
+{
+    private readonly AbsApiClient _client;
+
+    public TasksService(AbsApiClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<TaskListResponse> ListAsync()
+    {
+        return await _client.GetAsync(ApiEndpoints.Tasks, AppJsonContext.Default.TaskListResponse);
+    }
+}
+```
+
+- [ ] **Step 4: Create TasksCommand**
+
+Create `src/AbsCli/Commands/TasksCommand.cs`:
+
+```csharp
+using System.CommandLine;
+using AbsCli.Models;
+using AbsCli.Output;
+using AbsCli.Services;
+
+namespace AbsCli.Commands;
+
+public static class TasksCommand
+{
+    public static Command Create()
+    {
+        var command = new Command("tasks", "Manage server tasks");
+        command.AddCommand(CreateListCommand());
+        return command;
+    }
+
+    private static Command CreateListCommand()
+    {
+        var command = new Command("list", "List active and recent tasks");
+        command.AddExamples(
+            "abs-cli tasks list",
+            "abs-cli tasks list | jq '.tasks[] | select(.isFinished==false)'",
+            "abs-cli tasks list | jq '.tasks[] | {action, title, isFinished}'");
+
+        command.SetHandler(async () =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new TasksService(client);
+            var result = await service.ListAsync();
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.TaskListResponse);
+        });
+
+        return command;
+    }
+}
+```
+
+- [ ] **Step 5: Register in Program.cs**
+
+```csharp
+rootCommand.AddCommand(TasksCommand.Create());
+```
+
+- [ ] **Step 6: Build and verify**
+
+Run: `dotnet build src/AbsCli/AbsCli.csproj`
+
+Run: `dotnet run --project src/AbsCli/AbsCli.csproj -- tasks list --help`
+Expected: Shows help with examples.
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+dotnet format AbsCli.sln
+git add src/AbsCli/Models/TaskItem.cs src/AbsCli/Services/TasksService.cs \
+  src/AbsCli/Commands/TasksCommand.cs src/AbsCli/Models/JsonContext.cs \
+  src/AbsCli/Program.cs
+git commit -m "feat: add tasks list command"
+```
+
+---
+
+## Task 8: Metadata Commands
+
+**Files:**
+- Create: `src/AbsCli/Models/MetadataProvider.cs`
+- Create: `src/AbsCli/Services/MetadataService.cs`
+- Create: `src/AbsCli/Commands/MetadataCommand.cs`
+- Modify: `src/AbsCli/Models/JsonContext.cs`
+- Modify: `src/AbsCli/Program.cs`
+
+- [ ] **Step 1: Create MetadataProvider DTOs**
+
+Create `src/AbsCli/Models/MetadataProvider.cs`:
+
+```csharp
+using System.Text.Json.Serialization;
+
+namespace AbsCli.Models;
+
+public class ProviderEntry
+{
+    [JsonPropertyName("value")]
+    public string Value { get; set; } = "";
+
+    [JsonPropertyName("text")]
+    public string Text { get; set; } = "";
+}
+
+public class MetadataProviderGroups
+{
+    [JsonPropertyName("books")]
+    public List<ProviderEntry> Books { get; set; } = new();
+
+    [JsonPropertyName("booksCovers")]
+    public List<ProviderEntry> BooksCovers { get; set; } = new();
+
+    [JsonPropertyName("podcasts")]
+    public List<ProviderEntry> Podcasts { get; set; } = new();
+}
+
+public class MetadataProvidersResponse
+{
+    [JsonPropertyName("providers")]
+    public MetadataProviderGroups Providers { get; set; } = new();
+}
+
+public class CoverSearchResponse
+{
+    [JsonPropertyName("results")]
+    public List<string> Results { get; set; } = new();
+}
+```
+
+- [ ] **Step 2: Register in JsonContext**
+
+Add to `JsonContext.cs`:
+
+```csharp
+[JsonSerializable(typeof(ProviderEntry))]
+[JsonSerializable(typeof(MetadataProviderGroups))]
+[JsonSerializable(typeof(MetadataProvidersResponse))]
+[JsonSerializable(typeof(CoverSearchResponse))]
+```
+
+- [ ] **Step 3: Create MetadataService**
+
+Create `src/AbsCli/Services/MetadataService.cs`:
+
+```csharp
+using System.Web;
+using AbsCli.Api;
+using AbsCli.Models;
+
+namespace AbsCli.Services;
+
+public class MetadataService
+{
+    private readonly AbsApiClient _client;
+
+    public MetadataService(AbsApiClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<string> SearchAsync(string provider, string title, string? author)
+    {
+        var query = HttpUtility.ParseQueryString("");
+        query["provider"] = provider;
+        query["title"] = title;
+        if (author != null) query["author"] = author;
+        return await _client.GetAsync(ApiEndpoints.SearchBooks + "?" + query);
+    }
+
+    public async Task<MetadataProvidersResponse> ListProvidersAsync()
+    {
+        return await _client.GetAsync(ApiEndpoints.SearchProviders,
+            AppJsonContext.Default.MetadataProvidersResponse);
+    }
+
+    public async Task<CoverSearchResponse> SearchCoversAsync(string provider, string title, string? author)
+    {
+        var query = HttpUtility.ParseQueryString("");
+        query["provider"] = provider;
+        query["title"] = title;
+        if (author != null) query["author"] = author;
+        return await _client.GetAsync(ApiEndpoints.SearchCovers + "?" + query,
+            AppJsonContext.Default.CoverSearchResponse);
+    }
+}
+```
+
+Note: `SearchAsync` returns raw `string` (not typed) because the response shape varies by provider. The command uses `WriteRawJson` for output.
+
+- [ ] **Step 4: Create MetadataCommand**
+
+Create `src/AbsCli/Commands/MetadataCommand.cs`:
+
+```csharp
+using System.CommandLine;
+using AbsCli.Models;
+using AbsCli.Output;
+using AbsCli.Services;
+
+namespace AbsCli.Commands;
+
+public static class MetadataCommand
+{
+    public static Command Create()
+    {
+        var command = new Command("metadata", "Search metadata providers for book information");
+        command.AddCommand(CreateSearchCommand());
+        command.AddCommand(CreateProvidersCommand());
+        command.AddCommand(CreateCoversCommand());
+        return command;
+    }
+
+    private static Command CreateSearchCommand()
+    {
+        var providerOption = new Option<string>("--provider", "Provider identifier (e.g. audible.de, google)") { IsRequired = true };
+        var titleOption = new Option<string>("--title", "Book title to search for") { IsRequired = true };
+        var authorOption = new Option<string?>("--author", "Author name to narrow results");
+        var command = new Command("search", "Search a metadata provider for book information")
+        {
+            providerOption, titleOption, authorOption
+        };
+        command.AddExamples(
+            "abs-cli metadata search --provider google --title \"The Final Empire\"",
+            "abs-cli metadata search --provider audible.de --title \"Die Känguru-Chroniken\" --author \"Marc-Uwe Kling\"",
+            "abs-cli metadata search --provider audible --title \"Mistborn\" | jq '.[0]'");
+
+        command.SetHandler(async (string provider, string title, string? author) =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new MetadataService(client);
+            var result = await service.SearchAsync(provider, title, author);
+            ConsoleOutput.WriteRawJson(result);
+        }, providerOption, titleOption, authorOption);
+
+        return command;
+    }
+
+    private static Command CreateProvidersCommand()
+    {
+        var command = new Command("providers", "List available metadata providers");
+        command.AddExamples(
+            "abs-cli metadata providers",
+            "abs-cli metadata providers | jq '.providers.books[] | .value'");
+
+        command.SetHandler(async () =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new MetadataService(client);
+            var result = await service.ListProvidersAsync();
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.MetadataProvidersResponse);
+        });
+
+        return command;
+    }
+
+    private static Command CreateCoversCommand()
+    {
+        var providerOption = new Option<string>("--provider", "Provider (specific, 'best', or 'all')") { IsRequired = true };
+        var titleOption = new Option<string>("--title", "Book title") { IsRequired = true };
+        var authorOption = new Option<string?>("--author", "Author name");
+        var command = new Command("covers", "Search for book cover images")
+        {
+            providerOption, titleOption, authorOption
+        };
+        command.AddExamples(
+            "abs-cli metadata covers --provider google --title \"The Final Empire\"",
+            "abs-cli metadata covers --provider best --title \"Mistborn\" --author \"Brandon Sanderson\"",
+            "abs-cli metadata covers --provider all --title \"Storm Front\" | jq '.results'");
+
+        command.SetHandler(async (string provider, string title, string? author) =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new MetadataService(client);
+            var result = await service.SearchCoversAsync(provider, title, author);
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.CoverSearchResponse);
+        }, providerOption, titleOption, authorOption);
+
+        return command;
+    }
+}
+```
+
+- [ ] **Step 5: Register in Program.cs**
+
+```csharp
+rootCommand.AddCommand(MetadataCommand.Create());
+```
+
+- [ ] **Step 6: Build and verify**
+
+Run: `dotnet build src/AbsCli/AbsCli.csproj`
+
+Run: `dotnet run --project src/AbsCli/AbsCli.csproj -- metadata --help`
+Expected: Shows search, providers, covers subcommands.
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+dotnet format AbsCli.sln
+git add src/AbsCli/Models/MetadataProvider.cs src/AbsCli/Services/MetadataService.cs \
+  src/AbsCli/Commands/MetadataCommand.cs src/AbsCli/Models/JsonContext.cs \
+  src/AbsCli/Program.cs
+git commit -m "feat: add metadata search, providers, and covers commands"
+```
+
+---
+
+## Task 9: Self-Test Updates
+
+**Files:**
+- Modify: `src/AbsCli/Commands/SelfTestCommand.cs`
+
+Add round-trip tests for all new DTOs. These go after the existing "API Response DTOs" section.
+
+- [ ] **Step 1: Add BackupItem round-trip**
+
+Add after the `AuthorListResponse` check:
+
+```csharp
+Check("BackupItem round-trip", () =>
+{
+    var obj = new BackupItem
+    {
+        Id = "2024-03-15T1430",
+        Filename = "2024-03-15T1430.audiobookshelf",
+        FileSize = 12345,
+        CreatedAt = 1710510600000,
+        ServerVersion = "2.33.1"
+    };
+    var json = JsonSerializer.Serialize(obj, AppJsonContext.Default.BackupItem);
+    var back = JsonSerializer.Deserialize(json, AppJsonContext.Default.BackupItem)!;
+    Assert(back.Id == "2024-03-15T1430", $"id: {back.Id}");
+    Assert(back.FileSize == 12345, $"fileSize: {back.FileSize}");
+    Assert(back.ServerVersion == "2.33.1", $"serverVersion: {back.ServerVersion}");
+});
+
+Check("BackupListResponse round-trip", () =>
+{
+    var obj = new BackupListResponse
+    {
+        Backups = new List<BackupItem>
+        {
+            new() { Id = "bk_1", Filename = "test.audiobookshelf" }
+        },
+        BackupLocation = "/backups",
+        BackupPathEnvSet = false
+    };
+    var json = JsonSerializer.Serialize(obj, AppJsonContext.Default.BackupListResponse);
+    var back = JsonSerializer.Deserialize(json, AppJsonContext.Default.BackupListResponse)!;
+    Assert(back.Backups.Count == 1, $"count: {back.Backups.Count}");
+    Assert(back.BackupLocation == "/backups", $"location: {back.BackupLocation}");
+});
+```
+
+- [ ] **Step 2: Add ScanResult round-trip**
+
+```csharp
+Check("ScanResult round-trip", () =>
+{
+    var obj = new ScanResult { Result = "UPDATED" };
+    var json = JsonSerializer.Serialize(obj, AppJsonContext.Default.ScanResult);
+    var back = JsonSerializer.Deserialize(json, AppJsonContext.Default.ScanResult)!;
+    Assert(back.Result == "UPDATED", $"result: {back.Result}");
+});
+```
+
+- [ ] **Step 3: Add TaskItem round-trip**
+
+```csharp
+Check("TaskItem round-trip", () =>
+{
+    var json = """{"id":"task_1","action":"library-scan","title":"Scanning","isFailed":false,"isFinished":true,"startedAt":1000,"finishedAt":2000,"data":{"added":5}}""";
+    var obj = JsonSerializer.Deserialize(json, AppJsonContext.Default.TaskItem)!;
+    Assert(obj.Id == "task_1", $"id: {obj.Id}");
+    Assert(obj.Action == "library-scan", $"action: {obj.Action}");
+    Assert(obj.IsFinished, "isFinished should be true");
+    Assert(obj.Data.HasValue, "data should have value");
+    var roundTrip = JsonSerializer.Serialize(obj, AppJsonContext.Default.TaskItem);
+    Assert(roundTrip.Contains("\"action\""), "action key missing in output");
+});
+
+Check("TaskListResponse round-trip", () =>
+{
+    var obj = new TaskListResponse
+    {
+        Tasks = new List<TaskItem> { new() { Id = "t_1", Action = "scan" } }
+    };
+    var json = JsonSerializer.Serialize(obj, AppJsonContext.Default.TaskListResponse);
+    var back = JsonSerializer.Deserialize(json, AppJsonContext.Default.TaskListResponse)!;
+    Assert(back.Tasks.Count == 1, $"count: {back.Tasks.Count}");
+    Assert(back.Tasks[0].Action == "scan", $"action: {back.Tasks[0].Action}");
+});
+```
+
+- [ ] **Step 4: Add MetadataProvider round-trips**
+
+```csharp
+Check("MetadataProvidersResponse round-trip", () =>
+{
+    var obj = new MetadataProvidersResponse
+    {
+        Providers = new MetadataProviderGroups
+        {
+            Books = new List<ProviderEntry>
+            {
+                new() { Value = "google", Text = "Google Books" }
+            },
+            BooksCovers = new List<ProviderEntry>
+            {
+                new() { Value = "best", Text = "Best" }
+            },
+            Podcasts = new List<ProviderEntry>()
+        }
+    };
+    var json = JsonSerializer.Serialize(obj, AppJsonContext.Default.MetadataProvidersResponse);
+    var back = JsonSerializer.Deserialize(json, AppJsonContext.Default.MetadataProvidersResponse)!;
+    Assert(back.Providers.Books.Count == 1, $"books count: {back.Providers.Books.Count}");
+    Assert(back.Providers.Books[0].Value == "google", $"value: {back.Providers.Books[0].Value}");
+    Assert(back.Providers.Books[0].Text == "Google Books", $"text: {back.Providers.Books[0].Text}");
+});
+
+Check("CoverSearchResponse round-trip", () =>
+{
+    var obj = new CoverSearchResponse
+    {
+        Results = new List<string> { "https://example.com/cover1.jpg", "https://example.com/cover2.jpg" }
+    };
+    var json = JsonSerializer.Serialize(obj, AppJsonContext.Default.CoverSearchResponse);
+    var back = JsonSerializer.Deserialize(json, AppJsonContext.Default.CoverSearchResponse)!;
+    Assert(back.Results.Count == 2, $"count: {back.Results.Count}");
+    Assert(back.Results[0] == "https://example.com/cover1.jpg", $"url: {back.Results[0]}");
+});
+```
+
+- [ ] **Step 5: Run self-test**
+
+Run: `dotnet run --project src/AbsCli/AbsCli.csproj -- self-test`
+Expected: All checks pass including the new ones (should be ~32 total: 25 existing + 7 new).
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+dotnet format AbsCli.sln
+git add src/AbsCli/Commands/SelfTestCommand.cs
+git commit -m "test: add self-test round-trips for backup, scan, task, metadata DTOs"
+```
+
+---
+
+## Task 10: Test Infrastructure — Seed
+
+**Files:**
+- Modify: `docker/seed.sh`
+
+- [ ] **Step 1: Add uploaduser to seed script**
+
+Add after the existing `testuser` creation block (after line 71):
+
+```bash
+# Create upload test user (can upload but not delete)
+echo "Creating upload test user..."
+curl -sf -X POST "$ABS_URL/api/users" \
+    -H "$AUTH" \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "username": "uploaduser",
+        "password": "uploadpass",
+        "type": "user",
+        "permissions": {
+            "download": true,
+            "update": true,
+            "delete": false,
+            "upload": true,
+            "accessAllLibraries": true,
+            "accessAllTags": true,
+            "accessExplicitContent": true
+        }
+    }' > /dev/null 2>&1 || true
+```
+
+- [ ] **Step 2: Update the summary at the end of seed.sh**
+
+Replace the last echo line:
+
+```bash
+echo "Test credentials: testuser/testpass, uploaduser/uploadpass"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker/seed.sh
+git commit -m "test: add uploaduser to seed script for upload permission testing"
+```
+
+---
+
+## Task 11: Test Infrastructure — Smoke Tests
+
+**Files:**
+- Modify: `docker/smoke-test.sh`
+
+- [ ] **Step 1: Add help screen tests for new commands**
+
+In the parent-command help loop (line 91), add the new parent commands:
+
+```bash
+for cmd in "" "config" "libraries" "items" "series" "authors" "self-test" "backup" "metadata" "tasks"; do
+```
+
+In the leaf-command help+examples loop (line 102), add new leaf commands:
+
+```bash
+for cmd in "login" "config get" "config set" \
+           "libraries list" "libraries get" "libraries scan" \
+           "items list" "items get" "items search" \
+           "items update" "items batch-update" "items batch-get" "items scan" \
+           "series list" "series get" \
+           "authors list" "authors get" \
+           "search" \
+           "backup create" "backup list" "backup apply" "backup download" \
+           "backup delete" "backup upload" \
+           "upload" \
+           "metadata search" "metadata providers" "metadata covers" \
+           "tasks list"; do
+```
+
+- [ ] **Step 2: Add backup smoke tests**
+
+Add before the results summary section:
+
+```bash
+# ============================================================
+echo ""
+echo "=== Backup Commands ==="
+# ============================================================
+
+# Create a backup
+output=$($CLI backup create 2>/dev/null)
+assert_json_key "backup create returns backups" "backups" "$output"
+assert_json_expr "backup create has at least 1 backup" "len(d['backups'])>=1" "$output"
+
+BACKUP_ID=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin)['backups'][-1]['id'])")
+
+# List backups
+output=$($CLI backup list 2>/dev/null)
+assert_json_key "backup list has backups" "backups" "$output"
+assert_json_key "backup list has backupLocation" "backupLocation" "$output"
+assert_json_expr "backup list finds our backup" \
+    "any(b['id']=='$BACKUP_ID' for b in d['backups'])" "$output"
+
+# Download backup
+BACKUP_DL=$(mktemp)
+$CLI backup download --id "$BACKUP_ID" --output "$BACKUP_DL" 2>/dev/null
+if [ -s "$BACKUP_DL" ]; then
+    pass "backup download wrote file"
+else
+    fail "backup download wrote file" "file is empty"
+fi
+
+# Upload the downloaded backup (re-upload)
+output=$($CLI backup upload --file "$BACKUP_DL" 2>/dev/null)
+assert_json_key "backup upload returns backups" "backups" "$output"
+rm -f "$BACKUP_DL"
+
+# Apply backup
+output=$($CLI backup apply --id "$BACKUP_ID" 2>/dev/null)
+if echo "$output" | grep -q "success"; then
+    pass "backup apply reports success"
+else
+    pass "backup apply completed (exit 0)"
+fi
+
+# Delete backup
+output=$($CLI backup delete --id "$BACKUP_ID" 2>/dev/null)
+assert_json_key "backup delete returns backups" "backups" "$output"
+```
+
+- [ ] **Step 3: Add upload smoke tests**
+
+```bash
+# ============================================================
+echo ""
+echo "=== Upload Command ==="
+# ============================================================
+
+# Get folder ID for upload
+FOLDER_ID=$(echo "$($CLI libraries get --id "$LIB_ID" 2>/dev/null)" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['folders'][0]['id'])")
+
+# Create a tiny test file
+UPLOAD_TMP=$(mktemp -d)
+python3 -c "
+header = bytes([0xFF, 0xFB, 0x90, 0x00])
+frame = header + b'\x00' * 413
+with open('$UPLOAD_TMP/test.mp3', 'wb') as f:
+    for _ in range(38):
+        f.write(frame)
+"
+
+# Upload as uploaduser
+UPLOAD_TOKEN=$(curl -sf -X POST "$ABS_URL/login" \
+    -H 'Content-Type: application/json' \
+    -H 'X-Return-Tokens: true' \
+    -d '{"username":"uploaduser","password":"uploadpass"}' \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['user']['accessToken'])")
+
+SAVE_TOKEN="$ABS_TOKEN"
+export ABS_TOKEN="$UPLOAD_TOKEN"
+
+output=$($CLI upload --title "Smoke Test Upload" --author "Test Author" \
+    --folder "$FOLDER_ID" --wait --files "$UPLOAD_TMP/test.mp3" 2>/dev/null)
+if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'id' in d" 2>/dev/null; then
+    pass "upload --wait returned item JSON"
+else
+    fail "upload --wait returned item JSON" "no id in response"
+    echo "    response: ${output:0:200}"
+fi
+
+export ABS_TOKEN="$SAVE_TOKEN"
+rm -rf "$UPLOAD_TMP"
+```
+
+- [ ] **Step 4: Add permission denial smoke tests**
+
+```bash
+# ============================================================
+echo ""
+echo "=== Permission Errors ==="
+# ============================================================
+
+# testuser cannot upload
+TEST_TOKEN=$(curl -sf -X POST "$ABS_URL/login" \
+    -H 'Content-Type: application/json' \
+    -H 'X-Return-Tokens: true' \
+    -d '{"username":"testuser","password":"testpass"}' \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['user']['accessToken'])")
+
+SAVE_TOKEN="$ABS_TOKEN"
+export ABS_TOKEN="$TEST_TOKEN"
+
+UPLOAD_TMP2=$(mktemp -d)
+python3 -c "
+with open('$UPLOAD_TMP2/test.mp3', 'wb') as f:
+    f.write(bytes([0xFF, 0xFB, 0x90, 0x00]) + b'\x00' * 413)
+"
+
+error_output=$($CLI upload --title "Should Fail" --author "Test" \
+    --folder "$FOLDER_ID" --files "$UPLOAD_TMP2/test.mp3" 2>&1 || true)
+if echo "$error_output" | grep -qi "permission denied"; then
+    pass "upload as testuser shows permission denied"
+else
+    fail "upload as testuser shows permission denied" "got: ${error_output:0:200}"
+fi
+rm -rf "$UPLOAD_TMP2"
+
+# testuser cannot access backups (admin-only)
+error_output=$($CLI backup list 2>&1 || true)
+if echo "$error_output" | grep -qi "permission denied\|admin"; then
+    pass "backup list as testuser shows permission denied"
+else
+    fail "backup list as testuser shows permission denied" "got: ${error_output:0:200}"
+fi
+
+export ABS_TOKEN="$SAVE_TOKEN"
+```
+
+- [ ] **Step 5: Add scan and tasks smoke tests**
+
+```bash
+# ============================================================
+echo ""
+echo "=== Scan Commands ==="
+# ============================================================
+
+# Library scan (async — just verify it returns 0)
+$CLI libraries scan 2>/dev/null
+pass "libraries scan completed (exit 0)"
+
+# Wait a moment for scan to register as a task, then check tasks
+sleep 2
+
+output=$($CLI tasks list 2>/dev/null)
+assert_json_key "tasks list has tasks" "tasks" "$output"
+
+# Item scan (sync — returns result)
+output=$($CLI items scan --id "$FIRST_ITEM_ID" 2>/dev/null)
+assert_json_key "items scan has result" "result" "$output"
+```
+
+- [ ] **Step 6: Add metadata smoke tests**
+
+```bash
+# ============================================================
+echo ""
+echo "=== Metadata Commands ==="
+# ============================================================
+
+# Providers — always works (no external API call)
+output=$($CLI metadata providers 2>/dev/null)
+assert_json_key "metadata providers has providers" "providers" "$output"
+assert_json_expr "metadata providers has books" "len(d['providers']['books'])>0" "$output"
+assert_json_expr "metadata providers has google" \
+    "any(p['value']=='google' for p in d['providers']['books'])" "$output"
+
+# Search and covers — only run if SMOKE_TEST_EXTERNAL is set
+if [ "${SMOKE_TEST_EXTERNAL:-}" = "1" ]; then
+    echo "  (external provider tests enabled)"
+
+    output=$($CLI metadata search --provider google --title "Storm Front" --author "Jim Butcher" 2>/dev/null)
+    if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert len(d)>0" 2>/dev/null; then
+        pass "metadata search returns results"
+    else
+        fail "metadata search returns results" "empty or invalid response"
+    fi
+
+    output=$($CLI metadata covers --provider google --title "Storm Front" 2>/dev/null)
+    assert_json_key "metadata covers has results" "results" "$output"
+else
+    echo "  (skipping external provider tests — set SMOKE_TEST_EXTERNAL=1 to enable)"
+fi
+```
+
+- [ ] **Step 7: Update expected item count**
+
+After upload smoke test, the library has 16 items (15 seed + 1 upload test). Update the existing items count assertion (line 186) and the script header comment:
+
+Change the header comment to:
+```bash
+# Expects a seeded ABS instance (15 books, 6 authors, 3 series).
+# Upload tests add 1 more book during the test run.
+```
+
+Note: The items list test (15 items) runs before the upload test, so the assertion stays at 15. No change needed to existing assertions — order matters.
+
+- [ ] **Step 8: Verify the smoke test script is syntactically valid**
+
+Run: `bash -n docker/smoke-test.sh`
+Expected: No output (no syntax errors).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add docker/smoke-test.sh
+git commit -m "test: add smoke tests for backup, upload, scan, metadata, tasks, permissions"
+```
+
+---
+
+## Task 12: Final Verification
+
+- [ ] **Step 1: Full build**
+
+Run: `dotnet build src/AbsCli/AbsCli.csproj`
+Expected: Build succeeded with no warnings.
+
+- [ ] **Step 2: Format check**
+
+Run: `dotnet format AbsCli.sln --verify-no-changes`
+Expected: No formatting issues.
+
+- [ ] **Step 3: Unit tests**
+
+Run: `dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj`
+Expected: All existing tests pass.
+
+- [ ] **Step 4: Self-test**
+
+Run: `dotnet run --project src/AbsCli/AbsCli.csproj -- self-test`
+Expected: All checks pass (~32 total).
+
+- [ ] **Step 5: Verify all help screens**
+
+Run each new command with `--help` and verify output has description, options, and examples:
+
+```bash
+dotnet run --project src/AbsCli/AbsCli.csproj -- backup --help
+dotnet run --project src/AbsCli/AbsCli.csproj -- backup create --help
+dotnet run --project src/AbsCli/AbsCli.csproj -- upload --help
+dotnet run --project src/AbsCli/AbsCli.csproj -- libraries scan --help
+dotnet run --project src/AbsCli/AbsCli.csproj -- items scan --help
+dotnet run --project src/AbsCli/AbsCli.csproj -- metadata --help
+dotnet run --project src/AbsCli/AbsCli.csproj -- metadata search --help
+dotnet run --project src/AbsCli/AbsCli.csproj -- metadata providers --help
+dotnet run --project src/AbsCli/AbsCli.csproj -- metadata covers --help
+dotnet run --project src/AbsCli/AbsCli.csproj -- tasks list --help
+```
+
+- [ ] **Step 6: Smoke tests (if Docker available)**
+
+```bash
+docker compose -f docker/docker-compose.yml up -d
+bash docker/seed.sh
+bash docker/smoke-test.sh
+```
+
+Expected: All assertions pass.
+
+For external provider tests:
+```bash
+SMOKE_TEST_EXTERNAL=1 bash docker/smoke-test.sh
+```
+
+- [ ] **Step 7: Commit any final fixes, tag as ready for review**
+
+```bash
+git add -A
+git commit -m "chore: final cleanup for v0.2.0"
+```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,33 +1,31 @@
 # Roadmap
 
-## v0.2.0 — Backup & Restore (safety net for agent operations)
+## v0.2.0 — Upload, Metadata & Backup
 
-ABS has a full backup API (`/api/backups/*`, admin-only). Wrapping it in the CLI
-gives agents a rollback mechanism before making bulk metadata changes.
+Enable AI agents to upload books to ABS, apply metadata from providers, and
+create safety-net backups. CLI provides sharp primitives; agents orchestrate.
 
-| Command | ABS Endpoint | Description |
-|---------|-------------|-------------|
-| `abs-cli backup create` | `POST /api/backups` | Snapshot current state before changes |
-| `abs-cli backup list` | `GET /api/backups` | List available backups |
-| `abs-cli backup apply --id <id>` | `GET /api/backups/:id/apply` | Restore from a backup |
-| `abs-cli backup download --id <id>` | `GET /api/backups/:id/download` | Download backup file |
-| `abs-cli backup delete --id <id>` | `DELETE /api/backups/:id` | Delete a backup |
-| `abs-cli backup upload --file <path>` | `POST /api/backups/upload` | Upload a backup file |
+**Backup** — `abs-cli backup create|list|apply|download|delete|upload` (admin-only).
+Safety net before bulk changes. Backups contain the SQLite database + metadata.
 
-Intended agent workflow:
-```bash
-# Before bulk changes
-BACKUP_ID=$(abs-cli backup create | jq -r '.id')
+**Upload** — `abs-cli upload` with author/series/sequence folder naming.
+Supports `--wait` to poll until the item appears in the library after upload.
 
-# Agent makes changes...
-abs-cli items batch-update --stdin < changes.json
+**Scan** — `abs-cli libraries scan` (full library, async) and `abs-cli items scan`
+(single item, sync). Trigger scans after upload to create library items.
 
-# If something went wrong
-abs-cli backup apply --id "$BACKUP_ID"
-```
+**Metadata** — `abs-cli metadata search|providers|covers`. Search ABS-configured
+providers (Audible, Google Books, etc.) for book metadata and covers. Agent picks
+the match and applies via existing `abs-cli items update`.
 
-Backups contain the SQLite database + metadata — all library items, metadata,
-series, authors, user data. Restore replaces the current state entirely.
+**Tasks** — `abs-cli tasks list`. Poll background task status (e.g. scan progress).
+
+**Permission errors** — Improved error messages for 403/400/404/500 across all commands.
+
+**Testing** — New `uploaduser` test user, permission denial smoke tests, external
+provider tests gated behind local-only flag.
+
+Full spec: [docs/specs/2026-04-12-v0.2.0-upload-metadata-backup.md](specs/2026-04-12-v0.2.0-upload-metadata-backup.md)
 
 ---
 

--- a/docs/specs/2026-04-12-v0.2.0-upload-metadata-backup.md
+++ b/docs/specs/2026-04-12-v0.2.0-upload-metadata-backup.md
@@ -1,0 +1,207 @@
+# v0.2.0 Spec: Backup, Upload & Metadata Commands
+
+Goal: give AI agents the primitives to upload books to ABS with proper metadata.
+Agent orchestrates the workflow; CLI stays a sharp, composable tool.
+
+## New commands
+
+### Backup (admin-only)
+
+```
+abs-cli backup create
+abs-cli backup list
+abs-cli backup apply --id <id>
+abs-cli backup download --id <id> --output <path>
+abs-cli backup delete --id <id>
+abs-cli backup upload --file <path>
+```
+
+| Command | ABS endpoint | Response |
+|---------|-------------|----------|
+| `create` | `POST /api/backups` | `{ backups: [...] }` |
+| `list` | `GET /api/backups` | `{ backups: [...], backupLocation, backupPathEnvSet }` |
+| `apply --id` | `GET /api/backups/:id/apply` | HTTP 200, no body |
+| `download --id --output` | `GET /api/backups/:id/download` | Binary file written to `--output` path |
+| `delete --id` | `DELETE /api/backups/:id` | `{ backups: [...] }` (remaining) |
+| `upload --file` | `POST /api/backups/upload` | `{ backups: [...] }` |
+
+All backup commands require admin role. `download` writes to disk, all others output JSON to stdout.
+
+### Upload (requires upload permission)
+
+```
+abs-cli upload --library <id> --title <title> [--author <author>] \
+  [--folder <id>] [--series <series>] [--sequence <n>] [--wait] \
+  --files <path> [<path>...]
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--library` | Yes | Library ID (or default from config) |
+| `--title` | Yes | Book title |
+| `--author` | No | Author name |
+| `--files` | Yes | One or more file paths to upload |
+| `--folder` | No | Folder ID within library. Auto-resolved if library has one folder; errors if multiple. Folder IDs found via `abs-cli libraries get`. |
+| `--series` | No | Series name |
+| `--sequence` | No | Series position (integer). Requires `--series`. |
+| `--wait` | No | Poll until item appears in library, return item JSON |
+
+**Folder structure created on ABS server:**
+
+| Flags provided | Path created |
+|---------------|-------------|
+| `--title` only | `{folder}/{Title}/` |
+| `--author --title` | `{folder}/{Author}/{Title}/` |
+| `--author --series --title` | `{folder}/{Author}/{Series}/{Title}/` |
+| `--author --series --sequence N --title T` | `{folder}/{Author}/{Series}/{N}. - {T}/` |
+
+The `--sequence` prefix is composed CLI-side. ABS upload API receives a flat `title` string.
+Example: `--sequence 2 --title "Das Kanguru-Manifest"` sends `title: "2. - Das Kanguru-Manifest"` to ABS.
+
+**`--wait` behavior:**
+- After upload returns HTTP 200, polls library items searching for the title every ~3 seconds.
+- When item found, outputs item JSON to stdout.
+- Timeout after 60 seconds with error on stderr, exit code 1.
+
+**Without `--wait`:** empty stdout, exit 0 on success.
+
+**Help text** includes a note explaining where to find folder IDs (`abs-cli libraries get`).
+
+### Scan (added to existing command groups)
+
+**Library scan** (admin-only, async):
+```
+abs-cli libraries scan --id <id> [--force]
+```
+
+- `POST /api/libraries/:id/scan` (appends `?force=1` when `--force` is set)
+- Returns immediately. Scan runs in background.
+- Output: empty stdout, exit 0. Agent polls `tasks list` to track progress.
+
+**Item scan** (admin-only, sync):
+```
+abs-cli items scan --id <id>
+```
+
+- `POST /api/items/:id/scan`
+- Synchronous, waits for result.
+- Output: `{ "result": "UPDATED" }` (possible values: `NOTHING`, `ADDED`, `UPDATED`, `REMOVED`, `UPTODATE`)
+
+### Metadata (new group)
+
+**Search metadata providers:**
+```
+abs-cli metadata search --provider <provider> --title <title> [--author <author>]
+```
+
+- `GET /api/search/books?provider=X&title=Y&author=Z`
+- Output: JSON array of matches. Shape varies by provider but typically includes: `title`, `author`, `description`, `cover` (URL), `publishedYear`, `genres`, `isbn`, `asin`, `language`, `series`, `narrator`.
+- Agent inspects results, picks the right match, applies fields via `abs-cli items update`.
+
+**List available providers:**
+```
+abs-cli metadata providers
+```
+
+- `GET /api/search/providers`
+- Output: JSON with `books`, `booksCovers`, `podcasts` arrays. Each entry has `value` (ID to pass as `--provider`) and `text` (display name).
+
+**Search covers:**
+```
+abs-cli metadata covers --provider <provider> --title <title> [--author <author>]
+```
+
+- `GET /api/search/covers?provider=X&title=Y&author=Z`
+- `--provider` accepts specific provider, `best`, or `all`.
+- Output: `{ "results": ["url1", "url2", ...] }` (cover image URLs).
+
+### Tasks (new group)
+
+```
+abs-cli tasks list
+```
+
+- `GET /api/tasks`
+- Output: `{ "tasks": [...] }` — each task has `id`, `action`, `title`, `isFinished`, `isFailed`, `startedAt`, `finishedAt`, `data` (includes `scanResults` with `added`, `updated`, `missing`, `elapsed`).
+
+## Permission error handling
+
+Improve error messages across all commands. Currently all non-2xx responses get a generic dump.
+
+**403 responses** — contextual message based on command:
+
+| Command group | Error message |
+|--------------|---------------|
+| `upload` | `Error: Permission denied. This operation requires 'upload' permission.` |
+| `items update/batch-update` | `Error: Permission denied. This operation requires 'update' permission.` |
+| `backup *`, `libraries scan`, `items scan` | `Error: Permission denied. This operation requires admin access.` |
+
+**Other status codes:**
+
+| Status | Message format |
+|--------|---------------|
+| 400 | `Error: Bad request. {server message}` |
+| 403 | `Error: Permission denied. {context}` |
+| 404 | `Error: Not found. {resource type} '{id}' does not exist.` |
+| 500 | `Error: Server error. {server message}` |
+
+Implementation lives in `AbsApiClient.EnsureSuccessOrHandleAuthAsync()`. Commands pass context (required permission) for 403 messages. Exit code stays 2 for all API errors.
+
+## Test infrastructure changes
+
+### Test users
+
+| User | Password | Role | Key permissions | Purpose |
+|------|----------|------|----------------|---------|
+| `root` | `root` | admin | everything | backup, scan commands |
+| `testuser` | `testpass` | user | update, download. No upload, no delete. | permission denial tests |
+| `uploaduser` | `uploadpass` | user | upload, update, download. No delete. | upload happy path as non-admin |
+
+`root` and `testuser` already exist in seed. `uploaduser` is new.
+
+### New smoke test sections
+
+1. **Backup** (as `root`): create, list, download, apply, delete, upload
+2. **Upload** (as `uploaduser`): upload a book, verify with `--wait`
+3. **Upload denial** (as `testuser`): attempt upload, verify clear 403 message
+4. **Scan** (as `root`): `libraries scan`, `items scan`, `tasks list`
+5. **Metadata** (as any user): `metadata providers`, `metadata search`, `metadata covers`
+6. **Permission errors** (as `testuser`): attempt `backup create`, verify admin-required error
+
+### External provider tests
+
+Metadata search/covers hit external APIs (Audible, Google Books) which can be flaky.
+
+- **CI:** test only `metadata providers` (local to ABS, no external calls)
+- **Local:** test search against `google` provider with a known title (e.g. "Storm Front")
+- Gate external tests behind an environment variable or flag in the smoke test script
+
+## Agent workflow example
+
+```bash
+# 1. Safety net
+abs-cli backup create
+
+# 2. Discover target library
+abs-cli libraries list
+abs-cli libraries get --id lib_123
+
+# 3. Upload book
+abs-cli upload --library lib_123 --title "Die Kanguru-Chroniken" \
+  --author "Marc-Uwe Kling" --series "Das Kanguru" --sequence 1 \
+  --wait --files ./book.m4b
+
+# 4. Search metadata
+abs-cli metadata search --provider audible.de \
+  --title "Die Kanguru-Chroniken" --author "Marc-Uwe Kling"
+
+# 5. Agent picks best match, applies selected fields
+abs-cli items update --id li_xyz --stdin < metadata.json
+```
+
+## Out of scope for v0.2.0
+
+- Auto-match / quick-match (`POST /api/items/:id/match`) — skipped, unreliable results
+- `PATCH /api/backups/path` — niche admin operation
+- Podcast-specific commands
+- ASIN/narrator folder naming conventions (cleanup TBD)

--- a/src/AbsCli/AbsCli.csproj
+++ b/src/AbsCli/AbsCli.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
-    <Version>0.1.1</Version>
+    <Version>0.2.0</Version>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 

--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -96,6 +96,101 @@ public class AbsApiClient
             ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
     }
 
+    public async Task<string> GetAsync(string endpoint, string? permissionHint)
+    {
+        await EnsureValidTokenAsync();
+        var response = await _http.GetAsync(endpoint);
+        await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Get, endpoint, permissionHint);
+        return await response.Content.ReadAsStringAsync();
+    }
+
+    public async Task<T> GetAsync<T>(string endpoint, JsonTypeInfo<T> typeInfo, string? permissionHint)
+    {
+        var json = await GetAsync(endpoint, permissionHint);
+        return JsonSerializer.Deserialize(json, typeInfo)
+            ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
+    }
+
+    public async Task<string> PatchAsync(string endpoint, string jsonBody, string? permissionHint)
+    {
+        await EnsureValidTokenAsync();
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+        var response = await _http.PatchAsync(endpoint, content);
+        await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Patch, endpoint, permissionHint);
+        return await response.Content.ReadAsStringAsync();
+    }
+
+    public async Task<T> PatchAsync<T>(string endpoint, string jsonBody, JsonTypeInfo<T> typeInfo, string? permissionHint)
+    {
+        var json = await PatchAsync(endpoint, jsonBody, permissionHint);
+        return JsonSerializer.Deserialize(json, typeInfo)
+            ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
+    }
+
+    public async Task<string> PostAsync(string endpoint, string jsonBody, string? permissionHint)
+    {
+        await EnsureValidTokenAsync();
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+        var response = await _http.PostAsync(endpoint, content);
+        await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Post, endpoint, permissionHint);
+        return await response.Content.ReadAsStringAsync();
+    }
+
+    public async Task<T> PostAsync<T>(string endpoint, string jsonBody, JsonTypeInfo<T> typeInfo, string? permissionHint)
+    {
+        var json = await PostAsync(endpoint, jsonBody, permissionHint);
+        return JsonSerializer.Deserialize(json, typeInfo)
+            ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
+    }
+
+    public async Task<string> DeleteAsync(string endpoint, string? permissionHint = null)
+    {
+        await EnsureValidTokenAsync();
+        var response = await _http.DeleteAsync(endpoint);
+        await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Delete, endpoint, permissionHint);
+        return await response.Content.ReadAsStringAsync();
+    }
+
+    public async Task<T> DeleteAsync<T>(string endpoint, JsonTypeInfo<T> typeInfo, string? permissionHint = null)
+    {
+        var json = await DeleteAsync(endpoint, permissionHint);
+        return JsonSerializer.Deserialize(json, typeInfo)
+            ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
+    }
+
+    public async Task PostMultipartAsync(string endpoint, MultipartFormDataContent content,
+        string? permissionHint = null)
+    {
+        await EnsureValidTokenAsync();
+        var response = await _http.PostAsync(endpoint, content);
+        await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Post, endpoint, permissionHint);
+    }
+
+    public async Task DownloadFileAsync(string endpoint, string outputPath, string? permissionHint = null)
+    {
+        await EnsureValidTokenAsync();
+        var response = await _http.GetAsync(endpoint, HttpCompletionOption.ResponseHeadersRead);
+        await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Get, endpoint, permissionHint);
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        await using var fileStream = new FileStream(outputPath, FileMode.Create, FileAccess.Write);
+        await stream.CopyToAsync(fileStream);
+    }
+
+    public async Task<string> PostEmptyAsync(string endpoint, string? permissionHint = null)
+    {
+        await EnsureValidTokenAsync();
+        var response = await _http.PostAsync(endpoint, null);
+        await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Post, endpoint, permissionHint);
+        return await response.Content.ReadAsStringAsync();
+    }
+
+    public async Task<T> PostEmptyAsync<T>(string endpoint, JsonTypeInfo<T> typeInfo, string? permissionHint = null)
+    {
+        var json = await PostEmptyAsync(endpoint, permissionHint);
+        return JsonSerializer.Deserialize(json, typeInfo)
+            ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
+    }
+
     private async Task EnsureValidTokenAsync()
     {
         if (_config.AccessToken == null) return;
@@ -172,27 +267,34 @@ public class AbsApiClient
     }
 
     private async Task EnsureSuccessOrHandleAuthAsync(
-        HttpResponseMessage response, HttpMethod method, string endpoint)
+        HttpResponseMessage response, HttpMethod method, string endpoint,
+        string? permissionHint = null)
     {
         if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
         {
-            // Try one refresh
             await RefreshTokenAsync();
-
-            // Retry the original request
             var retryRequest = new HttpRequestMessage(method, endpoint);
             var retryResponse = await _http.SendAsync(retryRequest);
-
             if (!retryResponse.IsSuccessStatusCode)
             {
-                ConsoleOutput.WriteError($"API request failed: {(int)retryResponse.StatusCode} {retryResponse.ReasonPhrase}");
+                ConsoleOutput.WriteError($"API request failed after token refresh: {(int)retryResponse.StatusCode} {retryResponse.ReasonPhrase}");
                 Environment.Exit(2);
             }
         }
         else if (!response.IsSuccessStatusCode)
         {
             var body = await response.Content.ReadAsStringAsync();
-            ConsoleOutput.WriteError($"API request failed: {(int)response.StatusCode} {response.ReasonPhrase}\n{body}");
+            var status = (int)response.StatusCode;
+            var message = status switch
+            {
+                403 when permissionHint != null =>
+                    $"Permission denied. This operation requires {permissionHint}.",
+                403 => $"Permission denied.{(string.IsNullOrWhiteSpace(body) ? "" : $" {body.Trim()}")}",
+                400 => $"Bad request.{(string.IsNullOrWhiteSpace(body) ? "" : $" {body.Trim()}")}",
+                404 => $"Not found.{(string.IsNullOrWhiteSpace(body) ? "" : $" {body.Trim()}")}",
+                _ => $"API request failed: {status} {response.ReasonPhrase}{(string.IsNullOrWhiteSpace(body) ? "" : $"\n{body.Trim()}")}"
+            };
+            ConsoleOutput.WriteError(message);
             Environment.Exit(2);
         }
     }

--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -14,13 +14,19 @@ public class AbsApiClient
     private readonly ConfigManager _configManager;
     private AppConfig _config;
 
+    public static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromSeconds(100);
+
     public AbsApiClient(AppConfig config, ConfigManager configManager)
     {
         _config = config;
         _configManager = configManager;
         _http = new HttpClient
         {
-            BaseAddress = new Uri(config.Server!.TrimEnd('/'))
+            BaseAddress = new Uri(config.Server!.TrimEnd('/')),
+            // We manage timeouts per-request via CancellationTokenSource so that
+            // long operations (backup create/apply/download/upload) can opt into
+            // longer timeouts. Setting this to Infinite disables the global cap.
+            Timeout = Timeout.InfiniteTimeSpan
         };
         _http.DefaultRequestHeaders.UserAgent.ParseAdd($"abs-cli/{AssemblyVersion}");
 
@@ -49,97 +55,104 @@ public class AbsApiClient
         return JsonSerializer.Deserialize(json, AppJsonContext.Default.LoginResponse)!;
     }
 
-    public async Task<string> GetAsync(string endpoint, string? permissionHint = null)
+    public async Task<string> GetAsync(string endpoint, string? permissionHint = null, TimeSpan? timeout = null)
     {
         await EnsureValidTokenAsync();
-        var response = await _http.GetAsync(endpoint);
+        using var cts = new CancellationTokenSource(timeout ?? DefaultRequestTimeout);
+        var response = await _http.GetAsync(endpoint, cts.Token);
         await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Get, endpoint, permissionHint);
         return await response.Content.ReadAsStringAsync();
     }
 
-    public async Task<T> GetAsync<T>(string endpoint, JsonTypeInfo<T> typeInfo, string? permissionHint = null)
+    public async Task<T> GetAsync<T>(string endpoint, JsonTypeInfo<T> typeInfo, string? permissionHint = null, TimeSpan? timeout = null)
     {
-        var json = await GetAsync(endpoint, permissionHint);
+        var json = await GetAsync(endpoint, permissionHint, timeout);
         return JsonSerializer.Deserialize(json, typeInfo)
             ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
     }
 
-    public async Task<string> PatchAsync(string endpoint, string jsonBody, string? permissionHint = null)
+    public async Task<string> PatchAsync(string endpoint, string jsonBody, string? permissionHint = null, TimeSpan? timeout = null)
     {
         await EnsureValidTokenAsync();
+        using var cts = new CancellationTokenSource(timeout ?? DefaultRequestTimeout);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
-        var response = await _http.PatchAsync(endpoint, content);
+        var response = await _http.PatchAsync(endpoint, content, cts.Token);
         await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Patch, endpoint, permissionHint);
         return await response.Content.ReadAsStringAsync();
     }
 
-    public async Task<T> PatchAsync<T>(string endpoint, string jsonBody, JsonTypeInfo<T> typeInfo, string? permissionHint = null)
+    public async Task<T> PatchAsync<T>(string endpoint, string jsonBody, JsonTypeInfo<T> typeInfo, string? permissionHint = null, TimeSpan? timeout = null)
     {
-        var json = await PatchAsync(endpoint, jsonBody, permissionHint);
+        var json = await PatchAsync(endpoint, jsonBody, permissionHint, timeout);
         return JsonSerializer.Deserialize(json, typeInfo)
             ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
     }
 
-    public async Task<string> PostAsync(string endpoint, string jsonBody, string? permissionHint = null)
+    public async Task<string> PostAsync(string endpoint, string jsonBody, string? permissionHint = null, TimeSpan? timeout = null)
     {
         await EnsureValidTokenAsync();
+        using var cts = new CancellationTokenSource(timeout ?? DefaultRequestTimeout);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
-        var response = await _http.PostAsync(endpoint, content);
+        var response = await _http.PostAsync(endpoint, content, cts.Token);
         await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Post, endpoint, permissionHint);
         return await response.Content.ReadAsStringAsync();
     }
 
-    public async Task<T> PostAsync<T>(string endpoint, string jsonBody, JsonTypeInfo<T> typeInfo, string? permissionHint = null)
+    public async Task<T> PostAsync<T>(string endpoint, string jsonBody, JsonTypeInfo<T> typeInfo, string? permissionHint = null, TimeSpan? timeout = null)
     {
-        var json = await PostAsync(endpoint, jsonBody, permissionHint);
+        var json = await PostAsync(endpoint, jsonBody, permissionHint, timeout);
         return JsonSerializer.Deserialize(json, typeInfo)
             ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
     }
 
-    public async Task<string> DeleteAsync(string endpoint, string? permissionHint = null)
+    public async Task<string> DeleteAsync(string endpoint, string? permissionHint = null, TimeSpan? timeout = null)
     {
         await EnsureValidTokenAsync();
-        var response = await _http.DeleteAsync(endpoint);
+        using var cts = new CancellationTokenSource(timeout ?? DefaultRequestTimeout);
+        var response = await _http.DeleteAsync(endpoint, cts.Token);
         await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Delete, endpoint, permissionHint);
         return await response.Content.ReadAsStringAsync();
     }
 
-    public async Task<T> DeleteAsync<T>(string endpoint, JsonTypeInfo<T> typeInfo, string? permissionHint = null)
+    public async Task<T> DeleteAsync<T>(string endpoint, JsonTypeInfo<T> typeInfo, string? permissionHint = null, TimeSpan? timeout = null)
     {
-        var json = await DeleteAsync(endpoint, permissionHint);
+        var json = await DeleteAsync(endpoint, permissionHint, timeout);
         return JsonSerializer.Deserialize(json, typeInfo)
             ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
     }
 
     public async Task PostMultipartAsync(string endpoint, MultipartFormDataContent content,
-        string? permissionHint = null)
+        string? permissionHint = null, TimeSpan? timeout = null)
     {
         await EnsureValidTokenAsync();
-        var response = await _http.PostAsync(endpoint, content);
+        using var cts = new CancellationTokenSource(timeout ?? DefaultRequestTimeout);
+        var response = await _http.PostAsync(endpoint, content, cts.Token);
         await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Post, endpoint, permissionHint);
     }
 
-    public async Task DownloadFileAsync(string endpoint, string outputPath, string? permissionHint = null)
+    public async Task DownloadFileAsync(string endpoint, string outputPath, string? permissionHint = null, TimeSpan? timeout = null)
     {
         await EnsureValidTokenAsync();
-        var response = await _http.GetAsync(endpoint, HttpCompletionOption.ResponseHeadersRead);
+        using var cts = new CancellationTokenSource(timeout ?? DefaultRequestTimeout);
+        var response = await _http.GetAsync(endpoint, HttpCompletionOption.ResponseHeadersRead, cts.Token);
         await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Get, endpoint, permissionHint);
-        await using var stream = await response.Content.ReadAsStreamAsync();
+        await using var stream = await response.Content.ReadAsStreamAsync(cts.Token);
         await using var fileStream = new FileStream(outputPath, FileMode.Create, FileAccess.Write);
-        await stream.CopyToAsync(fileStream);
+        await stream.CopyToAsync(fileStream, cts.Token);
     }
 
-    public async Task<string> PostEmptyAsync(string endpoint, string? permissionHint = null)
+    public async Task<string> PostEmptyAsync(string endpoint, string? permissionHint = null, TimeSpan? timeout = null)
     {
         await EnsureValidTokenAsync();
-        var response = await _http.PostAsync(endpoint, null);
+        using var cts = new CancellationTokenSource(timeout ?? DefaultRequestTimeout);
+        var response = await _http.PostAsync(endpoint, null, cts.Token);
         await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Post, endpoint, permissionHint);
         return await response.Content.ReadAsStringAsync();
     }
 
-    public async Task<T> PostEmptyAsync<T>(string endpoint, JsonTypeInfo<T> typeInfo, string? permissionHint = null)
+    public async Task<T> PostEmptyAsync<T>(string endpoint, JsonTypeInfo<T> typeInfo, string? permissionHint = null, TimeSpan? timeout = null)
     {
-        var json = await PostEmptyAsync(endpoint, permissionHint);
+        var json = await PostEmptyAsync(endpoint, permissionHint, timeout);
         return JsonSerializer.Deserialize(json, typeInfo)
             ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
     }

--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -49,54 +49,7 @@ public class AbsApiClient
         return JsonSerializer.Deserialize(json, AppJsonContext.Default.LoginResponse)!;
     }
 
-    public async Task<string> GetAsync(string endpoint)
-    {
-        await EnsureValidTokenAsync();
-        var response = await _http.GetAsync(endpoint);
-        await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Get, endpoint);
-        return await response.Content.ReadAsStringAsync();
-    }
-
-    public async Task<T> GetAsync<T>(string endpoint, JsonTypeInfo<T> typeInfo)
-    {
-        var json = await GetAsync(endpoint);
-        return JsonSerializer.Deserialize(json, typeInfo)
-            ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
-    }
-
-    public async Task<string> PatchAsync(string endpoint, string jsonBody)
-    {
-        await EnsureValidTokenAsync();
-        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
-        var response = await _http.PatchAsync(endpoint, content);
-        await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Patch, endpoint);
-        return await response.Content.ReadAsStringAsync();
-    }
-
-    public async Task<T> PatchAsync<T>(string endpoint, string jsonBody, JsonTypeInfo<T> typeInfo)
-    {
-        var json = await PatchAsync(endpoint, jsonBody);
-        return JsonSerializer.Deserialize(json, typeInfo)
-            ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
-    }
-
-    public async Task<string> PostAsync(string endpoint, string jsonBody)
-    {
-        await EnsureValidTokenAsync();
-        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
-        var response = await _http.PostAsync(endpoint, content);
-        await EnsureSuccessOrHandleAuthAsync(response, HttpMethod.Post, endpoint);
-        return await response.Content.ReadAsStringAsync();
-    }
-
-    public async Task<T> PostAsync<T>(string endpoint, string jsonBody, JsonTypeInfo<T> typeInfo)
-    {
-        var json = await PostAsync(endpoint, jsonBody);
-        return JsonSerializer.Deserialize(json, typeInfo)
-            ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
-    }
-
-    public async Task<string> GetAsync(string endpoint, string? permissionHint)
+    public async Task<string> GetAsync(string endpoint, string? permissionHint = null)
     {
         await EnsureValidTokenAsync();
         var response = await _http.GetAsync(endpoint);
@@ -104,14 +57,14 @@ public class AbsApiClient
         return await response.Content.ReadAsStringAsync();
     }
 
-    public async Task<T> GetAsync<T>(string endpoint, JsonTypeInfo<T> typeInfo, string? permissionHint)
+    public async Task<T> GetAsync<T>(string endpoint, JsonTypeInfo<T> typeInfo, string? permissionHint = null)
     {
         var json = await GetAsync(endpoint, permissionHint);
         return JsonSerializer.Deserialize(json, typeInfo)
             ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
     }
 
-    public async Task<string> PatchAsync(string endpoint, string jsonBody, string? permissionHint)
+    public async Task<string> PatchAsync(string endpoint, string jsonBody, string? permissionHint = null)
     {
         await EnsureValidTokenAsync();
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
@@ -120,14 +73,14 @@ public class AbsApiClient
         return await response.Content.ReadAsStringAsync();
     }
 
-    public async Task<T> PatchAsync<T>(string endpoint, string jsonBody, JsonTypeInfo<T> typeInfo, string? permissionHint)
+    public async Task<T> PatchAsync<T>(string endpoint, string jsonBody, JsonTypeInfo<T> typeInfo, string? permissionHint = null)
     {
         var json = await PatchAsync(endpoint, jsonBody, permissionHint);
         return JsonSerializer.Deserialize(json, typeInfo)
             ?? throw new InvalidOperationException($"Failed to deserialize response from {endpoint}");
     }
 
-    public async Task<string> PostAsync(string endpoint, string jsonBody, string? permissionHint)
+    public async Task<string> PostAsync(string endpoint, string jsonBody, string? permissionHint = null)
     {
         await EnsureValidTokenAsync();
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
@@ -136,7 +89,7 @@ public class AbsApiClient
         return await response.Content.ReadAsStringAsync();
     }
 
-    public async Task<T> PostAsync<T>(string endpoint, string jsonBody, JsonTypeInfo<T> typeInfo, string? permissionHint)
+    public async Task<T> PostAsync<T>(string endpoint, string jsonBody, JsonTypeInfo<T> typeInfo, string? permissionHint = null)
     {
         var json = await PostAsync(endpoint, jsonBody, permissionHint);
         return JsonSerializer.Deserialize(json, typeInfo)

--- a/src/AbsCli/Api/ApiEndpoints.cs
+++ b/src/AbsCli/Api/ApiEndpoints.cs
@@ -19,4 +19,26 @@ public static class ApiEndpoints
 
     public static string SeriesById(string id) => $"/api/series/{id}";
     public static string AuthorById(string id) => $"/api/authors/{id}";
+
+    // Backup
+    public const string Backups = "/api/backups";
+    public static string Backup(string id) => $"/api/backups/{id}";
+    public static string BackupApply(string id) => $"/api/backups/{id}/apply";
+    public static string BackupDownload(string id) => $"/api/backups/{id}/download";
+    public const string BackupUpload = "/api/backups/upload";
+
+    // Upload
+    public const string Upload = "/api/upload";
+
+    // Scan
+    public static string LibraryScan(string libraryId) => $"/api/libraries/{libraryId}/scan";
+    public static string ItemScan(string id) => $"/api/items/{id}/scan";
+
+    // Metadata search
+    public const string SearchBooks = "/api/search/books";
+    public const string SearchProviders = "/api/search/providers";
+    public const string SearchCovers = "/api/search/covers";
+
+    // Tasks
+    public const string Tasks = "/api/tasks";
 }

--- a/src/AbsCli/Commands/BackupCommand.cs
+++ b/src/AbsCli/Commands/BackupCommand.cs
@@ -1,0 +1,139 @@
+using System.CommandLine;
+using AbsCli.Models;
+using AbsCli.Output;
+using AbsCli.Services;
+
+namespace AbsCli.Commands;
+
+public static class BackupCommand
+{
+    public static Command Create()
+    {
+        var command = new Command("backup", "Manage server backups");
+        command.AddCommand(CreateCreateCommand());
+        command.AddCommand(CreateListCommand());
+        command.AddCommand(CreateApplyCommand());
+        command.AddCommand(CreateDownloadCommand());
+        command.AddCommand(CreateDeleteCommand());
+        command.AddCommand(CreateUploadCommand());
+        return command;
+    }
+
+    private static Command CreateCreateCommand()
+    {
+        var command = new Command("create", "Create a new server backup");
+        command.AddExamples(
+            "abs-cli backup create",
+            "abs-cli backup create | jq '.backups | length'");
+
+        command.SetHandler(async () =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new BackupService(client);
+            var result = await service.CreateAsync();
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.BackupListResponse);
+        });
+
+        return command;
+    }
+
+    private static Command CreateListCommand()
+    {
+        var command = new Command("list", "List all server backups");
+        command.AddExamples(
+            "abs-cli backup list",
+            "abs-cli backup list | jq '.backups[] | {id, filename, datePretty}'");
+
+        command.SetHandler(async () =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new BackupService(client);
+            var result = await service.ListAsync();
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.BackupListResponse);
+        });
+
+        return command;
+    }
+
+    private static Command CreateApplyCommand()
+    {
+        var idOption = new Option<string>("--id", "Backup ID") { IsRequired = true };
+        var command = new Command("apply", "Apply (restore) a server backup") { idOption };
+        command.AddExamples(
+            "abs-cli backup apply --id \"2024-01-15T0000\"",
+            "abs-cli backup apply --id \"2024-01-15T0000\" | jq '.success'");
+
+        command.SetHandler(async (string id) =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new BackupService(client);
+            var result = await service.ApplyAsync(id);
+            ConsoleOutput.WriteRawJson(result);
+        }, idOption);
+
+        return command;
+    }
+
+    private static Command CreateDownloadCommand()
+    {
+        var idOption = new Option<string>("--id", "Backup ID") { IsRequired = true };
+        var outputOption = new Option<string>("--output", "Output file path") { IsRequired = true };
+        var command = new Command("download", "Download a server backup to a local file") { idOption, outputOption };
+        command.AddExamples(
+            "abs-cli backup download --id \"2024-01-15T0000\" --output backup.tar",
+            "abs-cli backup download --id \"2024-01-15T0000\" --output /tmp/abs-backup.tar");
+
+        command.SetHandler(async (string id, string output) =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new BackupService(client);
+            await service.DownloadAsync(id, output);
+        }, idOption, outputOption);
+
+        return command;
+    }
+
+    private static Command CreateDeleteCommand()
+    {
+        var idOption = new Option<string>("--id", "Backup ID") { IsRequired = true };
+        var command = new Command("delete", "Delete a server backup") { idOption };
+        command.AddExamples(
+            "abs-cli backup delete --id \"2024-01-15T0000\"",
+            "abs-cli backup delete --id \"2024-01-15T0000\" | jq '.backups | length'");
+
+        command.SetHandler(async (string id) =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new BackupService(client);
+            var result = await service.DeleteAsync(id);
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.BackupListResponse);
+        }, idOption);
+
+        return command;
+    }
+
+    private static Command CreateUploadCommand()
+    {
+        var fileOption = new Option<string>("--file", "Path to backup file") { IsRequired = true };
+        var command = new Command("upload", "Upload a backup file to the server") { fileOption };
+        command.AddExamples(
+            "abs-cli backup upload --file backup.tar",
+            "abs-cli backup upload --file /tmp/abs-backup.tar | jq '.backups | length'");
+
+        command.SetHandler(async (string file) =>
+        {
+            if (!File.Exists(file))
+            {
+                ConsoleOutput.WriteError($"File not found: {file}");
+                Environment.Exit(1);
+                return;
+            }
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new BackupService(client);
+            var result = await service.UploadAsync(file);
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.BackupListResponse);
+        }, fileOption);
+
+        return command;
+    }
+}

--- a/src/AbsCli/Commands/BackupCommand.cs
+++ b/src/AbsCli/Commands/BackupCommand.cs
@@ -77,11 +77,11 @@ public static class BackupCommand
     private static Command CreateDownloadCommand()
     {
         var idOption = new Option<string>("--id", "Backup ID") { IsRequired = true };
-        var outputOption = new Option<string>("--output", "Output file path") { IsRequired = true };
+        var outputOption = new Option<string>("--output", "Output file path (use .audiobookshelf extension — required for re-upload)") { IsRequired = true };
         var command = new Command("download", "Download a server backup to a local file") { idOption, outputOption };
         command.AddExamples(
-            "abs-cli backup download --id \"2024-01-15T0000\" --output backup.tar",
-            "abs-cli backup download --id \"2024-01-15T0000\" --output /tmp/abs-backup.tar");
+            "abs-cli backup download --id \"2024-01-15T0000\" --output backup.audiobookshelf",
+            "abs-cli backup download --id \"2024-01-15T0000\" --output /tmp/abs-backup.audiobookshelf");
 
         command.SetHandler(async (string id, string output) =>
         {
@@ -114,11 +114,11 @@ public static class BackupCommand
 
     private static Command CreateUploadCommand()
     {
-        var fileOption = new Option<string>("--file", "Path to backup file") { IsRequired = true };
+        var fileOption = new Option<string>("--file", "Path to backup file (must have .audiobookshelf extension)") { IsRequired = true };
         var command = new Command("upload", "Upload a backup file to the server") { fileOption };
         command.AddExamples(
-            "abs-cli backup upload --file backup.tar",
-            "abs-cli backup upload --file /tmp/abs-backup.tar | jq '.backups | length'");
+            "abs-cli backup upload --file backup.audiobookshelf",
+            "abs-cli backup upload --file /tmp/abs-backup.audiobookshelf | jq '.backups | length'");
 
         command.SetHandler(async (string file) =>
         {

--- a/src/AbsCli/Commands/ConfigCommand.cs
+++ b/src/AbsCli/Commands/ConfigCommand.cs
@@ -43,7 +43,7 @@ public static class ConfigCommand
 
     private static Command CreateSetCommand()
     {
-        var keyArg = new Argument<string>("key", "Configuration key (server, default-library)");
+        var keyArg = new Argument<string>("key", "Configuration key (server, defaultLibrary). Kebab-case 'default-library' also accepted.");
         var valueArg = new Argument<string>("value", "Configuration value");
 
         var command = new Command("set", "Set a configuration value")
@@ -53,23 +53,27 @@ public static class ConfigCommand
         };
         command.AddExamples(
             "abs-cli config set server https://abs.example.com",
-            "abs-cli config set default-library \"lib_abc123\"");
+            "abs-cli config set defaultLibrary \"lib_abc123\"",
+            "abs-cli config set default-library \"lib_abc123\"   # kebab-case also accepted");
 
         command.SetHandler((string key, string value) =>
         {
             var configManager = new ConfigManager();
             var config = configManager.Load();
 
-            switch (key.ToLower())
+            // Normalize: lowercase and strip hyphens so 'defaultLibrary',
+            // 'default-library', and 'DefaultLibrary' all match the same key.
+            var normalized = key.ToLowerInvariant().Replace("-", "");
+            switch (normalized)
             {
                 case "server":
                     config.Server = value;
                     break;
-                case "default-library":
+                case "defaultlibrary":
                     config.DefaultLibrary = value;
                     break;
                 default:
-                    ConsoleOutput.WriteError($"Unknown config key: '{key}'. Valid keys: server, default-library");
+                    ConsoleOutput.WriteError($"Unknown config key: '{key}'. Valid keys: server, defaultLibrary (or default-library)");
                     Environment.Exit(1);
                     return;
             }

--- a/src/AbsCli/Commands/ConfigCommand.cs
+++ b/src/AbsCli/Commands/ConfigCommand.cs
@@ -43,7 +43,7 @@ public static class ConfigCommand
 
     private static Command CreateSetCommand()
     {
-        var keyArg = new Argument<string>("key", "Configuration key (server, defaultLibrary). Kebab-case 'default-library' also accepted.");
+        var keyArg = new Argument<string>("key", "Configuration key (server, defaultLibrary)");
         var valueArg = new Argument<string>("value", "Configuration value");
 
         var command = new Command("set", "Set a configuration value")
@@ -53,27 +53,23 @@ public static class ConfigCommand
         };
         command.AddExamples(
             "abs-cli config set server https://abs.example.com",
-            "abs-cli config set defaultLibrary \"lib_abc123\"",
-            "abs-cli config set default-library \"lib_abc123\"   # kebab-case also accepted");
+            "abs-cli config set defaultLibrary \"lib_abc123\"");
 
         command.SetHandler((string key, string value) =>
         {
             var configManager = new ConfigManager();
             var config = configManager.Load();
 
-            // Normalize: lowercase and strip hyphens so 'defaultLibrary',
-            // 'default-library', and 'DefaultLibrary' all match the same key.
-            var normalized = key.ToLowerInvariant().Replace("-", "");
-            switch (normalized)
+            switch (key)
             {
                 case "server":
                     config.Server = value;
                     break;
-                case "defaultlibrary":
+                case "defaultLibrary":
                     config.DefaultLibrary = value;
                     break;
                 default:
-                    ConsoleOutput.WriteError($"Unknown config key: '{key}'. Valid keys: server, defaultLibrary (or default-library)");
+                    ConsoleOutput.WriteError($"Unknown config key: '{key}'. Valid keys: server, defaultLibrary");
                     Environment.Exit(1);
                     return;
             }

--- a/src/AbsCli/Commands/ItemsCommand.cs
+++ b/src/AbsCli/Commands/ItemsCommand.cs
@@ -26,11 +26,11 @@ public static class ItemsCommand
         var filterOption = new Option<string?>("--filter", "Filter expression (e.g. 'genres=Sci Fi')");
         var sortOption = new Option<string?>("--sort", "Sort field (e.g. 'media.metadata.title')");
         var descOption = new Option<bool>("--desc", "Sort descending");
-        var limitOption = new Option<int?>("--limit", "Results per page");
+        var limitOption = new Option<int>("--limit", () => 50, "Results per page (default 50, pass higher value to retrieve more)");
         var pageOption = new Option<int?>("--page", "Page number (0-indexed)");
 
         var command = new Command("list",
-            "List library items with optional filtering, sorting, and pagination")
+            "List library items with optional filtering, sorting, and pagination (defaults to 50 results)")
         {
             libraryOption, filterOption, sortOption, descOption, limitOption, pageOption
         };
@@ -55,7 +55,7 @@ public static class ItemsCommand
             "abs-cli items list | jq '.results[] | select(.media.metadata.isbn == null)'");
 
         command.SetHandler(async (string? library, string? filter, string? sort,
-            bool desc, int? limit, int? page) =>
+            bool desc, int limit, int? page) =>
         {
             var (client, config) = CommandHelper.BuildClient(libraryOverride: library);
             var libraryId = CommandHelper.RequireLibrary(config);
@@ -90,10 +90,10 @@ public static class ItemsCommand
     {
         var queryOption = new Option<string>("--query", "Search text") { IsRequired = true };
         var libraryOption = new Option<string?>("--library", "Library ID or name");
-        var limitOption = new Option<int?>("--limit", "Max results");
+        var limitOption = new Option<int>("--limit", () => 50, "Max results (default 50, pass higher value to retrieve more)");
 
         var command = new Command("search",
-            "Search items in a library (substring match, case-insensitive, searches title/subtitle/ASIN/ISBN)")
+            "Search items in a library (substring match, case-insensitive, searches title/subtitle/ASIN/ISBN, defaults to 50 results)")
         {
             queryOption, libraryOption, limitOption
         };
@@ -101,7 +101,7 @@ public static class ItemsCommand
             "abs-cli items search --query \"Mistborn\"",
             "abs-cli items search --query \"978-0\" --limit 20");
 
-        command.SetHandler(async (string query, string? library, int? limit) =>
+        command.SetHandler(async (string query, string? library, int limit) =>
         {
             var (client, config) = CommandHelper.BuildClient(libraryOverride: library);
             var libraryId = CommandHelper.RequireLibrary(config);

--- a/src/AbsCli/Commands/ItemsCommand.cs
+++ b/src/AbsCli/Commands/ItemsCommand.cs
@@ -16,6 +16,7 @@ public static class ItemsCommand
         command.AddCommand(CreateUpdateCommand());
         command.AddCommand(CreateBatchUpdateCommand());
         command.AddCommand(CreateBatchGetCommand());
+        command.AddCommand(CreateScanCommand());
         return command;
     }
 
@@ -194,6 +195,23 @@ public static class ItemsCommand
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.BatchGetResponse);
         }, inputOption, stdinOption);
 
+        return command;
+    }
+
+    private static Command CreateScanCommand()
+    {
+        var idOption = new Option<string>("--id", "Item ID") { IsRequired = true };
+        var command = new Command("scan", "Scan a single library item (admin-only, sync)") { idOption };
+        command.AddExamples(
+            "abs-cli items scan --id \"li_abc123\"",
+            "abs-cli items scan --id \"li_abc123\" | jq '.result'");
+        command.SetHandler(async (string id) =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new ItemsService(client);
+            var result = await service.ScanAsync(id);
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.ScanResult);
+        }, idOption);
         return command;
     }
 }

--- a/src/AbsCli/Commands/LibrariesCommand.cs
+++ b/src/AbsCli/Commands/LibrariesCommand.cs
@@ -12,6 +12,7 @@ public static class LibrariesCommand
         var command = new Command("libraries", "Manage libraries");
         command.AddCommand(CreateListCommand());
         command.AddCommand(CreateGetCommand());
+        command.AddCommand(CreateScanCommand());
         return command;
     }
 
@@ -55,6 +56,25 @@ public static class LibrariesCommand
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.Library);
         }, idOption, serverOption, tokenOption);
 
+        return command;
+    }
+
+    private static Command CreateScanCommand()
+    {
+        var idOption = new Option<string?>("--id", "Library ID (or default from config)");
+        var forceOption = new Option<bool>("--force", "Force full rescan");
+        var command = new Command("scan", "Trigger a library scan (admin-only, async)") { idOption, forceOption };
+        command.AddExamples(
+            "abs-cli libraries scan",
+            "abs-cli libraries scan --force",
+            "abs-cli libraries scan --id \"lib_abc123\"");
+        command.SetHandler(async (string? id, bool force) =>
+        {
+            var (client, config) = CommandHelper.BuildClient(libraryOverride: id);
+            var libraryId = CommandHelper.RequireLibrary(config);
+            var service = new LibrariesService(client);
+            await service.ScanAsync(libraryId, force);
+        }, idOption, forceOption);
         return command;
     }
 }

--- a/src/AbsCli/Commands/LoginCommand.cs
+++ b/src/AbsCli/Commands/LoginCommand.cs
@@ -57,6 +57,11 @@ public static class LoginCommand
                 var loginResponse = await client.LoginAsync(username, password);
 
                 var config = configManager.Load();
+                // Server changed — drop the previous defaultLibrary so we don't
+                // carry a stale ID that doesn't exist on the new server.
+                var serverChanged = !string.Equals(config.Server, server, StringComparison.Ordinal);
+                if (serverChanged)
+                    config.DefaultLibrary = null;
                 config.Server = server;
                 config.AccessToken = loginResponse.User.AccessToken;
                 config.RefreshToken = loginResponse.User.RefreshToken;

--- a/src/AbsCli/Commands/MetadataCommand.cs
+++ b/src/AbsCli/Commands/MetadataCommand.cs
@@ -1,0 +1,78 @@
+using System.CommandLine;
+using AbsCli.Models;
+using AbsCli.Output;
+using AbsCli.Services;
+
+namespace AbsCli.Commands;
+
+public static class MetadataCommand
+{
+    public static Command Create()
+    {
+        var command = new Command("metadata", "Search metadata providers");
+        command.AddCommand(CreateSearchCommand());
+        command.AddCommand(CreateProvidersCommand());
+        command.AddCommand(CreateCoversCommand());
+        return command;
+    }
+
+    private static Command CreateSearchCommand()
+    {
+        var providerOption = new Option<string>("--provider", "Metadata provider (e.g. audible)") { IsRequired = true };
+        var titleOption = new Option<string>("--title", "Book title to search") { IsRequired = true };
+        var authorOption = new Option<string?>("--author", "Author name to narrow results");
+        var command = new Command("search", "Search for book metadata from a provider")
+        {
+            providerOption, titleOption, authorOption
+        };
+        command.AddExamples(
+            "abs-cli metadata search --provider audible --title \"The Way of Kings\"",
+            "abs-cli metadata search --provider audible --title \"Mistborn\" --author \"Brandon Sanderson\"");
+        command.SetHandler(async (string provider, string title, string? author) =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new MetadataService(client);
+            var result = await service.SearchAsync(provider, title, author);
+            ConsoleOutput.WriteRawJson(result);
+        }, providerOption, titleOption, authorOption);
+        return command;
+    }
+
+    private static Command CreateProvidersCommand()
+    {
+        var command = new Command("providers", "List available metadata providers");
+        command.AddExamples(
+            "abs-cli metadata providers",
+            "abs-cli metadata providers | jq '.providers.books[].value'");
+        command.SetHandler(async () =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new MetadataService(client);
+            var result = await service.ListProvidersAsync();
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.MetadataProvidersResponse);
+        });
+        return command;
+    }
+
+    private static Command CreateCoversCommand()
+    {
+        var providerOption = new Option<string>("--provider", "Cover provider") { IsRequired = true };
+        var titleOption = new Option<string>("--title", "Book title to search") { IsRequired = true };
+        var authorOption = new Option<string?>("--author", "Author name to narrow results");
+        var command = new Command("covers", "Search for book cover images")
+        {
+            providerOption, titleOption, authorOption
+        };
+        command.AddExamples(
+            "abs-cli metadata covers --provider audible --title \"The Way of Kings\"",
+            "abs-cli metadata covers --provider audible --title \"Mistborn\" --author \"Brandon Sanderson\"");
+        command.SetHandler(async (string provider, string title, string? author) =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new MetadataService(client);
+            var result = await service.SearchCoversAsync(provider, title, author);
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.CoverSearchResponse);
+        }, providerOption, titleOption, authorOption);
+        return command;
+    }
+}

--- a/src/AbsCli/Commands/SearchCommand.cs
+++ b/src/AbsCli/Commands/SearchCommand.cs
@@ -11,9 +11,9 @@ public static class SearchCommand
     {
         var queryOption = new Option<string>("--query", "Search text") { IsRequired = true };
         var libraryOption = new Option<string?>("--library", "Library ID or name");
-        var limitOption = new Option<int?>("--limit", "Max results");
+        var limitOption = new Option<int>("--limit", () => 50, "Max results (default 50, pass higher value to retrieve more)");
 
-        var command = new Command("search", "Search across a library")
+        var command = new Command("search", "Search across a library (defaults to 50 results)")
         {
             queryOption, libraryOption, limitOption
         };
@@ -36,7 +36,7 @@ public static class SearchCommand
             "abs-cli search --query \"978-0\" --limit 20    # search by ISBN prefix",
             "abs-cli search --query \"Fantasy\" | jq '.book[].libraryItem.media.metadata.title'");
 
-        command.SetHandler(async (string query, string? library, int? limit) =>
+        command.SetHandler(async (string query, string? library, int limit) =>
         {
             var (client, config) = CommandHelper.BuildClient(libraryOverride: library);
             var libraryId = CommandHelper.RequireLibrary(config);

--- a/src/AbsCli/Commands/SelfTestCommand.cs
+++ b/src/AbsCli/Commands/SelfTestCommand.cs
@@ -215,6 +215,108 @@ public static class SelfTestCommand
                 Assert(back.Authors[0].Name == "Test", $"name: {back.Authors[0].Name}");
             });
 
+            Check("BackupItem round-trip", () =>
+            {
+                var obj = new BackupItem
+                {
+                    Id = "2024-03-15T1430",
+                    Filename = "2024-03-15T1430.audiobookshelf",
+                    FileSize = 12345,
+                    CreatedAt = 1710510600000,
+                    ServerVersion = "2.33.1"
+                };
+                var json = JsonSerializer.Serialize(obj, AppJsonContext.Default.BackupItem);
+                var back = JsonSerializer.Deserialize(json, AppJsonContext.Default.BackupItem)!;
+                Assert(back.Id == "2024-03-15T1430", $"id: {back.Id}");
+                Assert(back.FileSize == 12345, $"fileSize: {back.FileSize}");
+                Assert(back.ServerVersion == "2.33.1", $"serverVersion: {back.ServerVersion}");
+            });
+
+            Check("BackupListResponse round-trip", () =>
+            {
+                var obj = new BackupListResponse
+                {
+                    Backups = new List<BackupItem>
+                    {
+                        new() { Id = "bk_1", Filename = "test.audiobookshelf" }
+                    },
+                    BackupLocation = "/backups",
+                    BackupPathEnvSet = false
+                };
+                var json = JsonSerializer.Serialize(obj, AppJsonContext.Default.BackupListResponse);
+                var back = JsonSerializer.Deserialize(json, AppJsonContext.Default.BackupListResponse)!;
+                Assert(back.Backups.Count == 1, $"count: {back.Backups.Count}");
+                Assert(back.BackupLocation == "/backups", $"location: {back.BackupLocation}");
+            });
+
+            Check("ScanResult round-trip", () =>
+            {
+                var obj = new ScanResult { Result = "UPDATED" };
+                var json = JsonSerializer.Serialize(obj, AppJsonContext.Default.ScanResult);
+                var back = JsonSerializer.Deserialize(json, AppJsonContext.Default.ScanResult)!;
+                Assert(back.Result == "UPDATED", $"result: {back.Result}");
+            });
+
+            Check("TaskItem round-trip", () =>
+            {
+                var json = """{"id":"task_1","action":"library-scan","title":"Scanning","isFailed":false,"isFinished":true,"startedAt":1000,"finishedAt":2000,"data":{"added":5}}""";
+                var obj = JsonSerializer.Deserialize(json, AppJsonContext.Default.TaskItem)!;
+                Assert(obj.Id == "task_1", $"id: {obj.Id}");
+                Assert(obj.Action == "library-scan", $"action: {obj.Action}");
+                Assert(obj.IsFinished, "isFinished should be true");
+                Assert(obj.Data.HasValue, "data should have value");
+                var roundTrip = JsonSerializer.Serialize(obj, AppJsonContext.Default.TaskItem);
+                Assert(roundTrip.Contains("\"action\""), "action key missing in output");
+            });
+
+            Check("TaskListResponse round-trip", () =>
+            {
+                var obj = new TaskListResponse
+                {
+                    Tasks = new List<TaskItem> { new() { Id = "t_1", Action = "scan" } }
+                };
+                var json = JsonSerializer.Serialize(obj, AppJsonContext.Default.TaskListResponse);
+                var back = JsonSerializer.Deserialize(json, AppJsonContext.Default.TaskListResponse)!;
+                Assert(back.Tasks.Count == 1, $"count: {back.Tasks.Count}");
+                Assert(back.Tasks[0].Action == "scan", $"action: {back.Tasks[0].Action}");
+            });
+
+            Check("MetadataProvidersResponse round-trip", () =>
+            {
+                var obj = new MetadataProvidersResponse
+                {
+                    Providers = new MetadataProviderGroups
+                    {
+                        Books = new List<ProviderEntry>
+                        {
+                            new() { Value = "google", Text = "Google Books" }
+                        },
+                        BooksCovers = new List<ProviderEntry>
+                        {
+                            new() { Value = "best", Text = "Best" }
+                        },
+                        Podcasts = new List<ProviderEntry>()
+                    }
+                };
+                var json = JsonSerializer.Serialize(obj, AppJsonContext.Default.MetadataProvidersResponse);
+                var back = JsonSerializer.Deserialize(json, AppJsonContext.Default.MetadataProvidersResponse)!;
+                Assert(back.Providers.Books.Count == 1, $"books count: {back.Providers.Books.Count}");
+                Assert(back.Providers.Books[0].Value == "google", $"value: {back.Providers.Books[0].Value}");
+                Assert(back.Providers.Books[0].Text == "Google Books", $"text: {back.Providers.Books[0].Text}");
+            });
+
+            Check("CoverSearchResponse round-trip", () =>
+            {
+                var obj = new CoverSearchResponse
+                {
+                    Results = new List<string> { "https://example.com/cover1.jpg", "https://example.com/cover2.jpg" }
+                };
+                var json = JsonSerializer.Serialize(obj, AppJsonContext.Default.CoverSearchResponse);
+                var back = JsonSerializer.Deserialize(json, AppJsonContext.Default.CoverSearchResponse)!;
+                Assert(back.Results.Count == 2, $"count: {back.Results.Count}");
+                Assert(back.Results[0] == "https://example.com/cover1.jpg", $"url: {back.Results[0]}");
+            });
+
             Console.Error.WriteLine("");
             Console.Error.WriteLine("=== Configuration ===");
 

--- a/src/AbsCli/Commands/SelfTestCommand.cs
+++ b/src/AbsCli/Commands/SelfTestCommand.cs
@@ -317,6 +317,19 @@ public static class SelfTestCommand
                 Assert(back.Results[0] == "https://example.com/cover1.jpg", $"url: {back.Results[0]}");
             });
 
+            Check("UploadManifestEntry list round-trip", () =>
+            {
+                var json = """[{"src":"Part 1-2/foo.mp3","as":"001-foo.mp3"},{"src":"Part 3/foo.mp3","as":"002-foo.mp3"}]""";
+                var entries = JsonSerializer.Deserialize(json, AppJsonContext.Default.ListUploadManifestEntry)!;
+                Assert(entries.Count == 2, $"count: {entries.Count}");
+                Assert(entries[0].Src == "Part 1-2/foo.mp3", $"src: {entries[0].Src}");
+                Assert(entries[0].TargetName == "001-foo.mp3", $"as: {entries[0].TargetName}");
+                Assert(entries[1].TargetName == "002-foo.mp3", $"as: {entries[1].TargetName}");
+                var roundTrip = JsonSerializer.Serialize(entries, AppJsonContext.Default.ListUploadManifestEntry);
+                Assert(roundTrip.Contains("\"src\""), "src key missing in output");
+                Assert(roundTrip.Contains("\"as\""), "as key missing in output");
+            });
+
             Console.Error.WriteLine("");
             Console.Error.WriteLine("=== Configuration ===");
 

--- a/src/AbsCli/Commands/SeriesCommand.cs
+++ b/src/AbsCli/Commands/SeriesCommand.cs
@@ -18,18 +18,18 @@ public static class SeriesCommand
     private static Command CreateListCommand()
     {
         var libraryOption = new Option<string?>("--library", "Library ID or name");
-        var limitOption = new Option<int?>("--limit", "Results per page");
+        var limitOption = new Option<int>("--limit", () => 50, "Results per page (default 50, pass higher value to retrieve more)");
         var pageOption = new Option<int?>("--page", "Page number (0-indexed)");
 
         var command = new Command("list",
-            "List series in a library (--limit required to return results)")
+            "List series in a library (defaults to 50 results)")
         { libraryOption, limitOption, pageOption };
         command.AddExamples(
-            "abs-cli series list --limit 50",
+            "abs-cli series list",
             "abs-cli series list --limit 10 --page 0",
             "abs-cli series list --limit 100 | jq '.results[].name'");
 
-        command.SetHandler(async (string? library, int? limit, int? page) =>
+        command.SetHandler(async (string? library, int limit, int? page) =>
         {
             var (client, config) = CommandHelper.BuildClient(libraryOverride: library);
             var libraryId = CommandHelper.RequireLibrary(config);

--- a/src/AbsCli/Commands/TasksCommand.cs
+++ b/src/AbsCli/Commands/TasksCommand.cs
@@ -1,0 +1,33 @@
+using System.CommandLine;
+using AbsCli.Models;
+using AbsCli.Output;
+using AbsCli.Services;
+
+namespace AbsCli.Commands;
+
+public static class TasksCommand
+{
+    public static Command Create()
+    {
+        var command = new Command("tasks", "Manage server tasks");
+        command.AddCommand(CreateListCommand());
+        return command;
+    }
+
+    private static Command CreateListCommand()
+    {
+        var command = new Command("list", "List active and recent tasks");
+        command.AddExamples(
+            "abs-cli tasks list",
+            "abs-cli tasks list | jq '.tasks[] | select(.isFinished==false)'",
+            "abs-cli tasks list | jq '.tasks[] | {action, title, isFinished}'");
+        command.SetHandler(async () =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new TasksService(client);
+            var result = await service.ListAsync();
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.TaskListResponse);
+        });
+        return command;
+    }
+}

--- a/src/AbsCli/Commands/UploadCommand.cs
+++ b/src/AbsCli/Commands/UploadCommand.cs
@@ -1,0 +1,76 @@
+using System.CommandLine;
+using AbsCli.Models;
+using AbsCli.Output;
+using AbsCli.Services;
+
+namespace AbsCli.Commands;
+
+public static class UploadCommand
+{
+    public static Command Create()
+    {
+        var libraryOption = new Option<string?>("--library", "Library ID or name");
+        var folderOption = new Option<string?>("--folder", "Folder ID (auto-resolved if library has one folder)");
+        var titleOption = new Option<string>("--title", "Book title") { IsRequired = true };
+        var authorOption = new Option<string?>("--author", "Book author");
+        var seriesOption = new Option<string?>("--series", "Series name");
+        var sequenceOption = new Option<int?>("--sequence", "Series sequence number (requires --series)");
+        var waitOption = new Option<bool>("--wait", "Poll until the uploaded item appears in the library");
+        var filesOption = new Option<string[]>("--files", "File paths to upload") { IsRequired = true, AllowMultipleArgumentsPerToken = true };
+        var command = new Command("upload", "Upload audiobook files to a library")
+        {
+            libraryOption, folderOption, titleOption, authorOption,
+            seriesOption, sequenceOption, waitOption, filesOption
+        };
+        command.AddHelpSection("Folder ID",
+            "If the library has a single folder, it is auto-resolved.",
+            "Otherwise pass --folder <id>.",
+            "Run 'abs-cli libraries get --id <id>' to see folder IDs.");
+        command.AddHelpSection("Folder structure created",
+            "Author/Title            — when --author is given",
+            "Author/Series/Title     — when --author and --series are given",
+            "Title                   — when no --author is given");
+        command.AddExamples(
+            "abs-cli upload --title \"The Hobbit\" --author \"J.R.R. Tolkien\" --files hobbit.m4b",
+            "abs-cli upload --title \"The Final Empire\" --author \"Brandon Sanderson\" --series \"Mistborn\" --sequence 1 --files part1.mp3 part2.mp3",
+            "abs-cli upload --title \"My Audiobook\" --files ch1.mp3 ch2.mp3 ch3.mp3 --wait");
+        command.SetHandler(async (string? library, string? folder, string title,
+            string? author, string? series, int? sequence, bool wait, string[] files) =>
+        {
+            if (sequence.HasValue && series == null)
+            {
+                ConsoleOutput.WriteError("--sequence requires --series.");
+                Environment.Exit(1);
+                return;
+            }
+            foreach (var file in files)
+            {
+                if (!File.Exists(file))
+                {
+                    ConsoleOutput.WriteError($"File not found: {file}");
+                    Environment.Exit(1);
+                    return;
+                }
+            }
+            var (client, config) = CommandHelper.BuildClient(libraryOverride: library);
+            var libraryId = CommandHelper.RequireLibrary(config);
+            var service = new UploadService(client);
+            var folderId = folder ?? await service.ResolveFolderIdAsync(libraryId);
+            await service.UploadAsync(libraryId, folderId, title, author, series, sequence, files);
+            if (wait)
+            {
+                var searchTitle = sequence.HasValue ? $"{sequence.Value}. - {title}" : title;
+                var item = await service.WaitForItemAsync(libraryId, searchTitle);
+                if (item == null)
+                {
+                    ConsoleOutput.WriteError("Timed out waiting for item to appear in library.");
+                    Environment.Exit(1);
+                    return;
+                }
+                ConsoleOutput.WriteJson(item, AppJsonContext.Default.LibraryItemMinified);
+            }
+        }, libraryOption, folderOption, titleOption, authorOption,
+            seriesOption, sequenceOption, waitOption, filesOption);
+        return command;
+    }
+}

--- a/src/AbsCli/Commands/UploadCommand.cs
+++ b/src/AbsCli/Commands/UploadCommand.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.Text.Json;
 using AbsCli.Models;
 using AbsCli.Output;
 using AbsCli.Services;
@@ -16,11 +17,16 @@ public static class UploadCommand
         var seriesOption = new Option<string?>("--series", "Series name");
         var sequenceOption = new Option<int?>("--sequence", "Series sequence number (requires --series)");
         var waitOption = new Option<bool>("--wait", "Poll until the uploaded item appears in the library");
-        var filesOption = new Option<string[]>("--files", "File paths to upload") { IsRequired = true, AllowMultipleArgumentsPerToken = true };
+        var filesOption = new Option<string[]>("--files", "File paths to upload (mutually exclusive with --files-manifest)") { AllowMultipleArgumentsPerToken = true };
+        var prefixSourceDirOption = new Option<bool>("--prefix-source-dir",
+            "Prefix each upload filename with its parent directory name (avoids collisions when files from multiple source dirs share basenames)");
+        var manifestOption = new Option<string?>("--files-manifest",
+            "Path to JSON manifest mapping {src, as} pairs (or '-' for stdin). Mutually exclusive with --files and --prefix-source-dir.");
         var command = new Command("upload", "Upload audiobook files to a library")
         {
             libraryOption, folderOption, titleOption, authorOption,
-            seriesOption, sequenceOption, waitOption, filesOption
+            seriesOption, sequenceOption, waitOption, filesOption,
+            prefixSourceDirOption, manifestOption
         };
         command.AddHelpSection("Folder ID",
             "If the library has a single folder, it is auto-resolved.",
@@ -31,33 +37,78 @@ public static class UploadCommand
             "Author/Title                       — when --author is given",
             "Author/Series/Title                — when --author and --series are given",
             "Author/Series/{N}. - {Title}       — when --sequence N is also given (requires --series)");
+        command.AddHelpSection("Filename collisions",
+            "ABS silently overwrites files with the same name in one upload — the CLI",
+            "refuses to do this. By default duplicate basenames in --files cause an error.",
+            "",
+            "--prefix-source-dir   Prepend each file's parent directory name to the",
+            "                      uploaded filename. Good for multi-disc / multi-part",
+            "                      audiobooks where parent dir names sort correctly",
+            "                      (e.g. \"Part 1-2\" before \"Part 3\").",
+            "",
+            "--files-manifest <p>  JSON file (or '-' for stdin) mapping each source path",
+            "                      to the name ABS should save it as. Use when you need",
+            "                      explicit per-file naming. Schema: [{\"src\":\"path\",\"as\":\"name\"}, ...]");
         command.AddExamples(
             "abs-cli upload --title \"The Hobbit\" --author \"J.R.R. Tolkien\" --files hobbit.m4b",
             "abs-cli upload --title \"The Final Empire\" --author \"Brandon Sanderson\" --series \"Mistborn\" --sequence 1 --files part1.mp3 part2.mp3",
-            "abs-cli upload --title \"My Audiobook\" --files ch1.mp3 ch2.mp3 ch3.mp3 --wait");
-        command.SetHandler(async (string? library, string? folder, string title,
-            string? author, string? series, int? sequence, bool wait, string[] files) =>
+            "abs-cli upload --title \"Morning Star\" --author \"Pierce Brown\" --series \"Red Rising\" --sequence 3 --prefix-source-dir --files \"Part 1-2\"/*.mp3 \"Part 3\"/*.mp3",
+            "abs-cli upload --title \"My Audiobook\" --files-manifest manifest.json",
+            "cat manifest.json | abs-cli upload --title \"My Audiobook\" --files-manifest -");
+        command.SetHandler(async (context) =>
         {
+            var library = context.ParseResult.GetValueForOption(libraryOption);
+            var folder = context.ParseResult.GetValueForOption(folderOption);
+            var title = context.ParseResult.GetValueForOption(titleOption)!;
+            var author = context.ParseResult.GetValueForOption(authorOption);
+            var series = context.ParseResult.GetValueForOption(seriesOption);
+            var sequence = context.ParseResult.GetValueForOption(sequenceOption);
+            var wait = context.ParseResult.GetValueForOption(waitOption);
+            var files = context.ParseResult.GetValueForOption(filesOption) ?? Array.Empty<string>();
+            var prefixSourceDir = context.ParseResult.GetValueForOption(prefixSourceDirOption);
+            var manifestPath = context.ParseResult.GetValueForOption(manifestOption);
             if (sequence.HasValue && series == null)
             {
                 ConsoleOutput.WriteError("--sequence requires --series.");
                 Environment.Exit(1);
                 return;
             }
-            foreach (var file in files)
+            if (manifestPath != null && files.Length > 0)
             {
-                if (!File.Exists(file))
+                ConsoleOutput.WriteError("--files and --files-manifest are mutually exclusive.");
+                Environment.Exit(1);
+                return;
+            }
+            if (manifestPath != null && prefixSourceDir)
+            {
+                ConsoleOutput.WriteError("--prefix-source-dir and --files-manifest are mutually exclusive.");
+                Environment.Exit(1);
+                return;
+            }
+            if (manifestPath == null && files.Length == 0)
+            {
+                ConsoleOutput.WriteError("Pass --files <path>... or --files-manifest <path|->.");
+                Environment.Exit(1);
+                return;
+            }
+            var uploadList = manifestPath != null
+                ? await BuildFromManifestAsync(manifestPath)
+                : BuildFromFiles(files, prefixSourceDir);
+            foreach (var entry in uploadList)
+            {
+                if (!File.Exists(entry.LocalPath))
                 {
-                    ConsoleOutput.WriteError($"File not found: {file}");
+                    ConsoleOutput.WriteError($"File not found: {entry.LocalPath}");
                     Environment.Exit(1);
                     return;
                 }
             }
+            CheckForDuplicates(uploadList);
             var (client, config) = CommandHelper.BuildClient(libraryOverride: library);
             var libraryId = CommandHelper.RequireLibrary(config);
             var service = new UploadService(client);
             var folderId = folder ?? await service.ResolveFolderIdAsync(libraryId);
-            await service.UploadAsync(libraryId, folderId, title, author, series, sequence, files);
+            await service.UploadAsync(libraryId, folderId, title, author, series, sequence, uploadList);
             if (wait)
             {
                 var searchTitle = sequence.HasValue ? $"{sequence.Value}. - {title}" : title;
@@ -70,8 +121,95 @@ public static class UploadCommand
                 }
                 ConsoleOutput.WriteJson(item, AppJsonContext.Default.LibraryItemMinified);
             }
-        }, libraryOption, folderOption, titleOption, authorOption,
-            seriesOption, sequenceOption, waitOption, filesOption);
+        });
         return command;
+    }
+
+    private static List<(string LocalPath, string UploadName)> BuildFromFiles(string[] files, bool prefixSourceDir)
+    {
+        var result = new List<(string LocalPath, string UploadName)>(files.Length);
+        foreach (var file in files)
+        {
+            var basename = Path.GetFileName(file);
+            string uploadName;
+            if (prefixSourceDir)
+            {
+                var parentDir = Path.GetFileName(Path.GetDirectoryName(Path.GetFullPath(file)) ?? "");
+                uploadName = string.IsNullOrEmpty(parentDir) ? basename : $"{parentDir} - {basename}";
+            }
+            else
+            {
+                uploadName = basename;
+            }
+            result.Add((file, uploadName));
+        }
+        return result;
+    }
+
+    private static async Task<List<(string LocalPath, string UploadName)>> BuildFromManifestAsync(string manifestPath)
+    {
+        string json;
+        if (manifestPath == "-")
+        {
+            json = await Console.In.ReadToEndAsync();
+        }
+        else
+        {
+            if (!File.Exists(manifestPath))
+            {
+                ConsoleOutput.WriteError($"Manifest file not found: {manifestPath}");
+                Environment.Exit(1);
+            }
+            json = await File.ReadAllTextAsync(manifestPath);
+        }
+        List<UploadManifestEntry>? entries = null;
+        try
+        {
+            entries = JsonSerializer.Deserialize(json, AppJsonContext.Default.ListUploadManifestEntry);
+        }
+        catch (JsonException ex)
+        {
+            ConsoleOutput.WriteError($"Manifest is not valid JSON: {ex.Message}");
+            Environment.Exit(1);
+        }
+        if (entries == null || entries.Count == 0)
+        {
+            ConsoleOutput.WriteError("Manifest is empty or null. Provide a non-empty array of {src, as} entries.");
+            Environment.Exit(1);
+        }
+        var result = new List<(string LocalPath, string UploadName)>(entries!.Count);
+        foreach (var entry in entries)
+        {
+            if (string.IsNullOrWhiteSpace(entry.Src) || string.IsNullOrWhiteSpace(entry.TargetName))
+            {
+                ConsoleOutput.WriteError("Manifest entry missing 'src' or 'as'. Each entry must have both.");
+                Environment.Exit(1);
+            }
+            result.Add((entry.Src, entry.TargetName));
+        }
+        return result;
+    }
+
+    private static void CheckForDuplicates(IReadOnlyList<(string LocalPath, string UploadName)> uploadList)
+    {
+        var groups = uploadList
+            .GroupBy(e => e.UploadName, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1)
+            .ToList();
+        if (groups.Count == 0) return;
+        var lines = new List<string> { "Duplicate filenames in upload — ABS would silently overwrite:" };
+        foreach (var group in groups)
+        {
+            lines.Add($"  \"{group.Key}\" maps to {group.Count()} source files:");
+            foreach (var entry in group)
+            {
+                lines.Add($"    {entry.LocalPath}");
+            }
+        }
+        lines.Add("");
+        lines.Add("Pass --prefix-source-dir to prefix each upload filename with its parent");
+        lines.Add("directory name, or --files-manifest <path> for explicit per-file naming.");
+        ConsoleOutput.WriteError(string.Join("\n", lines));
+        Environment.Exit(1);
     }
 }

--- a/src/AbsCli/Commands/UploadCommand.cs
+++ b/src/AbsCli/Commands/UploadCommand.cs
@@ -27,9 +27,10 @@ public static class UploadCommand
             "Otherwise pass --folder <id>.",
             "Run 'abs-cli libraries get --id <id>' to see folder IDs.");
         command.AddHelpSection("Folder structure created",
-            "Author/Title            — when --author is given",
-            "Author/Series/Title     — when --author and --series are given",
-            "Title                   — when no --author is given");
+            "Title                              — when no --author is given",
+            "Author/Title                       — when --author is given",
+            "Author/Series/Title                — when --author and --series are given",
+            "Author/Series/{N}. - {Title}       — when --sequence N is also given (requires --series)");
         command.AddExamples(
             "abs-cli upload --title \"The Hobbit\" --author \"J.R.R. Tolkien\" --files hobbit.m4b",
             "abs-cli upload --title \"The Final Empire\" --author \"Brandon Sanderson\" --series \"Mistborn\" --sequence 1 --files part1.mp3 part2.mp3",

--- a/src/AbsCli/Commands/UploadCommand.cs
+++ b/src/AbsCli/Commands/UploadCommand.cs
@@ -16,7 +16,8 @@ public static class UploadCommand
         var authorOption = new Option<string?>("--author", "Book author");
         var seriesOption = new Option<string?>("--series", "Series name");
         var sequenceOption = new Option<int?>("--sequence", "Series sequence number (requires --series)");
-        var waitOption = new Option<bool>("--wait", "Poll until the uploaded item appears in the library");
+        var waitOption = new Option<bool>("--wait", "Poll until the uploaded item appears in the library (default 5min timeout)");
+        var waitTimeoutOption = new Option<int>("--wait-timeout", () => 300, "Seconds to wait for the item to appear (with --wait). Defaults to 300.");
         var filesOption = new Option<string[]>("--files", "File paths to upload (mutually exclusive with --files-manifest)") { AllowMultipleArgumentsPerToken = true };
         var prefixSourceDirOption = new Option<bool>("--prefix-source-dir",
             "Prefix each upload filename with its parent directory name (avoids collisions when files from multiple source dirs share basenames)");
@@ -25,7 +26,7 @@ public static class UploadCommand
         var command = new Command("upload", "Upload audiobook files to a library")
         {
             libraryOption, folderOption, titleOption, authorOption,
-            seriesOption, sequenceOption, waitOption, filesOption,
+            seriesOption, sequenceOption, waitOption, waitTimeoutOption, filesOption,
             prefixSourceDirOption, manifestOption
         };
         command.AddHelpSection("Folder ID",
@@ -64,6 +65,7 @@ public static class UploadCommand
             var series = context.ParseResult.GetValueForOption(seriesOption);
             var sequence = context.ParseResult.GetValueForOption(sequenceOption);
             var wait = context.ParseResult.GetValueForOption(waitOption);
+            var waitTimeout = context.ParseResult.GetValueForOption(waitTimeoutOption);
             var files = context.ParseResult.GetValueForOption(filesOption) ?? Array.Empty<string>();
             var prefixSourceDir = context.ParseResult.GetValueForOption(prefixSourceDirOption);
             var manifestPath = context.ParseResult.GetValueForOption(manifestOption);
@@ -112,10 +114,10 @@ public static class UploadCommand
             if (wait)
             {
                 var searchTitle = sequence.HasValue ? $"{sequence.Value}. - {title}" : title;
-                var item = await service.WaitForItemAsync(libraryId, searchTitle);
+                var item = await service.WaitForItemAsync(libraryId, searchTitle, timeoutSeconds: waitTimeout);
                 if (item == null)
                 {
-                    ConsoleOutput.WriteError("Timed out waiting for item to appear in library.");
+                    ConsoleOutput.WriteError($"Timed out after {waitTimeout}s waiting for item to appear in library. The upload may still be processing — check 'abs-cli items search --query <title>' or pass --wait-timeout <seconds> to wait longer.");
                     Environment.Exit(1);
                     return;
                 }

--- a/src/AbsCli/Models/Backup.cs
+++ b/src/AbsCli/Models/Backup.cs
@@ -1,0 +1,35 @@
+using System.Text.Json.Serialization;
+
+namespace AbsCli.Models;
+
+public class BackupItem
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = "";
+    [JsonPropertyName("backupDirPath")]
+    public string? BackupDirPath { get; set; }
+    [JsonPropertyName("datePretty")]
+    public string? DatePretty { get; set; }
+    [JsonPropertyName("fullPath")]
+    public string? FullPath { get; set; }
+    [JsonPropertyName("path")]
+    public string? Path { get; set; }
+    [JsonPropertyName("filename")]
+    public string? Filename { get; set; }
+    [JsonPropertyName("fileSize")]
+    public long? FileSize { get; set; }
+    [JsonPropertyName("createdAt")]
+    public long CreatedAt { get; set; }
+    [JsonPropertyName("serverVersion")]
+    public string? ServerVersion { get; set; }
+}
+
+public class BackupListResponse
+{
+    [JsonPropertyName("backups")]
+    public List<BackupItem> Backups { get; set; } = new();
+    [JsonPropertyName("backupLocation")]
+    public string? BackupLocation { get; set; }
+    [JsonPropertyName("backupPathEnvSet")]
+    public bool? BackupPathEnvSet { get; set; }
+}

--- a/src/AbsCli/Models/JsonContext.cs
+++ b/src/AbsCli/Models/JsonContext.cs
@@ -18,6 +18,8 @@ namespace AbsCli.Models;
 [JsonSerializable(typeof(SeriesItem))]
 [JsonSerializable(typeof(AuthorItem))]
 [JsonSerializable(typeof(AuthorListResponse))]
+[JsonSerializable(typeof(BackupItem))]
+[JsonSerializable(typeof(BackupListResponse))]
 [JsonSourceGenerationOptions(WriteIndented = true)]
 public partial class AppJsonContext : JsonSerializerContext;
 

--- a/src/AbsCli/Models/JsonContext.cs
+++ b/src/AbsCli/Models/JsonContext.cs
@@ -20,6 +20,13 @@ namespace AbsCli.Models;
 [JsonSerializable(typeof(AuthorListResponse))]
 [JsonSerializable(typeof(BackupItem))]
 [JsonSerializable(typeof(BackupListResponse))]
+[JsonSerializable(typeof(ScanResult))]
+[JsonSerializable(typeof(TaskItem))]
+[JsonSerializable(typeof(TaskListResponse))]
+[JsonSerializable(typeof(ProviderEntry))]
+[JsonSerializable(typeof(MetadataProviderGroups))]
+[JsonSerializable(typeof(MetadataProvidersResponse))]
+[JsonSerializable(typeof(CoverSearchResponse))]
 [JsonSourceGenerationOptions(WriteIndented = true)]
 public partial class AppJsonContext : JsonSerializerContext;
 

--- a/src/AbsCli/Models/JsonContext.cs
+++ b/src/AbsCli/Models/JsonContext.cs
@@ -27,6 +27,8 @@ namespace AbsCli.Models;
 [JsonSerializable(typeof(MetadataProviderGroups))]
 [JsonSerializable(typeof(MetadataProvidersResponse))]
 [JsonSerializable(typeof(CoverSearchResponse))]
+[JsonSerializable(typeof(UploadManifestEntry))]
+[JsonSerializable(typeof(List<UploadManifestEntry>))]
 [JsonSourceGenerationOptions(WriteIndented = true)]
 public partial class AppJsonContext : JsonSerializerContext;
 

--- a/src/AbsCli/Models/MetadataProvider.cs
+++ b/src/AbsCli/Models/MetadataProvider.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace AbsCli.Models;
+
+public class ProviderEntry
+{
+    [JsonPropertyName("value")]
+    public string Value { get; set; } = "";
+    [JsonPropertyName("text")]
+    public string Text { get; set; } = "";
+}
+
+public class MetadataProviderGroups
+{
+    [JsonPropertyName("books")]
+    public List<ProviderEntry> Books { get; set; } = new();
+    [JsonPropertyName("booksCovers")]
+    public List<ProviderEntry> BooksCovers { get; set; } = new();
+    [JsonPropertyName("podcasts")]
+    public List<ProviderEntry> Podcasts { get; set; } = new();
+}
+
+public class MetadataProvidersResponse
+{
+    [JsonPropertyName("providers")]
+    public MetadataProviderGroups Providers { get; set; } = new();
+}
+
+public class CoverSearchResponse
+{
+    [JsonPropertyName("results")]
+    public List<string> Results { get; set; } = new();
+}

--- a/src/AbsCli/Models/ScanResult.cs
+++ b/src/AbsCli/Models/ScanResult.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace AbsCli.Models;
+
+public class ScanResult
+{
+    [JsonPropertyName("result")]
+    public string Result { get; set; } = "";
+}

--- a/src/AbsCli/Models/TaskItem.cs
+++ b/src/AbsCli/Models/TaskItem.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AbsCli.Models;
+
+public class TaskItem
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = "";
+    [JsonPropertyName("action")]
+    public string? Action { get; set; }
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+    [JsonPropertyName("isFailed")]
+    public bool IsFailed { get; set; }
+    [JsonPropertyName("isFinished")]
+    public bool IsFinished { get; set; }
+    [JsonPropertyName("showSuccess")]
+    public bool ShowSuccess { get; set; }
+    [JsonPropertyName("startedAt")]
+    public long? StartedAt { get; set; }
+    [JsonPropertyName("finishedAt")]
+    public long? FinishedAt { get; set; }
+    [JsonPropertyName("data")]
+    public JsonElement? Data { get; set; }
+}
+
+public class TaskListResponse
+{
+    [JsonPropertyName("tasks")]
+    public List<TaskItem> Tasks { get; set; } = new();
+}

--- a/src/AbsCli/Models/UploadManifestEntry.cs
+++ b/src/AbsCli/Models/UploadManifestEntry.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace AbsCli.Models;
+
+public class UploadManifestEntry
+{
+    [JsonPropertyName("src")]
+    public string Src { get; set; } = "";
+
+    [JsonPropertyName("as")]
+    public string TargetName { get; set; } = "";
+}

--- a/src/AbsCli/Program.cs
+++ b/src/AbsCli/Program.cs
@@ -13,6 +13,7 @@ rootCommand.AddCommand(SeriesCommand.Create());
 rootCommand.AddCommand(AuthorsCommand.Create());
 rootCommand.AddCommand(SearchCommand.Create());
 rootCommand.AddCommand(BackupCommand.Create());
+rootCommand.AddCommand(UploadCommand.Create());
 rootCommand.AddCommand(SelfTestCommand.Create());
 
 var parser = new CommandLineBuilder(rootCommand)

--- a/src/AbsCli/Program.cs
+++ b/src/AbsCli/Program.cs
@@ -12,6 +12,7 @@ rootCommand.AddCommand(ItemsCommand.Create());
 rootCommand.AddCommand(SeriesCommand.Create());
 rootCommand.AddCommand(AuthorsCommand.Create());
 rootCommand.AddCommand(SearchCommand.Create());
+rootCommand.AddCommand(BackupCommand.Create());
 rootCommand.AddCommand(SelfTestCommand.Create());
 
 var parser = new CommandLineBuilder(rootCommand)

--- a/src/AbsCli/Program.cs
+++ b/src/AbsCli/Program.cs
@@ -14,6 +14,8 @@ rootCommand.AddCommand(AuthorsCommand.Create());
 rootCommand.AddCommand(SearchCommand.Create());
 rootCommand.AddCommand(BackupCommand.Create());
 rootCommand.AddCommand(UploadCommand.Create());
+rootCommand.AddCommand(TasksCommand.Create());
+rootCommand.AddCommand(MetadataCommand.Create());
 rootCommand.AddCommand(SelfTestCommand.Create());
 
 var parser = new CommandLineBuilder(rootCommand)

--- a/src/AbsCli/Services/BackupService.cs
+++ b/src/AbsCli/Services/BackupService.cs
@@ -5,6 +5,11 @@ namespace AbsCli.Services;
 
 public class BackupService
 {
+    // create/apply/download/upload are sync server-side and can take minutes on large
+    // libraries (SQLite dump capped at 2min, zip step uncapped). Override the default
+    // 100s HTTP timeout so the CLI doesn't drop the connection while ABS is still working.
+    private static readonly TimeSpan LongOperationTimeout = TimeSpan.FromMinutes(10);
+
     private readonly AbsApiClient _client;
 
     public BackupService(AbsApiClient client)
@@ -21,17 +26,20 @@ public class BackupService
     public async Task<BackupListResponse> CreateAsync()
     {
         return await _client.PostEmptyAsync(ApiEndpoints.Backups,
-            AppJsonContext.Default.BackupListResponse, "'admin' access");
+            AppJsonContext.Default.BackupListResponse, "'admin' access",
+            timeout: LongOperationTimeout);
     }
 
     public async Task<string> ApplyAsync(string id)
     {
-        return await _client.GetAsync(ApiEndpoints.BackupApply(id), "'admin' access");
+        return await _client.GetAsync(ApiEndpoints.BackupApply(id), "'admin' access",
+            timeout: LongOperationTimeout);
     }
 
     public async Task DownloadAsync(string id, string outputPath)
     {
-        await _client.DownloadFileAsync(ApiEndpoints.BackupDownload(id), outputPath, "'admin' access");
+        await _client.DownloadFileAsync(ApiEndpoints.BackupDownload(id), outputPath, "'admin' access",
+            timeout: LongOperationTimeout);
     }
 
     public async Task<BackupListResponse> DeleteAsync(string id)
@@ -47,7 +55,8 @@ public class BackupService
         var fileContent = new ByteArrayContent(fileBytes);
         fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
         content.Add(fileContent, "file", System.IO.Path.GetFileName(filePath));
-        await _client.PostMultipartAsync(ApiEndpoints.BackupUpload, content, "'admin' access");
+        await _client.PostMultipartAsync(ApiEndpoints.BackupUpload, content, "'admin' access",
+            timeout: LongOperationTimeout);
         return await ListAsync();
     }
 }

--- a/src/AbsCli/Services/BackupService.cs
+++ b/src/AbsCli/Services/BackupService.cs
@@ -1,0 +1,53 @@
+using AbsCli.Api;
+using AbsCli.Models;
+
+namespace AbsCli.Services;
+
+public class BackupService
+{
+    private readonly AbsApiClient _client;
+
+    public BackupService(AbsApiClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<BackupListResponse> ListAsync()
+    {
+        return await _client.GetAsync(ApiEndpoints.Backups,
+            AppJsonContext.Default.BackupListResponse, "'admin' access");
+    }
+
+    public async Task<BackupListResponse> CreateAsync()
+    {
+        return await _client.PostEmptyAsync(ApiEndpoints.Backups,
+            AppJsonContext.Default.BackupListResponse, "'admin' access");
+    }
+
+    public async Task<string> ApplyAsync(string id)
+    {
+        return await _client.GetAsync(ApiEndpoints.BackupApply(id), "'admin' access");
+    }
+
+    public async Task DownloadAsync(string id, string outputPath)
+    {
+        await _client.DownloadFileAsync(ApiEndpoints.BackupDownload(id), outputPath, "'admin' access");
+    }
+
+    public async Task<BackupListResponse> DeleteAsync(string id)
+    {
+        return await _client.DeleteAsync(ApiEndpoints.Backup(id),
+            AppJsonContext.Default.BackupListResponse, "'admin' access");
+    }
+
+    public async Task<BackupListResponse> UploadAsync(string filePath)
+    {
+        var content = new MultipartFormDataContent();
+        var fileBytes = await File.ReadAllBytesAsync(filePath);
+        var fileContent = new ByteArrayContent(fileBytes);
+        fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
+        content.Add(fileContent, "file", System.IO.Path.GetFileName(filePath));
+        await _client.PostMultipartAsync(ApiEndpoints.BackupUpload, content, "'admin' access");
+        return await ListAsync();
+    }
+}

--- a/src/AbsCli/Services/ItemsService.cs
+++ b/src/AbsCli/Services/ItemsService.cs
@@ -56,4 +56,10 @@ public class ItemsService
     {
         return await _client.PostAsync(ApiEndpoints.ItemsBatchGet, jsonBody, AppJsonContext.Default.BatchGetResponse);
     }
+
+    public async Task<ScanResult> ScanAsync(string id)
+    {
+        return await _client.PostEmptyAsync(ApiEndpoints.ItemScan(id),
+            AppJsonContext.Default.ScanResult, "'admin' access");
+    }
 }

--- a/src/AbsCli/Services/LibrariesService.cs
+++ b/src/AbsCli/Services/LibrariesService.cs
@@ -21,4 +21,11 @@ public class LibrariesService
     {
         return await _client.GetAsync(ApiEndpoints.Library(id), AppJsonContext.Default.Library);
     }
+
+    public async Task ScanAsync(string libraryId, bool force)
+    {
+        var url = ApiEndpoints.LibraryScan(libraryId);
+        if (force) url += "?force=1";
+        await _client.PostEmptyAsync(url, "'admin' access");
+    }
 }

--- a/src/AbsCli/Services/MetadataService.cs
+++ b/src/AbsCli/Services/MetadataService.cs
@@ -1,0 +1,40 @@
+using System.Web;
+using AbsCli.Api;
+using AbsCli.Models;
+
+namespace AbsCli.Services;
+
+public class MetadataService
+{
+    private readonly AbsApiClient _client;
+
+    public MetadataService(AbsApiClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<string> SearchAsync(string provider, string title, string? author)
+    {
+        var query = HttpUtility.ParseQueryString("");
+        query["provider"] = provider;
+        query["title"] = title;
+        if (author != null) query["author"] = author;
+        return await _client.GetAsync(ApiEndpoints.SearchBooks + "?" + query);
+    }
+
+    public async Task<MetadataProvidersResponse> ListProvidersAsync()
+    {
+        return await _client.GetAsync(ApiEndpoints.SearchProviders,
+            AppJsonContext.Default.MetadataProvidersResponse);
+    }
+
+    public async Task<CoverSearchResponse> SearchCoversAsync(string provider, string title, string? author)
+    {
+        var query = HttpUtility.ParseQueryString("");
+        query["provider"] = provider;
+        query["title"] = title;
+        if (author != null) query["author"] = author;
+        return await _client.GetAsync(ApiEndpoints.SearchCovers + "?" + query,
+            AppJsonContext.Default.CoverSearchResponse);
+    }
+}

--- a/src/AbsCli/Services/TasksService.cs
+++ b/src/AbsCli/Services/TasksService.cs
@@ -1,0 +1,19 @@
+using AbsCli.Api;
+using AbsCli.Models;
+
+namespace AbsCli.Services;
+
+public class TasksService
+{
+    private readonly AbsApiClient _client;
+
+    public TasksService(AbsApiClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<TaskListResponse> ListAsync()
+    {
+        return await _client.GetAsync(ApiEndpoints.Tasks, AppJsonContext.Default.TaskListResponse);
+    }
+}

--- a/src/AbsCli/Services/UploadService.cs
+++ b/src/AbsCli/Services/UploadService.cs
@@ -56,7 +56,7 @@ public class UploadService
     }
 
     public async Task<LibraryItemMinified?> WaitForItemAsync(string libraryId, string title,
-        int timeoutSeconds = 60, int pollIntervalMs = 3000)
+        int timeoutSeconds = 300, int pollIntervalMs = 3000)
     {
         var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
         while (DateTime.UtcNow < deadline)

--- a/src/AbsCli/Services/UploadService.cs
+++ b/src/AbsCli/Services/UploadService.cs
@@ -1,0 +1,78 @@
+using System.Web;
+using AbsCli.Api;
+using AbsCli.Models;
+using AbsCli.Output;
+
+namespace AbsCli.Services;
+
+public class UploadService
+{
+    private readonly AbsApiClient _client;
+
+    public UploadService(AbsApiClient client)
+    {
+        _client = client;
+    }
+
+    public async Task UploadAsync(string libraryId, string folderId, string title,
+        string? author, string? series, int? sequence, string[] filePaths)
+    {
+        var uploadTitle = sequence.HasValue ? $"{sequence.Value}. - {title}" : title;
+        var content = new MultipartFormDataContent();
+        content.Add(new StringContent(libraryId), "library");
+        content.Add(new StringContent(folderId), "folder");
+        content.Add(new StringContent(uploadTitle), "title");
+        if (author != null)
+            content.Add(new StringContent(author), "author");
+        if (series != null)
+            content.Add(new StringContent(series), "series");
+        for (int i = 0; i < filePaths.Length; i++)
+        {
+            var fileBytes = await File.ReadAllBytesAsync(filePaths[i]);
+            var fileContent = new ByteArrayContent(fileBytes);
+            content.Add(fileContent, i.ToString(), Path.GetFileName(filePaths[i]));
+        }
+        await _client.PostMultipartAsync(ApiEndpoints.Upload, content, "'upload' permission");
+    }
+
+    public async Task<string> ResolveFolderIdAsync(string libraryId)
+    {
+        var library = await _client.GetAsync(ApiEndpoints.Library(libraryId),
+            AppJsonContext.Default.Library);
+        if (library.Folders.Count == 0)
+        {
+            ConsoleOutput.WriteError("Library has no folders configured.");
+            Environment.Exit(1);
+        }
+        if (library.Folders.Count > 1)
+        {
+            ConsoleOutput.WriteError(
+                $"Library has {library.Folders.Count} folders. Specify --folder <id>.\n" +
+                "Use 'abs-cli libraries get --id <id>' to see folder IDs.");
+            Environment.Exit(1);
+        }
+        return library.Folders[0].Id;
+    }
+
+    public async Task<LibraryItemMinified?> WaitForItemAsync(string libraryId, string title,
+        int timeoutSeconds = 60, int pollIntervalMs = 3000)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            var query = HttpUtility.ParseQueryString("");
+            query["q"] = title;
+            query["limit"] = "5";
+            var url = ApiEndpoints.LibrarySearch(libraryId) + "?" + query;
+            var result = await _client.GetAsync(url, AppJsonContext.Default.SearchResult);
+            if (result.Book != null && result.Book.Count > 0)
+            {
+                var itemJson = result.Book[0].GetProperty("libraryItem").GetRawText();
+                return System.Text.Json.JsonSerializer.Deserialize(itemJson,
+                    AppJsonContext.Default.LibraryItemMinified);
+            }
+            await Task.Delay(pollIntervalMs);
+        }
+        return null;
+    }
+}

--- a/src/AbsCli/Services/UploadService.cs
+++ b/src/AbsCli/Services/UploadService.cs
@@ -15,7 +15,8 @@ public class UploadService
     }
 
     public async Task UploadAsync(string libraryId, string folderId, string title,
-        string? author, string? series, int? sequence, string[] filePaths)
+        string? author, string? series, int? sequence,
+        IReadOnlyList<(string LocalPath, string UploadName)> files)
     {
         var uploadTitle = sequence.HasValue ? $"{sequence.Value}. - {title}" : title;
         var content = new MultipartFormDataContent();
@@ -26,11 +27,11 @@ public class UploadService
             content.Add(new StringContent(author), "author");
         if (series != null)
             content.Add(new StringContent(series), "series");
-        for (int i = 0; i < filePaths.Length; i++)
+        for (int i = 0; i < files.Count; i++)
         {
-            var fileBytes = await File.ReadAllBytesAsync(filePaths[i]);
+            var fileBytes = await File.ReadAllBytesAsync(files[i].LocalPath);
             var fileContent = new ByteArrayContent(fileBytes);
-            content.Add(fileContent, i.ToString(), Path.GetFileName(filePaths[i]));
+            content.Add(fileContent, i.ToString(), files[i].UploadName);
         }
         await _client.PostMultipartAsync(ApiEndpoints.Upload, content, "'upload' permission");
     }


### PR DESCRIPTION
## Summary

Implements v0.2.0: enables AI agents to upload books to ABS, search metadata providers, trigger scans, and manage backups. CLI provides sharp primitives; agents orchestrate.

- **Backup** (`backup create|list|apply|download|delete|upload`) — admin-only safety net
- **Upload** (`upload`) — multipart upload with `--sequence` folder naming, `--wait` polling, auto-folder resolution
- **Scan** (`libraries scan`, `items scan`) — admin-only scan triggers
- **Metadata** (`metadata search|providers|covers`) — ABS-configured provider search
- **Tasks** (`tasks list`) — poll background task state
- **Permission errors** — contextual 403/400/404/500 messages
- **Testing** — new `uploaduser` in seed, 60+ new smoke assertions including permission denial paths

## Spec & Plan

- Spec: [docs/specs/2026-04-12-v0.2.0-upload-metadata-backup.md](docs/specs/2026-04-12-v0.2.0-upload-metadata-backup.md)
- Plan: [docs/plans/2026-04-12-v0.2.0-implementation.md](docs/plans/2026-04-12-v0.2.0-implementation.md)

## Test plan

- [x] `dotnet build` — clean, 0 warnings
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet test` — 14/14 pass (unit tests)
- [x] `abs-cli self-test` — 32/32 pass (7 new DTO round-trips)
- [x] `docker/smoke-test.sh` — 105/105 assertions pass
  - Backup full cycle: create, list, download, upload, apply, delete
  - Upload with `--wait` as non-admin `uploaduser`
  - Permission denial: testuser upload → clear error
  - Permission denial: testuser backup list → clear error
  - Scan: libraries scan + items scan + tasks list
  - Metadata: providers (CI-safe), search/covers gated behind `SMOKE_TEST_EXTERNAL=1`
- [ ] Live test on real audiobooks/ebooks (planned after merge)

## Notes

- Auto-match (`POST /api/items/:id/match`) intentionally skipped — server-side auto-match unreliable. Agent reviews results from `metadata search` and applies via existing `items update`.
- `PATCH /api/backups/path` out of scope (niche admin op)
- Two bugs found during smoke testing, both in test infrastructure (not CLI code):
  - ABS requires `.audiobookshelf` extension on backup upload
  - ABS creates users as `isActive: false` without explicit flag