### PR TITLE
feat: upload receipt + series/items help clarifications

### DIFF
--- a/src/AbsCli/Commands/ItemsCommand.cs
+++ b/src/AbsCli/Commands/ItemsCommand.cs
@@ -59,6 +59,7 @@ public static class ItemsCommand
             "abs-cli items list",
             "abs-cli items list --filter \"languages=English\" --sort \"media.metadata.title\"",
             "abs-cli items list --filter \"genres=Fantasy\" --desc",
+            "abs-cli items list --filter \"series=se_abc123\" --sort sequence",
             "abs-cli items list --sort \"addedAt\" --desc --limit 10",
             "abs-cli items list | jq '.results[] | select(.media.metadata.isbn == null)'");
         command.AddResponseExample(typeof(PaginatedResponse), typeof(LibraryItemMinified));

--- a/src/AbsCli/Commands/ResponseExamples.g.cs
+++ b/src/AbsCli/Commands/ResponseExamples.g.cs
@@ -57,6 +57,8 @@ internal static class ResponseExamples
           "{\n  \"tasks\": [\n    {\n      \"id\": \"<string>\",\n      \"action\": null,\n      \"title\": null,\n      \"description\": null,\n      \"error\": null,\n      \"isFailed\": false,\n      \"isFinished\": false,\n      \"showSuccess\": false,\n      \"startedAt\": 0,\n      \"finishedAt\": 0,\n      \"data\": {}\n    }\n  ]\n}" },
         { typeof(AbsCli.Models.UpdateMediaResponse),
           "{\n  \"updated\": false,\n  \"libraryItem\": {\n    \"id\": \"<string>\",\n    \"ino\": null,\n    \"libraryId\": \"<string>\",\n    \"folderId\": null,\n    \"path\": null,\n    \"relPath\": null,\n    \"isFile\": false,\n    \"mtimeMs\": 0,\n    \"ctimeMs\": 0,\n    \"birthtimeMs\": 0,\n    \"addedAt\": 0,\n    \"updatedAt\": 0,\n    \"isMissing\": false,\n    \"isInvalid\": false,\n    \"mediaType\": \"<string>\",\n    \"media\": \"<book or podcast media — see Book media shape / Podcast media shape below>\",\n    \"numFiles\": 0,\n    \"size\": 0\n  }\n}" },
+        { typeof(AbsCli.Models.UploadReceipt),
+          "{\n  \"uploaded\": false,\n  \"title\": \"<string>\",\n  \"author\": null,\n  \"series\": null,\n  \"libraryId\": \"<string>\",\n  \"folderId\": \"<string>\",\n  \"files\": [\n    \"<string>\"\n  ]\n}" },
     };
 
     public static string For(Type type)

--- a/src/AbsCli/Commands/SeriesCommand.cs
+++ b/src/AbsCli/Commands/SeriesCommand.cs
@@ -14,7 +14,11 @@ public static class SeriesCommand
             "Series are derived from book metadata. A series exists while at least one",
             "library item references it. When the last referencing item is removed or",
             "re-tagged, the scanner deletes the series on its next run. To remove a",
-            "series, update the books that reference it.");
+            "series, update the books that reference it.",
+            "",
+            "Neither 'series list' nor 'series get' returns the books in a series —",
+            "they return series entities only. To list books in a specific series:",
+            "  abs-cli items list --filter \"series=<series-id>\" --sort sequence");
         command.AddCommand(CreateListCommand());
         command.AddCommand(CreateGetCommand());
         return command;

--- a/src/AbsCli/Commands/UploadCommand.cs
+++ b/src/AbsCli/Commands/UploadCommand.cs
@@ -56,6 +56,15 @@ public static class UploadCommand
             "abs-cli upload --title \"Morning Star\" --author \"Pierce Brown\" --series \"Red Rising\" --sequence 3 --prefix-source-dir --files \"Part 1-2\"/*.mp3 \"Part 3\"/*.mp3",
             "abs-cli upload --title \"My Audiobook\" --files-manifest manifest.json",
             "cat manifest.json | abs-cli upload --title \"My Audiobook\" --files-manifest -");
+        command.AddHelpSection("Output",
+            "Without --wait: returns a receipt ({uploaded, title, libraryId, folderId, files})",
+            "                once the HTTP upload completes. ABS writes the files",
+            "                synchronously but creates the library item on its next",
+            "                scan tick — so the receipt confirms files landed, not",
+            "                that the item exists yet.",
+            "With --wait:    polls items search and returns the resulting library",
+            "                item (LibraryItemMinified shape) once it appears.");
+        command.AddResponseExample<UploadReceipt>();
         command.SetHandler(async (context) =>
         {
             var library = context.ParseResult.GetValueForOption(libraryOption);
@@ -110,11 +119,10 @@ public static class UploadCommand
             var libraryId = CommandHelper.RequireLibrary(config);
             var service = new UploadService(client);
             var folderId = folder ?? await service.ResolveFolderIdAsync(libraryId);
-            await service.UploadAsync(libraryId, folderId, title, author, series, sequence, uploadList);
+            var receipt = await service.UploadAsync(libraryId, folderId, title, author, series, sequence, uploadList);
             if (wait)
             {
-                var searchTitle = sequence.HasValue ? $"{sequence.Value}. - {title}" : title;
-                var item = await service.WaitForItemAsync(libraryId, searchTitle, timeoutSeconds: waitTimeout);
+                var item = await service.WaitForItemAsync(libraryId, receipt.Title, timeoutSeconds: waitTimeout);
                 if (item == null)
                 {
                     ConsoleOutput.WriteError($"Timed out after {waitTimeout}s waiting for item to appear in library. The upload may still be processing — check 'abs-cli items search --query <title>' or pass --wait-timeout <seconds> to wait longer.");
@@ -122,6 +130,10 @@ public static class UploadCommand
                     return;
                 }
                 ConsoleOutput.WriteJson(item, AppJsonContext.Default.LibraryItemMinified);
+            }
+            else
+            {
+                ConsoleOutput.WriteJson(receipt, AppJsonContext.Default.UploadReceipt);
             }
         });
         return command;

--- a/src/AbsCli/Models/JsonContext.cs
+++ b/src/AbsCli/Models/JsonContext.cs
@@ -30,6 +30,7 @@ namespace AbsCli.Models;
 [JsonSerializable(typeof(MetadataProvidersResponse))]
 [JsonSerializable(typeof(CoverSearchResponse))]
 [JsonSerializable(typeof(UploadManifestEntry))]
+[JsonSerializable(typeof(UploadReceipt))]
 [JsonSerializable(typeof(List<UploadManifestEntry>))]
 [JsonSourceGenerationOptions(WriteIndented = true)]
 public partial class AppJsonContext : JsonSerializerContext;

--- a/src/AbsCli/Models/UploadReceipt.cs
+++ b/src/AbsCli/Models/UploadReceipt.cs
@@ -1,0 +1,35 @@
+using System.Text.Json.Serialization;
+
+namespace AbsCli.Models;
+
+/// <summary>
+/// Returned by <c>abs-cli upload</c> (without <c>--wait</c>) after the POST
+/// /api/upload call completes. ABS writes the files synchronously then returns
+/// HTTP 200 with an empty body — the library item is created asynchronously
+/// by ABS's file watcher on its next scan, so this receipt describes what
+/// was uploaded, not the resulting library item. Use <c>--wait</c> to also
+/// resolve the library item (returned as <see cref="LibraryItemMinified"/>).
+/// </summary>
+public class UploadReceipt
+{
+    [JsonPropertyName("uploaded")]
+    public bool Uploaded { get; set; }
+
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = "";
+
+    [JsonPropertyName("author")]
+    public string? Author { get; set; }
+
+    [JsonPropertyName("series")]
+    public string? Series { get; set; }
+
+    [JsonPropertyName("libraryId")]
+    public string LibraryId { get; set; } = "";
+
+    [JsonPropertyName("folderId")]
+    public string FolderId { get; set; } = "";
+
+    [JsonPropertyName("files")]
+    public List<string> Files { get; set; } = new();
+}

--- a/src/AbsCli/Services/UploadService.cs
+++ b/src/AbsCli/Services/UploadService.cs
@@ -14,7 +14,7 @@ public class UploadService
         _client = client;
     }
 
-    public async Task UploadAsync(string libraryId, string folderId, string title,
+    public async Task<UploadReceipt> UploadAsync(string libraryId, string folderId, string title,
         string? author, string? series, int? sequence,
         IReadOnlyList<(string LocalPath, string UploadName)> files)
     {
@@ -35,6 +35,21 @@ public class UploadService
         }
         await _client.PostMultipartAsync(ApiEndpoints.Upload, content, "'upload' permission",
             timeout: Timeout.InfiniteTimeSpan);
+
+        // ABS's upload endpoint returns HTTP 200 with an empty body (see
+        // server/controllers/MiscController.js handleUpload → res.sendStatus(200)).
+        // Synthesise a receipt from the request so callers have a concrete
+        // success signal instead of empty stdout.
+        return new UploadReceipt
+        {
+            Uploaded = true,
+            Title = uploadTitle,
+            Author = author,
+            Series = series,
+            LibraryId = libraryId,
+            FolderId = folderId,
+            Files = files.Select(f => f.UploadName).ToList(),
+        };
     }
 
     public async Task<string> ResolveFolderIdAsync(string libraryId)


### PR DESCRIPTION
## Summary

Addresses two UX issues flagged by an agent skill using the CLI (`temp/todo.md`).

### 1. Silent `upload` without `--wait` → typed receipt

ABS's `POST /api/upload` writes files synchronously then returns HTTP 200 with an empty body (see `server/controllers/MiscController.js:handleUpload`). The library item only materialises on ABS's next scan tick. Previously the CLI exited silently in the no-wait path — callers could not distinguish success from a swallowed error and had to poll `items search` blind.

Now a typed `UploadReceipt` is emitted:

\`\`\`
{
  "uploaded": true,
  "title": "Receipt Test",
  "author": "Receipt Author",
  "series": null,
  "libraryId": "4cfaeefc-...",
  "folderId": "a272d98f-...",
  "files": ["track.mp3"]
}
\`\`\`

With `--wait` the command keeps returning the full `LibraryItemMinified` (unchanged behaviour). An `Output:` help section spells out both modes and the two-phase "files written" vs "item scanned" nature.

### 2. `series get`/`series list` don't return books

Top-level `series --help` gains a Note block explaining that series subcommands return entities only, with a concrete pointer:

\`\`\`
To list books in a specific series:
  abs-cli items list --filter "series=<series-id>" --sort sequence
\`\`\`

And `items list --help` Examples now include the series-filter + sequence-sort pattern.

## Test plan

- [x] `dotnet test` — 65/65 pass
- [x] AOT publish + self-test — 33/33
- [x] Docker smoke against ABS 2.33.1 — 108/108 pass
- [x] Manual no-wait upload: receipt printed as expected
- [x] Manual `series --help` / `items list --help` rendering checked