### PR TITLE
fix: use POST for items batch-update (was PATCH, 404'd)

### DIFF
--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -263,6 +263,30 @@ output=$(echo "{\"libraryItemIds\":[\"$FIRST_ITEM_ID\",\"$SECOND_ITEM_ID\"]}" \
     | $CLI items batch-get --stdin 2>/dev/null)
 assert_json_expr "batch-get returns 2 items" "len(d.get('libraryItems',[]))==2" "$output"
 
+# Batch update — update two items in one call. Guards against the bug
+# where the CLI issued PATCH /api/items/batch/update while ABS only
+# registers POST for that route (which 404s as "Cannot PATCH ...").
+BATCH_PAYLOAD="[{\"id\":\"$FIRST_ITEM_ID\",\"mediaPayload\":{\"metadata\":{\"publisher\":\"Smoke Batch Press A\"}}},{\"id\":\"$SECOND_ITEM_ID\",\"mediaPayload\":{\"metadata\":{\"publisher\":\"Smoke Batch Press B\"}}}]"
+output=$(echo "$BATCH_PAYLOAD" | $CLI items batch-update --stdin 2>&1)
+rc=$?
+if [ $rc -eq 0 ] && echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d.get('success') is True" 2>/dev/null; then
+    pass "batch-update returns success"
+else
+    fail "batch-update returns success" "rc=$rc output: ${output:0:200}"
+fi
+
+# Verify both items actually got the new publisher.
+pub_a=$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['media']['metadata'].get('publisher'))")
+pub_b=$($CLI items get --id "$SECOND_ITEM_ID" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['media']['metadata'].get('publisher'))")
+if [ "$pub_a" = "Smoke Batch Press A" ] && [ "$pub_b" = "Smoke Batch Press B" ]; then
+    pass "batch-update persisted both items"
+else
+    fail "batch-update persisted both items" "got '$pub_a' / '$pub_b'"
+fi
+
+# Restore both
+$CLI items batch-update --stdin 2>/dev/null <<< "[{\"id\":\"$FIRST_ITEM_ID\",\"mediaPayload\":{\"metadata\":{\"publisher\":null}}},{\"id\":\"$SECOND_ITEM_ID\",\"mediaPayload\":{\"metadata\":{\"publisher\":null}}}]" > /dev/null
+
 # ============================================================
 echo ""
 echo "=== Series Commands ==="

--- a/src/AbsCli/Services/ItemsService.cs
+++ b/src/AbsCli/Services/ItemsService.cs
@@ -49,7 +49,10 @@ public class ItemsService
 
     public async Task<BatchUpdateResponse> BatchUpdateAsync(string jsonBody)
     {
-        return await _client.PatchAsync(ApiEndpoints.ItemsBatchUpdate, jsonBody, AppJsonContext.Default.BatchUpdateResponse);
+        // ABS route is POST /items/batch/update (not PATCH — the single-item
+        // /items/:id/media endpoint is PATCH but the batch variant is POST).
+        // See temp/audiobookshelf/server/routers/ApiRouter.js.
+        return await _client.PostAsync(ApiEndpoints.ItemsBatchUpdate, jsonBody, AppJsonContext.Default.BatchUpdateResponse);
     }
 
     public async Task<BatchGetResponse> BatchGetAsync(string jsonBody)


### PR DESCRIPTION
\`abs-cli items batch-update\` has been returning:

\`\`\`
Error: Not found. <!DOCTYPE html>...
<pre>Cannot PATCH /api/items/batch/update</pre>
\`\`\`

since v0.2.2 (earliest version reported). ABS registers the batch-update route as **POST only** (\`temp/audiobookshelf/server/routers/ApiRouter.js:103\`) — the CLI was issuing PATCH, which Express 404s since no route matches the verb+path pair.

Likely cause of the confusion: the **single-item** update endpoint \`PATCH /api/items/:id/media\` is PATCH, so \`UpdateMediaAsync\` correctly uses \`PatchAsync\` — \`BatchUpdateAsync\` appears to have been copy-pasted and kept the verb even though the route doesn't.

## Fix

One-line change in \`ItemsService.BatchUpdateAsync\`: \`PatchAsync\` → \`PostAsync\`. Comment added explaining the asymmetry so the next person doesn't "fix" it back.

## Test coverage (new)

The smoke suite previously only asserted \`items batch-update --help\` had ≥2 examples; it never fired the command. Added two new cases:

1. **\`batch-update returns success\`** — fire a two-item batch-update, assert response \`success: true\`.
2. **\`batch-update persisted both items\`** — re-fetch both items, assert the new \`publisher\` values landed.

Both would have caught this bug on day 1. Run locally against ABS 2.33.2 — 115/115 pass.

## Other batch endpoints re-verified against ABS routes

| CLI method | Verb used | ABS route | Correct? |
|---|---|---|---|
| \`UpdateMediaAsync\` | PATCH | \`PATCH /items/:id/media\` | ✓ |
| \`BatchUpdateAsync\` | ~~PATCH~~ → POST | \`POST /items/batch/update\` | ✓ after this PR |
| \`BatchGetAsync\` | POST | \`POST /items/batch/get\` | ✓ |

## Test plan

- [x] \`dotnet test\` — 95/95
- [x] Docker smoke against ABS 2.33.2 — 115/115 pass (new: 2 batch-update cases)
- [x] Manual verification of the reporter's repro payload — would now succeed

Patch release v0.2.6 after merge.