### PR TITLE
docs: align items search help with actual behavior

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,3 +40,11 @@ All are additive — nothing in the v1 architecture blocks them.
 | Collections / Playlists resources | Not needed for metadata workflow |
 | `items files` / `items progress` | Playback and file management not in scope |
 | Auto-update mechanism | Check for new versions, prompt/apply updates from GitHub releases |
+
+## Planned breaking changes
+
+Scheduled for a future minor release with a prior deprecation window.
+
+| Change | Reason |
+|--------|--------|
+| Remove `abs-cli items search` | Functional duplicate of top-level `abs-cli search` — same endpoint (`/api/libraries/:id/search`), same response shape. Kept as alias through v0.2.x with a note in its help; remove in the next minor bump. |

--- a/src/AbsCli/Commands/ItemsCommand.cs
+++ b/src/AbsCli/Commands/ItemsCommand.cs
@@ -106,12 +106,30 @@ public static class ItemsCommand
         var limitOption = new Option<int>("--limit", () => 50, "Max results (default 50, pass higher value to retrieve more)");
 
         var command = new Command("search",
-            "Search items in a library (substring match, case-insensitive, searches title/subtitle/ASIN/ISBN, defaults to 50 results)")
+            "Search across a library (substring match, case-insensitive, defaults to 50 results). Alias for 'abs-cli search' — same endpoint, same response shape.")
         {
             queryOption, libraryOption, limitOption
         };
+        command.AddHelpSection("Search behavior",
+            "Substring match, case-insensitive. No operators or wildcards.",
+            "Multi-word queries match as a single phrase (\"brandon sanderson\"",
+            "matches but \"sanderson brandon\" does not).",
+            "Accent-insensitive when the server supports it.");
+        command.AddHelpSection("Fields searched",
+            "Books: title, subtitle, ASIN, ISBN",
+            "Authors: name",
+            "Series: name",
+            "Narrators: name",
+            "Tags: name",
+            "Genres: name",
+            "NOT searched: description, publisher");
+        command.AddHelpSection("Note",
+            "The response populates book, podcast, authors, series, narrators,",
+            "tags and genres arrays — not just books. This command is kept as",
+            "an alias; prefer top-level 'abs-cli search'. See roadmap for removal.");
         command.AddExamples(
             "abs-cli items search --query \"Mistborn\"",
+            "abs-cli items search --query \"Brandon Sanderson\" | jq '.authors[].name'",
             "abs-cli items search --query \"978-0\" --limit 20");
         command.AddResponseExample<SearchResult>();
         command.AddMediaUnionShapes();


### PR DESCRIPTION
Agent feedback flagged that \`items search --help\` claimed narrower behavior than reality. Digging in: \`items search\` and top-level \`search\` both call \`GET /api/libraries/:id/search\` (the only library-scoped search route in ABS) and deserialize the same multi-array \`SearchResult\`.

## Changes

- **\`items search --help\`** now mirrors top-level \`search --help\`:
  - Description re-worded to match reality
  - New \`Search behavior\` and \`Fields searched\` sections (copied from top-level \`search\`)
  - New \`Note\` flagging that this is an alias and pointing at the roadmap
  - New Example showing \`.authors[].name\` extraction to signal that non-book arrays are populated
- **\`docs/roadmap.md\`** gains a "Planned breaking changes" section noting removal of \`items search\` in a future minor bump, with deprecation window via the Note above.

## Test plan

- [x] \`dotnet test\` — 95/95
- [x] Manual render of \`items search --help\` inspected — all new sections appear in the expected positions (Notes top, Search behavior / Fields searched / Note body, Examples + Response shape + Book/Podcast media shapes at the bottom).

No behaviour change — command still returns the full SearchResult. This is docs-only.