### PR TITLE
fix: accept string sequences on upload --sequence

### DIFF
--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -466,6 +466,12 @@ run_drift_case "trailing dot in author" "Plain Title One" "J.R.R. Tolkien." \
 run_drift_case "sequence prefix kept in relPath" "Hobbit Draft" "Sanitize Author Seq" \
     "Sanitize Author Seq/Dwarves/1. - Hobbit Draft" "--sequence 1" "--series Dwarves"
 
+# Decimal sequence: ABS stores BookSeries.sequence as STRING, so "1.5" must
+# flow through the CLI unchanged. Regression test for the old int-only typing
+# that rejected decimal series positions at the CLI boundary.
+run_drift_case "decimal sequence kept in relPath" "Hobbit Decimal" "Sanitize Author Dec" \
+    "Sanitize Author Dec/Dwarves/1.5. - Hobbit Decimal" "--sequence 1.5" "--series Dwarves"
+
 # Illegal char (pipe) stripped
 run_drift_case "illegal char stripped" "Pipe|Title" "Sanitize Author Pipe" \
     "Sanitize Author Pipe/PipeTitle" "" ""

--- a/src/AbsCli/Commands/UploadCommand.cs
+++ b/src/AbsCli/Commands/UploadCommand.cs
@@ -15,7 +15,7 @@ public static class UploadCommand
         var titleOption = new Option<string>("--title", "Book title") { IsRequired = true };
         var authorOption = new Option<string?>("--author", "Book author");
         var seriesOption = new Option<string?>("--series", "Series name");
-        var sequenceOption = new Option<int?>("--sequence", "Series sequence number (requires --series)");
+        var sequenceOption = new Option<string?>("--sequence", "Series sequence (requires --series). Any non-empty string — integer (\"1\"), decimal (\"1.5\"), or free-form (\"0\", \"II\"). Becomes the \"N. -\" prefix on the item folder.");
         var waitOption = new Option<bool>("--wait",
             "After upload, poll until the item appears in the library (up to ~2min) and return its full LibraryItemMinified. Without --wait, a terse UploadReceipt is returned immediately.");
         var filesOption = new Option<string[]>("--files", "File paths to upload (mutually exclusive with --files-manifest)") { AllowMultipleArgumentsPerToken = true };
@@ -86,9 +86,15 @@ public static class UploadCommand
             var files = context.ParseResult.GetValueForOption(filesOption) ?? Array.Empty<string>();
             var prefixSourceDir = context.ParseResult.GetValueForOption(prefixSourceDirOption);
             var manifestPath = context.ParseResult.GetValueForOption(manifestOption);
-            if (sequence.HasValue && series == null)
+            if (sequence != null && series == null)
             {
                 ConsoleOutput.WriteError("--sequence requires --series.");
+                Environment.Exit(1);
+                return;
+            }
+            if (sequence != null && string.IsNullOrWhiteSpace(sequence))
+            {
+                ConsoleOutput.WriteError("--sequence must be a non-empty string.");
                 Environment.Exit(1);
                 return;
             }

--- a/src/AbsCli/Services/UploadService.cs
+++ b/src/AbsCli/Services/UploadService.cs
@@ -15,10 +15,10 @@ public class UploadService
     }
 
     public async Task<UploadReceipt> UploadAsync(string libraryId, string folderId, string title,
-        string? author, string? series, int? sequence,
+        string? author, string? series, string? sequence,
         IReadOnlyList<(string LocalPath, string UploadName)> files)
     {
-        var uploadTitle = sequence.HasValue ? $"{sequence.Value}. - {title}" : title;
+        var uploadTitle = sequence != null ? $"{sequence}. - {title}" : title;
         var content = new MultipartFormDataContent();
         content.Add(new StringContent(libraryId), "library");
         content.Add(new StringContent(folderId), "folder");


### PR DESCRIPTION
## Summary

- `abs-cli upload --sequence` was typed `int?`, so decimal positions (`1.5`, `4.75`) and non-numeric labels (`II`, `0a`) were rejected at the CLI boundary even though ABS stores `BookSeries.sequence` as a STRING (`server/models/BookSeries.js:40`).
- Change `--sequence` to accept any non-empty string; the value flows through unchanged to the `{seq}. - {title}` folder-name prefix.
- Add a smoke drift case with `--sequence 1.5` so the int-only regression can't come back.

Caught by the `abs-management` skill while orchestrating a multi-book upload with fractional series positions.

## Test plan

- [x] `dotnet format AbsCli.sln --verify-no-changes`
- [x] Unit tests: 95/95 pass
- [x] Smoke tests: 116/116 pass (incl. new `decimal sequence kept in relPath` case)
- [x] Manual: `--sequence 1.5 --series Dwarves` produces relPath `.../Dwarves/1.5. - <title>`