### PR TITLE
fix: report actual version via --version and User-Agent

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -69,11 +69,44 @@ Determine the version number:
 **GATE: Ask the human to confirm the version number.** Show them the proposed
 version and the commit summary. Wait for their response.
 
-## Step 2: Create Release Branch
+## Step 2: Create Release Branch and Bump Version
 
 ```bash
 VERSION="v{version}"  # from step 1, e.g. "v0.1.0"
+VERSION_NUM="${VERSION#v}"  # strip leading "v" — csproj wants "0.1.0", not "v0.1.0"
 git checkout -b "release/${VERSION}"
+```
+
+Bump `<Version>` in `src/AbsCli/AbsCli.csproj` to `${VERSION_NUM}`. This is
+what `abs-cli --version` reports and what the binary sends in its HTTP
+`User-Agent` header. Forgetting this leaves the binary self-reporting the
+previous version.
+
+Use `Edit` to change the line `<Version>OLD</Version>` to `<Version>NEW</Version>`
+in `src/AbsCli/AbsCli.csproj`. Verify with grep:
+
+```bash
+grep "<Version>" src/AbsCli/AbsCli.csproj
+# Should print:   <Version>{VERSION_NUM}</Version>
+```
+
+Rebuild the AOT binary and confirm `--version` reports the new number:
+
+```bash
+dotnet publish src/AbsCli/AbsCli.csproj -c Release -r linux-x64 --self-contained true /p:PublishAot=true -o ./publish
+./publish/abs-cli --version
+# Must print exactly: {VERSION_NUM}
+rm -rf publish/
+```
+
+If the printed version does not match, stop — something is wrong with
+the csproj or the build.
+
+Commit the bump:
+
+```bash
+git add src/AbsCli/AbsCli.csproj
+git commit -m "chore: bump version to ${VERSION_NUM}"
 ```
 
 ## Step 3: Generate Release Notes

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -26,10 +26,25 @@ Agent verifies prerequisites:
 
 **Human gate:** Confirm the version number.
 
-### Step 2: Create release branch (agent)
+### Step 2: Create release branch and bump version (agent)
 
 ```bash
 git checkout -b release/v{version}
+```
+
+Update `<Version>` in `src/AbsCli/AbsCli.csproj` to match the new version.
+This is what `abs-cli --version` reports and what gets sent in the
+HTTP `User-Agent` header. Forgetting this leaves the binary self-reporting
+the previous version.
+
+After editing, rebuild the AOT binary and confirm `abs-cli --version`
+prints exactly the new version (no `+sha` suffix — that is suppressed
+in the csproj). If it doesn't match, stop and investigate before
+committing.
+
+```bash
+git add src/AbsCli/AbsCli.csproj
+git commit -m "chore: bump version to {version}"
 ```
 
 ### Step 3: Generate release notes (agent)

--- a/src/AbsCli/AbsCli.csproj
+++ b/src/AbsCli/AbsCli.csproj
@@ -9,6 +9,8 @@
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <Version>0.1.1</Version>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -22,7 +22,7 @@ public class AbsApiClient
         {
             BaseAddress = new Uri(config.Server!.TrimEnd('/'))
         };
-        _http.DefaultRequestHeaders.UserAgent.ParseAdd("abs-cli/0.1.0");
+        _http.DefaultRequestHeaders.UserAgent.ParseAdd($"abs-cli/{AssemblyVersion}");
 
         if (config.AccessToken != null)
             _http.DefaultRequestHeaders.Authorization =
@@ -137,6 +137,9 @@ public class AbsApiClient
 
     private static readonly string MinSupportedVersion = "2.33.1";
     private static readonly string MaxTestedVersion = "2.33.1";
+
+    private static readonly string AssemblyVersion =
+        typeof(AbsApiClient).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
 
     public static void CheckServerVersion(string? version)
     {


### PR DESCRIPTION
## Summary

The binary self-reported wrong version info in two places:

- `abs-cli --version` showed `1.0.0+<commit-sha>` (the .NET assembly default since no `<Version>` was set in the csproj)
- HTTP `User-Agent` header was hardcoded as `abs-cli/0.1.0` (stale even at v0.1.1)

Now both report the actual version (currently `0.1.1`).

## Changes

- Set `<Version>0.1.1</Version>` in [src/AbsCli/AbsCli.csproj](src/AbsCli/AbsCli.csproj) so `System.CommandLine`'s built-in `--version` flag picks it up.
- Read the same value from assembly metadata for the `User-Agent` header in [src/AbsCli/Api/AbsApiClient.cs](src/AbsCli/Api/AbsApiClient.cs) so it stays in sync automatically.
- Set `<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>` to suppress the SourceLink `+<sha>` suffix — `--version` now prints just `0.1.1`.
- Update [docs/releasing.md](docs/releasing.md) and [.claude/skills/release/SKILL.md](.claude/skills/release/SKILL.md) Step 2 to bump `<Version>`, rebuild, and verify the AOT binary reports the new number before committing.

## Test plan

- [x] `dotnet build` clean, 0 warnings
- [x] `dotnet format --verify-no-changes` clean
- [x] `dotnet run -- --version` → `0.1.1`
- [x] AOT binary `--version` → `0.1.1`
- [x] `self-test` 25/25 pass
- [x] `smoke-test.sh` 71/71 pass

## Note on v0.1.1 release

After this merges, the plan is to force-replace the `v0.1.1` git tag and GitHub release with this fix included (per offline discussion — docs changes between original v0.1.1 and now are repo-only and don't affect the binary).