### PR TITLE
fix: match uploaded item by relPath, port ABS sanitizeFilename

### DIFF
--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -391,13 +391,66 @@ else
 fi
 
 export ABS_TOKEN="$SAVE_TOKEN"
-rm -rf "$UPLOAD_TMP"
 
 # Cleanup: hard-delete the uploaded item (also removes orphan author "Test Author")
 if [ -n "$UPLOADED_ITEM_ID" ]; then
     curl -sf -X DELETE "$ABS_URL/api/items/$UPLOADED_ITEM_ID?hard=1" \
         -H "Authorization: Bearer $ABS_TOKEN" > /dev/null 2>&1 || true
 fi
+
+# --- Sanitisation drift detection ---
+# If the CLI's FilenameSanitizer drifts from ABS's sanitizeFilename, --wait
+# will fail to match the scanned item's relPath and these uploads will time
+# out. Each case exercises a specific sanitisation rule.
+
+run_drift_case() {
+    local label="$1" title="$2" author="$3" expected_relpath="$4" sequence_arg="$5" series_arg="$6"
+    export ABS_TOKEN="$UPLOAD_TOKEN"
+    local out
+    out=$($CLI upload --title "$title" --author "$author" $series_arg $sequence_arg \
+        --folder "$FOLDER_ID" --wait --files "$UPLOAD_TMP/test.mp3" 2>&1)
+    local rc=$?
+    export ABS_TOKEN="$SAVE_TOKEN"
+    if [ $rc -ne 0 ]; then
+        fail "sanitize drift: $label" "upload failed: ${out:0:300}"
+        return
+    fi
+    local actual
+    actual=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin)['relPath'].lstrip('/'))" 2>/dev/null || echo "PARSE_ERROR")
+    if [ "$actual" = "$expected_relpath" ]; then
+        pass "sanitize drift: $label"
+        local item_id=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null)
+        [ -n "$item_id" ] && curl -sf -X DELETE "$ABS_URL/api/items/$item_id?hard=1" \
+            -H "Authorization: Bearer $ABS_TOKEN" > /dev/null 2>&1 || true
+    else
+        fail "sanitize drift: $label" "expected relPath '$expected_relpath', got '$actual'"
+    fi
+}
+
+# Colon in title: first ':' replaced with ' - '
+run_drift_case "colon in title" "Alien: 3" "Sanitize Author" \
+    "Sanitize Author/Alien - 3" "" ""
+
+# Trailing dot in author
+run_drift_case "trailing dot in author" "Plain Title One" "J.R.R. Tolkien." \
+    "J.R.R. Tolkien/Plain Title One" "" ""
+
+# Sequence prefix: ABS keeps "N. -" in relPath (it's the folder name);
+# it only strips the prefix when deriving media.metadata.title. This is
+# why title-substring search failed pre-fix — the title-metadata lost the
+# prefix but the search query we built included it.
+run_drift_case "sequence prefix kept in relPath" "Hobbit Draft" "Sanitize Author Seq" \
+    "Sanitize Author Seq/Dwarves/1. - Hobbit Draft" "--sequence 1" "--series Dwarves"
+
+# Illegal char (pipe) stripped
+run_drift_case "illegal char stripped" "Pipe|Title" "Sanitize Author Pipe" \
+    "Sanitize Author Pipe/PipeTitle" "" ""
+
+# Whitespace run collapsed
+run_drift_case "whitespace collapsed" "Extra   Spaces   Title" "Sanitize Author WS" \
+    "Sanitize Author WS/Extra Spaces Title" "" ""
+
+rm -rf "$UPLOAD_TMP"
 
 # Filename-collision tests: build a 2-dir source tree where both dirs have a file
 # called "01.mp3". Confirm default errors, --prefix-source-dir succeeds, and

--- a/src/AbsCli/Api/FilenameSanitizer.cs
+++ b/src/AbsCli/Api/FilenameSanitizer.cs
@@ -1,0 +1,102 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace AbsCli.Api;
+
+/// <summary>
+/// Port of ABS's <c>sanitizeFilename</c> (see
+/// <c>temp/audiobookshelf/server/utils/fileUtils.js</c>). ABS applies this to
+/// every directory part (author, series, title) on upload, so the CLI runs
+/// the same transformation to predict the <c>relPath</c> ABS will assign to
+/// the resulting library item.
+///
+/// Behaviour that must stay in sync with ABS:
+///   1. NFC normalise.
+///   2. Replace first ':' with ' - ' (configurable separator).
+///   3. Strip illegal chars: / ? &lt; &gt; \ * | "
+///   4. Strip ASCII control chars (0x00-0x1f) and C1 controls (0x80-0x9f).
+///   5. Strip whole-string sequences of '.' only.
+///   6. Strip line breaks (\n, \r).
+///   7. Strip Windows reserved basenames (con, prn, aux, nul, com[0-9], lpt[0-9]).
+///   8. Strip trailing sequences of '.' or ' '.
+///   9. Collapse runs of whitespace to a single space.
+///  10. If basename in UTF-16 bytes &gt; 255, truncate the basename (ext preserved).
+///
+/// Drift risk: if ABS changes sanitise rules, CLI predictions desync silently.
+/// Smoke-test asserts that upload round-trips produce the same relPath we
+/// predicted — catches drift before it ships.
+/// </summary>
+public static class FilenameSanitizer
+{
+    private const int MaxFilenameBytes = 255;
+
+    private static readonly Regex IllegalChars = new(@"[/\?<>\\:\*\|""]", RegexOptions.Compiled);
+    private static readonly Regex ControlChars = new(@"[\x00-\x1f\x80-\x9f]", RegexOptions.Compiled);
+    private static readonly Regex DotsOnly = new(@"^\.+$", RegexOptions.Compiled);
+    private static readonly Regex LineBreaks = new(@"[\n\r]", RegexOptions.Compiled);
+    private static readonly Regex WindowsReserved = new(@"^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex TrailingDotsOrSpaces = new(@"[\. ]+$", RegexOptions.Compiled);
+    private static readonly Regex WhitespaceRun = new(@"\s+", RegexOptions.Compiled);
+
+    /// <summary>Sanitises a single path component the way ABS does on upload.</summary>
+    public static string Sanitize(string filename, string colonReplacement = " - ")
+    {
+        if (filename == null) throw new ArgumentNullException(nameof(filename));
+
+        var s = filename.Normalize(NormalizationForm.FormC);
+
+        // JS's String.prototype.replace with a non-regex pattern only replaces the first match.
+        var firstColon = s.IndexOf(':');
+        if (firstColon >= 0)
+            s = s[..firstColon] + colonReplacement + s[(firstColon + 1)..];
+
+        s = IllegalChars.Replace(s, "");
+        s = ControlChars.Replace(s, "");
+        s = DotsOnly.Replace(s, "");
+        s = LineBreaks.Replace(s, "");
+        s = WindowsReserved.Replace(s, "");
+        s = TrailingDotsOrSpaces.Replace(s, "");
+        s = WhitespaceRun.Replace(s, " ");
+
+        return TruncateToByteLimit(s);
+    }
+
+    /// <summary>
+    /// Compute the relPath ABS will assign to an uploaded library item, given
+    /// the request's author/series/title values. Parts that are null or empty
+    /// after sanitising are dropped (ABS does <c>.filter(Boolean)</c> on the
+    /// parts array before joining).
+    /// </summary>
+    public static string PredictRelPath(string? author, string? series, string title)
+    {
+        var parts = new List<string>();
+        foreach (var raw in new[] { author, series, title })
+        {
+            if (string.IsNullOrEmpty(raw)) continue;
+            var sanitized = Sanitize(raw);
+            if (!string.IsNullOrEmpty(sanitized)) parts.Add(sanitized);
+        }
+        return string.Join('/', parts);
+    }
+
+    private static string TruncateToByteLimit(string s)
+    {
+        // ABS measures basename only (extension preserved). On upload ABS sanitises
+        // each directory part separately before Path.join, so there's no extension
+        // here — we treat the whole string as basename.
+        var byteLen = Encoding.Unicode.GetByteCount(s);
+        if (byteLen <= MaxFilenameBytes) return s;
+
+        var sb = new StringBuilder();
+        var total = 0;
+        foreach (var c in s)
+        {
+            var charBytes = Encoding.Unicode.GetByteCount(new[] { c });
+            if (total + charBytes > MaxFilenameBytes) break;
+            sb.Append(c);
+            total += charBytes;
+        }
+        return sb.ToString();
+    }
+}

--- a/src/AbsCli/Commands/ResponseExamples.g.cs
+++ b/src/AbsCli/Commands/ResponseExamples.g.cs
@@ -58,7 +58,7 @@ internal static class ResponseExamples
         { typeof(AbsCli.Models.UpdateMediaResponse),
           "{\n  \"updated\": false,\n  \"libraryItem\": {\n    \"id\": \"<string>\",\n    \"ino\": null,\n    \"libraryId\": \"<string>\",\n    \"folderId\": null,\n    \"path\": null,\n    \"relPath\": null,\n    \"isFile\": false,\n    \"mtimeMs\": 0,\n    \"ctimeMs\": 0,\n    \"birthtimeMs\": 0,\n    \"addedAt\": 0,\n    \"updatedAt\": 0,\n    \"isMissing\": false,\n    \"isInvalid\": false,\n    \"mediaType\": \"<string>\",\n    \"media\": \"<book or podcast media — see Book media shape / Podcast media shape below>\",\n    \"numFiles\": 0,\n    \"size\": 0\n  }\n}" },
         { typeof(AbsCli.Models.UploadReceipt),
-          "{\n  \"uploaded\": true,\n  \"title\": \"<string>\",\n  \"author\": null,\n  \"series\": null,\n  \"libraryId\": \"<string>\",\n  \"folderId\": \"<string>\",\n  \"files\": [\n    \"<string>\"\n  ]\n}" },
+          "{\n  \"uploaded\": true,\n  \"title\": \"<string>\",\n  \"author\": null,\n  \"series\": null,\n  \"libraryId\": \"<string>\",\n  \"folderId\": \"<string>\",\n  \"relPath\": \"<string>\",\n  \"files\": [\n    \"<string>\"\n  ]\n}" },
     };
 
     public static string For(Type type)

--- a/src/AbsCli/Commands/ResponseExamples.g.cs
+++ b/src/AbsCli/Commands/ResponseExamples.g.cs
@@ -58,7 +58,7 @@ internal static class ResponseExamples
         { typeof(AbsCli.Models.UpdateMediaResponse),
           "{\n  \"updated\": false,\n  \"libraryItem\": {\n    \"id\": \"<string>\",\n    \"ino\": null,\n    \"libraryId\": \"<string>\",\n    \"folderId\": null,\n    \"path\": null,\n    \"relPath\": null,\n    \"isFile\": false,\n    \"mtimeMs\": 0,\n    \"ctimeMs\": 0,\n    \"birthtimeMs\": 0,\n    \"addedAt\": 0,\n    \"updatedAt\": 0,\n    \"isMissing\": false,\n    \"isInvalid\": false,\n    \"mediaType\": \"<string>\",\n    \"media\": \"<book or podcast media — see Book media shape / Podcast media shape below>\",\n    \"numFiles\": 0,\n    \"size\": 0\n  }\n}" },
         { typeof(AbsCli.Models.UploadReceipt),
-          "{\n  \"uploaded\": false,\n  \"title\": \"<string>\",\n  \"author\": null,\n  \"series\": null,\n  \"libraryId\": \"<string>\",\n  \"folderId\": \"<string>\",\n  \"files\": [\n    \"<string>\"\n  ]\n}" },
+          "{\n  \"uploaded\": true,\n  \"title\": \"<string>\",\n  \"author\": null,\n  \"series\": null,\n  \"libraryId\": \"<string>\",\n  \"folderId\": \"<string>\",\n  \"files\": [\n    \"<string>\"\n  ]\n}" },
     };
 
     public static string For(Type type)

--- a/src/AbsCli/Commands/UploadCommand.cs
+++ b/src/AbsCli/Commands/UploadCommand.cs
@@ -16,8 +16,8 @@ public static class UploadCommand
         var authorOption = new Option<string?>("--author", "Book author");
         var seriesOption = new Option<string?>("--series", "Series name");
         var sequenceOption = new Option<int?>("--sequence", "Series sequence number (requires --series)");
-        var waitOption = new Option<bool>("--wait", "Poll until the uploaded item appears in the library (default 5min timeout)");
-        var waitTimeoutOption = new Option<int>("--wait-timeout", () => 300, "Seconds to wait for the item to appear (with --wait). Defaults to 300.");
+        var waitOption = new Option<bool>("--wait",
+            "After upload, poll until the item appears in the library (up to ~2min) and return its full LibraryItemMinified. Without --wait, a terse UploadReceipt is returned immediately.");
         var filesOption = new Option<string[]>("--files", "File paths to upload (mutually exclusive with --files-manifest)") { AllowMultipleArgumentsPerToken = true };
         var prefixSourceDirOption = new Option<bool>("--prefix-source-dir",
             "Prefix each upload filename with its parent directory name (avoids collisions when files from multiple source dirs share basenames)");
@@ -26,7 +26,7 @@ public static class UploadCommand
         var command = new Command("upload", "Upload audiobook files to a library")
         {
             libraryOption, folderOption, titleOption, authorOption,
-            seriesOption, sequenceOption, waitOption, waitTimeoutOption, filesOption,
+            seriesOption, sequenceOption, waitOption, filesOption,
             prefixSourceDirOption, manifestOption
         };
         command.AddHelpSection("Folder ID",
@@ -62,8 +62,11 @@ public static class UploadCommand
             "                synchronously but creates the library item on its next",
             "                scan tick — so the receipt confirms files landed, not",
             "                that the item exists yet.",
-            "With --wait:    polls items search and returns the resulting library",
-            "                item (LibraryItemMinified shape) once it appears.");
+            "With --wait:    polls items list for an item whose relPath matches the",
+            "                folder ABS created, and returns it as a LibraryItemMinified.",
+            "                If the item doesn't appear within ~2 minutes the receipt",
+            "                is emitted on stdout and the command exits 1 — ABS may",
+            "                still be scanning; re-check with 'items list --sort addedAt --desc'.");
         command.AddResponseExample<UploadReceipt>();
         command.SetHandler(async (context) =>
         {
@@ -74,7 +77,6 @@ public static class UploadCommand
             var series = context.ParseResult.GetValueForOption(seriesOption);
             var sequence = context.ParseResult.GetValueForOption(sequenceOption);
             var wait = context.ParseResult.GetValueForOption(waitOption);
-            var waitTimeout = context.ParseResult.GetValueForOption(waitTimeoutOption);
             var files = context.ParseResult.GetValueForOption(filesOption) ?? Array.Empty<string>();
             var prefixSourceDir = context.ParseResult.GetValueForOption(prefixSourceDirOption);
             var manifestPath = context.ParseResult.GetValueForOption(manifestOption);
@@ -122,10 +124,21 @@ public static class UploadCommand
             var receipt = await service.UploadAsync(libraryId, folderId, title, author, series, sequence, uploadList);
             if (wait)
             {
-                var item = await service.WaitForItemAsync(libraryId, receipt.Title, timeoutSeconds: waitTimeout);
+                // Match by relPath — deterministic given that we compute the
+                // exact path ABS wrote to using the same sanitisation. The
+                // old title-substring search failed with --sequence because
+                // ABS strips the "N. -" prefix from media.metadata.title when
+                // scanning, so the CLI's search query (which included the
+                // prefix) no longer matched what ABS had indexed.
+                var expectedRelPath = Api.FilenameSanitizer.PredictRelPath(author, series, receipt.Title);
+                var item = await service.WaitForItemByPathAsync(libraryId, expectedRelPath);
                 if (item == null)
                 {
-                    ConsoleOutput.WriteError($"Timed out after {waitTimeout}s waiting for item to appear in library. The upload may still be processing — check 'abs-cli items search --query <title>' or pass --wait-timeout <seconds> to wait longer.");
+                    ConsoleOutput.WriteError(
+                        $"Upload completed but the library item did not appear within the wait window. " +
+                        $"Expected relPath: '{expectedRelPath}'. " +
+                        $"ABS may still be scanning — re-run: abs-cli items list --sort addedAt --desc --limit 5");
+                    ConsoleOutput.WriteJson(receipt, AppJsonContext.Default.UploadReceipt);
                     Environment.Exit(1);
                     return;
                 }

--- a/src/AbsCli/Commands/UploadCommand.cs
+++ b/src/AbsCli/Commands/UploadCommand.cs
@@ -68,6 +68,8 @@ public static class UploadCommand
             "                is emitted on stdout and the command exits 1 — ABS may",
             "                still be scanning; re-check with 'items list --sort addedAt --desc'.");
         command.AddResponseExample<UploadReceipt>();
+        command.AddHelpSection("Response shape (with --wait, on success)",
+            "LibraryItemMinified — same shape as 'abs-cli items get --help'.");
         command.SetHandler(async (context) =>
         {
             var library = context.ParseResult.GetValueForOption(libraryOption);

--- a/src/AbsCli/Commands/UploadCommand.cs
+++ b/src/AbsCli/Commands/UploadCommand.cs
@@ -57,13 +57,17 @@ public static class UploadCommand
             "abs-cli upload --title \"My Audiobook\" --files-manifest manifest.json",
             "cat manifest.json | abs-cli upload --title \"My Audiobook\" --files-manifest -");
         command.AddHelpSection("Output",
-            "Without --wait: returns a receipt ({uploaded, title, libraryId, folderId, files})",
-            "                once the HTTP upload completes. ABS writes the files",
-            "                synchronously but creates the library item on its next",
-            "                scan tick — so the receipt confirms files landed, not",
-            "                that the item exists yet.",
+            "Without --wait: returns a receipt ({uploaded, title, author, series,",
+            "                libraryId, folderId, relPath, files}) once the HTTP",
+            "                upload completes. ABS writes the files synchronously",
+            "                but creates the library item on its next scan tick, so",
+            "                the receipt confirms files landed, not that the item",
+            "                exists yet. Use receipt.relPath to locate the resulting",
+            "                library item later, e.g.:",
+            "                  abs-cli items list --sort addedAt --desc \\",
+            "                    | jq '.results[] | select(.relPath == \"<relPath>\")'",
             "With --wait:    polls items list for an item whose relPath matches the",
-            "                folder ABS created, and returns it as a LibraryItemMinified.",
+            "                receipt.relPath above, returns it as a LibraryItemMinified.",
             "                If the item doesn't appear within ~2 minutes the receipt",
             "                is emitted on stdout and the command exits 1 — ABS may",
             "                still be scanning; re-check with 'items list --sort addedAt --desc'.");
@@ -132,13 +136,12 @@ public static class UploadCommand
                 // ABS strips the "N. -" prefix from media.metadata.title when
                 // scanning, so the CLI's search query (which included the
                 // prefix) no longer matched what ABS had indexed.
-                var expectedRelPath = Api.FilenameSanitizer.PredictRelPath(author, series, receipt.Title);
-                var item = await service.WaitForItemByPathAsync(libraryId, expectedRelPath);
+                var item = await service.WaitForItemByPathAsync(libraryId, receipt.RelPath);
                 if (item == null)
                 {
                     ConsoleOutput.WriteError(
                         $"Upload completed but the library item did not appear within the wait window. " +
-                        $"Expected relPath: '{expectedRelPath}'. " +
+                        $"Expected relPath: '{receipt.RelPath}'. " +
                         $"ABS may still be scanning — re-run: abs-cli items list --sort addedAt --desc --limit 5");
                     ConsoleOutput.WriteJson(receipt, AppJsonContext.Default.UploadReceipt);
                     Environment.Exit(1);

--- a/src/AbsCli/Models/UploadReceipt.cs
+++ b/src/AbsCli/Models/UploadReceipt.cs
@@ -30,6 +30,16 @@ public class UploadReceipt
     [JsonPropertyName("folderId")]
     public string FolderId { get; set; } = "";
 
+    /// <summary>
+    /// Relative path (under the library folder) where ABS wrote the files.
+    /// The CLI predicts this using <see cref="Api.FilenameSanitizer"/> since
+    /// ABS's upload endpoint returns no body. Agents can use this to locate
+    /// the resulting library item once ABS scans — e.g.
+    /// <c>abs-cli items list --sort addedAt --desc | jq '.results[] | select(.relPath == "&lt;relPath&gt;")'</c>.
+    /// </summary>
+    [JsonPropertyName("relPath")]
+    public string RelPath { get; set; } = "";
+
     [JsonPropertyName("files")]
     public List<string> Files { get; set; } = new();
 }

--- a/src/AbsCli/Services/UploadService.cs
+++ b/src/AbsCli/Services/UploadService.cs
@@ -48,6 +48,7 @@ public class UploadService
             Series = series,
             LibraryId = libraryId,
             FolderId = folderId,
+            RelPath = FilenameSanitizer.PredictRelPath(author, series, uploadTitle),
             Files = files.Select(f => f.UploadName).ToList(),
         };
     }

--- a/src/AbsCli/Services/UploadService.cs
+++ b/src/AbsCli/Services/UploadService.cs
@@ -71,22 +71,39 @@ public class UploadService
         return library.Folders[0].Id;
     }
 
-    public async Task<LibraryItemMinified?> WaitForItemAsync(string libraryId, string title,
-        int timeoutSeconds = 300, int pollIntervalMs = 3000)
+    /// <summary>
+    /// Poll items list (sorted by addedAt desc) and return the first item whose
+    /// relPath matches <paramref name="expectedRelPath"/>. Path-based match is
+    /// deterministic: we computed the exact folder ABS wrote the files into
+    /// using the same sanitisation ABS applies, so there is no false positive
+    /// and no false negative from title substring matching (which broke when
+    /// --sequence prefixed the uploaded title).
+    /// </summary>
+    public async Task<LibraryItemMinified?> WaitForItemByPathAsync(
+        string libraryId, string expectedRelPath,
+        int timeoutSeconds = 120, int pollIntervalMs = 3000)
     {
         var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
         while (DateTime.UtcNow < deadline)
         {
             var query = HttpUtility.ParseQueryString("");
-            query["q"] = title;
-            query["limit"] = "5";
-            var url = ApiEndpoints.LibrarySearch(libraryId) + "?" + query;
-            var result = await _client.GetAsync(url, AppJsonContext.Default.SearchResult);
-            if (result.Book != null && result.Book.Count > 0)
+            query["sort"] = "addedAt";
+            query["desc"] = "1";
+            query["limit"] = "20";
+            var url = ApiEndpoints.LibraryItems(libraryId) + "?" + query;
+            var result = await _client.GetAsync(url, AppJsonContext.Default.PaginatedResponse);
+            foreach (var itemElement in result.Results)
             {
-                var itemJson = result.Book[0].GetProperty("libraryItem").GetRawText();
-                return System.Text.Json.JsonSerializer.Deserialize(itemJson,
-                    AppJsonContext.Default.LibraryItemMinified);
+                if (!itemElement.TryGetProperty("relPath", out var relPathProp)) continue;
+                var relPath = relPathProp.GetString();
+                if (relPath == null) continue;
+                // ABS stores relPath with a leading slash; strip it for comparison.
+                var normalised = relPath.TrimStart('/');
+                if (string.Equals(normalised, expectedRelPath, StringComparison.Ordinal))
+                {
+                    return System.Text.Json.JsonSerializer.Deserialize(itemElement.GetRawText(),
+                        AppJsonContext.Default.LibraryItemMinified);
+                }
             }
             await Task.Delay(pollIntervalMs);
         }

--- a/tests/AbsCli.Tests/Api/FilenameSanitizerTests.cs
+++ b/tests/AbsCli.Tests/Api/FilenameSanitizerTests.cs
@@ -1,0 +1,151 @@
+using AbsCli.Api;
+
+namespace AbsCli.Tests.Api;
+
+public class FilenameSanitizerTests
+{
+    [Fact]
+    public void Colon_FirstOccurrenceReplacedWithSeparator()
+    {
+        Assert.Equal("Alien - 3", FilenameSanitizer.Sanitize("Alien: 3"));
+    }
+
+    [Fact]
+    public void Colon_OnlyFirstIsReplaced()
+    {
+        // Second colon is stripped (it's in the illegal-char set).
+        Assert.Equal("a - b - c", FilenameSanitizer.Sanitize("a: b - c").Replace("  ", " "));
+        // Explicit check: only one " - " pair in output for multi-colon input.
+        var input = "a:b:c";
+        var output = FilenameSanitizer.Sanitize(input);
+        Assert.Equal("a - bc", output);
+    }
+
+    [Theory]
+    [InlineData("a/b", "ab")]
+    [InlineData("a?b", "ab")]
+    [InlineData("a<b>c", "abc")]
+    [InlineData("a\\b", "ab")]
+    [InlineData("a*b", "ab")]
+    [InlineData("a|b", "ab")]
+    [InlineData("a\"b", "ab")]
+    public void IllegalPathChars_Stripped(string input, string expected)
+    {
+        Assert.Equal(expected, FilenameSanitizer.Sanitize(input));
+    }
+
+    [Fact]
+    public void ControlChars_Stripped()
+    {
+        // Strips ASCII controls 0x00-0x1f and C1 controls 0x80-0x9f. Note ABS
+        // does NOT strip DEL (0x7f) — it's outside both ranges.
+        // Using \u escapes (always 4 hex digits) — \x is greedy and swallows
+        // the trailing 'b' as a hex digit.
+        Assert.Equal("ab", FilenameSanitizer.Sanitize("a\u0001b"));
+        Assert.Equal("a\u007fb", FilenameSanitizer.Sanitize("a\u007fb"));
+        Assert.Equal("ab", FilenameSanitizer.Sanitize("a\u009fb"));
+        // Tab (0x09) is in the ASCII control range → stripped.
+        Assert.Equal("ab", FilenameSanitizer.Sanitize("a\tb"));
+    }
+
+    [Fact]
+    public void LineBreaks_Stripped()
+    {
+        Assert.Equal("ab", FilenameSanitizer.Sanitize("a\nb"));
+        Assert.Equal("ab", FilenameSanitizer.Sanitize("a\rb"));
+    }
+
+    [Fact]
+    public void DotsOnly_Stripped()
+    {
+        // Whole-string sequences of dots are removed.
+        Assert.Equal("", FilenameSanitizer.Sanitize("..."));
+        Assert.Equal("", FilenameSanitizer.Sanitize("."));
+    }
+
+    [Theory]
+    [InlineData("con")]
+    [InlineData("CON")]
+    [InlineData("prn")]
+    [InlineData("aux")]
+    [InlineData("nul")]
+    [InlineData("com1")]
+    [InlineData("com9")]
+    [InlineData("lpt1")]
+    [InlineData("lpt9")]
+    [InlineData("con.txt")]
+    public void WindowsReserved_Stripped(string input)
+    {
+        Assert.Equal("", FilenameSanitizer.Sanitize(input));
+    }
+
+    [Fact]
+    public void TrailingDotsAndSpaces_Stripped()
+    {
+        Assert.Equal("J.R.R", FilenameSanitizer.Sanitize("J.R.R."));
+        Assert.Equal("a", FilenameSanitizer.Sanitize("a   "));
+        Assert.Equal("a", FilenameSanitizer.Sanitize("a. . ."));
+    }
+
+    [Fact]
+    public void WhitespaceRuns_CollapsedToSingleSpace()
+    {
+        Assert.Equal("a b c", FilenameSanitizer.Sanitize("a    b   c"));
+    }
+
+    [Fact]
+    public void NfcNormalisation_AppliedBeforeOtherRules()
+    {
+        // "é" as NFD (e + combining acute) must be normalised to NFC single char.
+        var nfd = "e\u0301";
+        var result = FilenameSanitizer.Sanitize(nfd);
+        Assert.Equal("é", result);
+    }
+
+    [Fact]
+    public void LongBasename_TruncatedToByteLimit()
+    {
+        // UTF-16 is 2 bytes per ASCII char → 300 chars = 600 bytes, exceeds 255.
+        var longName = new string('a', 300);
+        var result = FilenameSanitizer.Sanitize(longName);
+        // MaxFilenameBytes / 2 = 127 chars for ASCII-only.
+        Assert.Equal(127, result.Length);
+    }
+
+    [Fact]
+    public void PredictRelPath_JoinsSanitisedPartsWithSlash()
+    {
+        Assert.Equal("Author/Series/Title",
+            FilenameSanitizer.PredictRelPath("Author", "Series", "Title"));
+    }
+
+    [Fact]
+    public void PredictRelPath_DropsNullAndEmptyParts()
+    {
+        Assert.Equal("Author/Title",
+            FilenameSanitizer.PredictRelPath("Author", null, "Title"));
+        Assert.Equal("Title",
+            FilenameSanitizer.PredictRelPath(null, null, "Title"));
+    }
+
+    [Fact]
+    public void PredictRelPath_SanitisesEachPart()
+    {
+        // Author "Tolkien, J.R.R." has trailing dot stripped → "Tolkien, J.R.R"
+        // Title "Alien: 3" has colon replaced → "Alien - 3"
+        Assert.Equal("Tolkien, J.R.R/Alien - 3",
+            FilenameSanitizer.PredictRelPath("Tolkien, J.R.R.", null, "Alien: 3"));
+    }
+
+    [Fact]
+    public void PredictRelPath_DropsPartsThatSanitiseToEmpty()
+    {
+        // Series is just ":" → becomes "" after sanitise (colon replaced by
+        // " - ", then trailing-space strip, then whitespace-collapse, but
+        // leading " - " has no trailing anchor to match… actually ": " →
+        // " - " after colon replace, then WhitespaceRun normalises to " - ",
+        // which is non-empty. So use a surer empty case: ".." sanitises to "".
+        Assert.Equal("Author/Title",
+            FilenameSanitizer.PredictRelPath("Author", "...", "Title"));
+    }
+}

--- a/tools/GenerateResponseExamples/Program.cs
+++ b/tools/GenerateResponseExamples/Program.cs
@@ -76,6 +76,11 @@ internal static class Program
         o.Placeholders[(typeof(LibraryItemMinified), nameof(LibraryItemMinified.Media))]
             = "<book or podcast media — see Book media shape / Podcast media shape below>";
 
+        // UploadReceipt.Uploaded is always true on success (failure paths exit
+        // before emitting the receipt), so the walker's default-false is
+        // misleading. Override to true.
+        o.BoolValues[(typeof(UploadReceipt), nameof(UploadReceipt.Uploaded))] = true;
+
         // Typed containers for libraryItem / libraryItems that ABS returns
         // but we declared as JsonElement(?) to keep the CLI transparent.
         o.TypeSubstitutions[(typeof(BatchGetResponse), nameof(BatchGetResponse.LibraryItems))] = typeof(LibraryItemMinified);

--- a/tools/GenerateResponseExamples/SampleJsonWalker.cs
+++ b/tools/GenerateResponseExamples/SampleJsonWalker.cs
@@ -17,6 +17,10 @@ public class PropertyOverrides
 {
     public Dictionary<(Type, string), string> Placeholders { get; } = new();
     public Dictionary<(Type, string), Type> TypeSubstitutions { get; } = new();
+    /// <summary>Override the sample value of a <c>bool</c> property. Walker's
+    /// default is always <c>false</c>, which is misleading for fields whose
+    /// only meaningful runtime value is <c>true</c> (e.g. success flags).</summary>
+    public Dictionary<(Type, string), bool> BoolValues { get; } = new();
 }
 
 /// <summary>
@@ -139,6 +143,11 @@ public static class SampleJsonWalker
             if (overrides != null && overrides.Placeholders.TryGetValue(key, out var placeholder))
             {
                 writer.WriteStringValue(placeholder);
+                continue;
+            }
+            if (overrides != null && overrides.BoolValues.TryGetValue(key, out var boolValue))
+            {
+                writer.WriteBooleanValue(boolValue);
                 continue;
             }
             if (overrides != null && overrides.TypeSubstitutions.TryGetValue(key, out var substitute))


### PR DESCRIPTION
## Summary

Fixes the `--wait` flow silently failing when `--sequence` is used, and removes the brittle `--wait-timeout` knob.

### The bug

`UploadCommand`'s `--wait` used title-substring search via `/api/libraries/:id/search?q=<uploadTitle>`. With `--sequence N`, the uploaded title was `"N. - Title"`. ABS's scanner (`temp/audiobookshelf/server/utils/scandir.js:getSequence`) **strips the `N. -` prefix from `media.metadata.title`** when parsing the folder name for indexing — but keeps it in `relPath`. So the CLI's search query (which included the prefix) never matched what ABS had indexed, and `--wait` timed out after the full window every time.

### The fix

Match by `relPath` instead of title substring. Since we know exactly what folder ABS created (same transformations applied to `author` / `series` / `title`), we can predict the exact `relPath` and poll `items list --sort addedAt --desc --limit 20` for that specific path. No substring false positives, no prefix-stripping mismatch.

To predict the path, `ABS/server/utils/fileUtils.js:sanitizeFilename` is ported to C# as `FilenameSanitizer`:
- NFC normalise
- Replace first `:` with ` - `
- Strip illegal path chars (`/ ? < > \ * | "`)
- Strip ASCII + C1 control chars
- Strip line breaks, whole-string dots, Windows reserved names
- Strip trailing `.` and space
- Collapse whitespace runs
- Truncate basename to 255 UTF-16 bytes

### Drift detection

The risk with reimplementing a server-side function is silent drift: if ABS ever changes sanitisation, the CLI's prediction goes wrong and `--wait` breaks again. New smoke-test cases upload with tricky inputs (colon, trailing dot, sequence prefix, illegal char, whitespace run) and assert the returned `relPath` matches what the CLI predicted. If ABS changes behaviour, these fail loudly.

### `--wait-timeout` removed

The option only bounded the post-upload polling loop; the upload HTTP call was never governed by it. The failure mode (timeout) was also indistinguishable from "our search term didn't match". With path-based matching timeouts should be rare, so `--wait` now uses a fixed 120s internal window. On timeout the `UploadReceipt` is emitted to stdout (so callers never get empty output) and the command exits 1.

### Breaking changes

- `--wait-timeout` no longer accepted. Anyone passing it will get a `System.CommandLine` unknown-option error.

## Test plan

- [x] `dotnet test` — 95/95 pass (30 new FilenameSanitizer tests)
- [x] AOT publish + self-test — 33/33
- [x] Docker smoke against ABS 2.33.1 — 113/113 pass (108 baseline + 5 drift)
- [x] The 5 drift cases confirm the sanitizer port matches ABS's actual behaviour for: colon, trailing dot, sequence prefix, illegal char, whitespace run