### PR TITLE
chore: bump ABS to 2.33.2 (smoke + MaxTestedVersion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ See [docs/](docs/) for architecture, authentication, build targets, and more.
 
 ## Compatibility
 
-Tested against Audiobookshelf **2.33.1**. The CLI warns on login if the server version is outside the tested range. See [docs/abs-compatibility.md](docs/abs-compatibility.md) for the compatibility policy.
+Tested against Audiobookshelf **2.33.1 — 2.33.2**. The CLI warns on login if the server version is outside the tested range. See [docs/abs-compatibility.md](docs/abs-compatibility.md) for the full compatibility matrix and policy.
 
 ## License
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   audiobookshelf:
-    image: advplyr/audiobookshelf:2.33.1
+    image: advplyr/audiobookshelf:2.33.2
     ports:
       - "13378:80"
     volumes:

--- a/docs/abs-compatibility.md
+++ b/docs/abs-compatibility.md
@@ -5,9 +5,10 @@
 The CLI tracks which ABS versions it has been tested against. This is documented in
 the project README and checked at runtime.
 
-| abs-cli Version | ABS Versions | Notes |
-|----------------|-------------|-------|
-| 0.1.x          | 2.33.1      | Initial release, baseline API |
+| abs-cli Version | ABS Versions  | Notes |
+|----------------|--------------|-------|
+| 0.1.x — 0.2.4   | 2.33.1        | Initial release, baseline API |
+| 0.2.5+          | 2.33.1 — 2.33.2 | No API surface changes in 2.33.2 (maintenance release; internal refactors, image-endpoint clamping, cross-library bulk-download guard) |
 
 This table grows as new ABS versions are tested. A single CLI version may support
 multiple ABS versions if the API surface hasn't changed.

--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -197,7 +197,7 @@ public class AbsApiClient
     }
 
     private static readonly string MinSupportedVersion = "2.33.1";
-    private static readonly string MaxTestedVersion = "2.33.1";
+    private static readonly string MaxTestedVersion = "2.33.2";
 
     private static readonly string AssemblyVersion =
         typeof(AbsApiClient).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";


### PR DESCRIPTION
Raises abs-cli's tested ABS version range to include 2.33.2.

## Controller / model diff v2.33.1 → v2.33.2

Reviewed against the abs-cli surface per `docs/abs-compatibility.md` "Handling ABS Updates":

| File | Change | Impact on abs-cli |
|---|---|---|
| `AuthorController.js` | image endpoint width/height clamped to ≤4096 | CLI doesn't use author images |
| `LibraryController.js` | bulk download: items restricted to requested library | CLI doesn't use bulk download |
| `LibraryController.js` | `handleDeleteLibraryItem` internal 3rd param (libraryId) | internal refactor, not exposed |
| `LibraryItemController.js` | cover image clamp, delete internal param | no public shape change |
| `Author.js` | `findOrCreateByNameAndLibrary` returns `{author, created}` | internal model |
| `Book.js` | emits `author_added`/`author_updated` socket events | CLI doesn't use sockets |
| `PlaybackSession.toJSON()` | adds optional `coverAspectRatio` (share sessions) | CLI doesn't read PlaybackSession |
| `Stream.js` | adds `opus` to forced-AAC codec list | internal transcoder |
| `Series / Search / Misc / Backup / TokenManager` | **no changes** | clean |

Zero breaking changes for the CLI.

## Changes in this PR

- `docker/docker-compose.yml` — image bumped to `advplyr/audiobookshelf:2.33.2`
- `src/AbsCli/Api/AbsApiClient.cs` — `MaxTestedVersion` raised to `2.33.2` (`MinSupportedVersion` stays at `2.33.1`)
- `docs/abs-compatibility.md` — matrix row added (and the stale `0.1.x` entry refreshed to `0.1.x — 0.2.4`)
- `README.md` — tested-against line updated to `2.33.1 — 2.33.2`

## Verification

- Controller / model / objects diff — see table above
- Unit tests: 95/95
- Docker smoke against 2.33.2: **113/113 pass** (including the 5 sanitise-drift cases)
- Runtime version warning confirmed firing with `MaxTestedVersion` still at 2.33.1:

  ```
  ./publish/abs-cli login
  ...
  Warning: ABS server version 2.33.2 has not been tested with this version of abs-cli. Proceed with caution.
  Logged in as root to http://... (ABS 2.33.2)
  ```

  After this PR merges and `MaxTestedVersion` is `2.33.2`, the warning stops firing against 2.33.2 servers — as intended.

Next: per `docs/releasing.md:9` this qualifies as a PATCH release (ABS compatibility bump, no CLI feature changes). Should cut **v0.2.5** via `/release` once merged.