### PR TITLE
feat: add abs-cli changelog command and scope v0.3.0

### DIFF
--- a/docs/plans/2026-04-27-changelog-command.md
+++ b/docs/plans/2026-04-27-changelog-command.md
@@ -616,46 +616,13 @@ If there were no changes, skip this step.
 
 ---
 
-## Task 9: CHANGELOG entry
+## Note on `CHANGELOG.md`
 
-Document the new command. The version bump itself is part of the release process, not this plan — but the changelog entry belongs with the work. Roadmap was restructured in commit `43c6c89` (separate from the plan tasks); no roadmap edits needed here.
-
-**Files:**
-- Modify: `CHANGELOG.md`
-
-- [ ] **Step 1: Add an unreleased entry to `CHANGELOG.md`**
-
-At the top of `CHANGELOG.md` (just below the file header preamble, above `## 0.2.7`), add:
-
-```markdown
-## Unreleased
-
-### Highlights
-- `abs-cli changelog` prints release notes from the bundled CHANGELOG.md.
-  Default output is the latest version's entry; `--all` prints the full file.
-  The file is embedded as an assembly resource so the command works offline
-  and ships in a single artifact.
-
-### Features
-- feat: add abs-cli changelog command
-```
-
-The release process will rename `## Unreleased` to `## 0.3.0 — <date>` at version-bump time.
-
-- [ ] **Step 2: Verify the new entry round-trips through the command**
-
-```bash
-dotnet run --project /workspaces/abs-cli/src/AbsCli/AbsCli.csproj -- changelog | head -2
-```
-
-Expected: stdout begins with `## Unreleased`.
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add CHANGELOG.md
-git commit -m "docs: add changelog entry for changelog command"
-```
+`CHANGELOG.md` is **owned by the release process** (`docs/releasing.md`,
+invoked via `/release` on a `release/v{version}` branch). Feature branches —
+including this one — must not edit it. The release agent picks new entries
+up from the commit log when v0.3.0 is cut. Any plan that includes a
+"document the change in CHANGELOG.md" task is wrong; skip such steps.
 
 ---
 

--- a/docs/plans/2026-04-27-changelog-command.md
+++ b/docs/plans/2026-04-27-changelog-command.md
@@ -616,13 +616,12 @@ If there were no changes, skip this step.
 
 ---
 
-## Task 9: Roadmap and CHANGELOG entries
+## Task 9: CHANGELOG entry
 
-Document the new command. The version bump itself is part of the release process, not this plan — but the changelog entry and roadmap update belong with the work.
+Document the new command. The version bump itself is part of the release process, not this plan — but the changelog entry belongs with the work. Roadmap was restructured in commit `43c6c89` (separate from the plan tasks); no roadmap edits needed here.
 
 **Files:**
 - Modify: `CHANGELOG.md`
-- Modify: `docs/roadmap.md`
 
 - [ ] **Step 1: Add an unreleased entry to `CHANGELOG.md`**
 
@@ -643,17 +642,7 @@ At the top of `CHANGELOG.md` (just below the file header preamble, above `## 0.2
 
 The release process will rename `## Unreleased` to `## 0.3.0 — <date>` at version-bump time.
 
-- [ ] **Step 2: Remove the changelog idea from the roadmap**
-
-In `docs/roadmap.md`, delete this row from the Ideas table:
-
-```markdown
-| `abs-cli changelog` command | Print the most recent entry by default; a flag (e.g. `--all`) prints the full file. Source of truth is the bundled `CHANGELOG.md`. |
-```
-
-Leave the cover-handling row in place — it's a separate sub-project.
-
-- [ ] **Step 3: Verify the new entry round-trips through the command**
+- [ ] **Step 2: Verify the new entry round-trips through the command**
 
 ```bash
 dotnet run --project /workspaces/abs-cli/src/AbsCli/AbsCli.csproj -- changelog | head -2
@@ -661,11 +650,11 @@ dotnet run --project /workspaces/abs-cli/src/AbsCli/AbsCli.csproj -- changelog |
 
 Expected: stdout begins with `## Unreleased`.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 3: Commit**
 
 ```bash
-git add CHANGELOG.md docs/roadmap.md
-git commit -m "docs: add changelog command entry and tidy roadmap"
+git add CHANGELOG.md
+git commit -m "docs: add changelog entry for changelog command"
 ```
 
 ---

--- a/docs/plans/2026-04-27-changelog-command.md
+++ b/docs/plans/2026-04-27-changelog-command.md
@@ -1,0 +1,697 @@
+# `abs-cli changelog` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a top-level `abs-cli changelog` command that prints the latest entry from the bundled `CHANGELOG.md` by default, or the full file with `--all`.
+
+**Architecture:** `CHANGELOG.md` is embedded as an assembly manifest resource at build time. A small `ChangelogReader` static helper reads the resource and either returns it verbatim (`ReadAll`) or extracts the topmost `## ` block (`ReadLatest`). `ChangelogCommand` wires the command surface and writes the result to stdout. The command does not call `CommandHelper.BuildClient`, so it inherits the same no-auth/no-network status as `self-test`.
+
+**Tech Stack:** C# / .NET 8 / System.CommandLine 2.0-beta4 / xUnit 2.5. Target CLI is published with `PublishAot=true`. `InternalsVisibleTo("AbsCli.Tests")` is already configured.
+
+**Spec:** [docs/specs/2026-04-27-changelog-command.md](../specs/2026-04-27-changelog-command.md)
+
+---
+
+## File Structure
+
+**New files:**
+
+- `src/AbsCli/Services/ChangelogReader.cs` — static helper exposing `ReadAll()`, `ReadLatest()`, and `internal static string ExtractLatest(string)` (the test seam).
+- `src/AbsCli/Commands/ChangelogCommand.cs` — System.CommandLine `Command` factory; defines `--all`; sets handler.
+- `tests/AbsCli.Tests/Commands/ChangelogReaderTests.cs` — unit tests for `ExtractLatest`.
+- `tests/AbsCli.Tests/Commands/ChangelogCommandTests.cs` — end-to-end test invoking the command via the parser.
+
+**Modified files:**
+
+- `src/AbsCli/AbsCli.csproj` — add `<EmbeddedResource>` for repo-root `CHANGELOG.md`.
+- `src/AbsCli/Program.cs` — register `ChangelogCommand.Create()` on the root command.
+- `src/AbsCli/Commands/SelfTestCommand.cs` — add a `Check` block asserting the embedded resource is present and parseable.
+- `CHANGELOG.md` — add a `0.3.0` (or next-version) entry covering the new command. The version bump is part of the release process; this plan only adds the entry.
+- `docs/roadmap.md` — move "abs-cli changelog command" from Ideas table to a new shipped-milestone subsection (or leave for the release commit; see Task 8).
+
+---
+
+## Task 1: Embed `CHANGELOG.md` as an assembly resource
+
+Wire the build so the file ships inside the binary.
+
+**Files:**
+- Modify: `src/AbsCli/AbsCli.csproj`
+
+- [ ] **Step 1: Add the embedded resource ItemGroup**
+
+In `src/AbsCli/AbsCli.csproj`, add a new `<ItemGroup>` near the existing `InternalsVisibleTo` block:
+
+```xml
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\CHANGELOG.md" LogicalName="CHANGELOG.md" />
+  </ItemGroup>
+```
+
+The `LogicalName` attribute makes the resource accessible as `"CHANGELOG.md"` rather than the default `AbsCli.CHANGELOG.md` derived from the include path.
+
+- [ ] **Step 2: Verify the resource is embedded**
+
+Run from `src/AbsCli/`:
+
+```bash
+dotnet build /workspaces/abs-cli/AbsCli.sln -c Debug
+```
+
+Expected: build succeeds. Then list resources in the produced assembly:
+
+```bash
+dotnet run --project /workspaces/abs-cli/src/AbsCli/AbsCli.csproj -- --version 2>/dev/null; \
+  strings /workspaces/abs-cli/src/AbsCli/bin/Debug/net8.0/abs-cli.dll | grep -E '^CHANGELOG\.md$'
+```
+
+Expected: a line `CHANGELOG.md` is printed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/AbsCli/AbsCli.csproj
+git commit -m "chore: embed CHANGELOG.md as assembly resource"
+```
+
+---
+
+## Task 2: Add failing test for `ExtractLatest` — single-entry extraction
+
+TDD red step: tests come before any implementation.
+
+**Files:**
+- Create: `tests/AbsCli.Tests/Commands/ChangelogReaderTests.cs`
+
+- [ ] **Step 1: Write the first failing test**
+
+Create `tests/AbsCli.Tests/Commands/ChangelogReaderTests.cs`:
+
+```csharp
+using AbsCli.Services;
+using Xunit;
+
+namespace AbsCli.Tests.Commands;
+
+public class ChangelogReaderTests
+{
+    private const string TwoEntries =
+        "# Changelog\n" +
+        "\n" +
+        "All notable changes are documented here.\n" +
+        "\n" +
+        "## 0.2.7 — 2026-04-24\n" +
+        "\n" +
+        "### Highlights\n" +
+        "- latest highlight\n" +
+        "\n" +
+        "### Fixes\n" +
+        "- fix: latest fix\n" +
+        "\n" +
+        "## 0.2.6 — 2026-04-24\n" +
+        "\n" +
+        "### Highlights\n" +
+        "- older highlight\n";
+
+    [Fact]
+    public void ExtractLatest_ReturnsBlockStartingAtTopmostVersionHeading()
+    {
+        var result = ChangelogReader.ExtractLatest(TwoEntries);
+        Assert.StartsWith("## 0.2.7 — 2026-04-24", result);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails to compile**
+
+```bash
+dotnet test /workspaces/abs-cli/AbsCli.sln --filter "FullyQualifiedName~ChangelogReaderTests"
+```
+
+Expected: build error — `The name 'ChangelogReader' does not exist`.
+
+---
+
+## Task 3: Implement `ChangelogReader.ExtractLatest` with the minimal logic to pass
+
+Green step. Implement just enough to pass the test from Task 2.
+
+**Files:**
+- Create: `src/AbsCli/Services/ChangelogReader.cs`
+
+- [ ] **Step 1: Create `ChangelogReader.cs` with stubs and the extraction algorithm**
+
+Create `src/AbsCli/Services/ChangelogReader.cs`:
+
+```csharp
+using System.Reflection;
+using System.Text;
+
+namespace AbsCli.Services;
+
+public static class ChangelogReader
+{
+    private const string ResourceName = "CHANGELOG.md";
+
+    public static string ReadAll()
+    {
+        return ReadEmbeddedResource();
+    }
+
+    public static string ReadLatest()
+    {
+        return ExtractLatest(ReadEmbeddedResource());
+    }
+
+    internal static string ExtractLatest(string changelog)
+    {
+        if (string.IsNullOrEmpty(changelog))
+        {
+            throw new InvalidOperationException("CHANGELOG.md has no version entries");
+        }
+
+        var lines = changelog.Split('\n');
+        var startIndex = -1;
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].StartsWith("## ", StringComparison.Ordinal))
+            {
+                startIndex = i;
+                break;
+            }
+        }
+
+        if (startIndex < 0)
+        {
+            throw new InvalidOperationException("CHANGELOG.md has no version entries");
+        }
+
+        var endIndex = lines.Length;
+        for (var i = startIndex + 1; i < lines.Length; i++)
+        {
+            if (lines[i].StartsWith("## ", StringComparison.Ordinal))
+            {
+                endIndex = i;
+                break;
+            }
+        }
+
+        var lastNonBlank = endIndex - 1;
+        while (lastNonBlank > startIndex && string.IsNullOrWhiteSpace(lines[lastNonBlank]))
+        {
+            lastNonBlank--;
+        }
+
+        var sb = new StringBuilder();
+        for (var i = startIndex; i <= lastNonBlank; i++)
+        {
+            sb.Append(lines[i]);
+            if (i < lastNonBlank)
+            {
+                sb.Append('\n');
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static string ReadEmbeddedResource()
+    {
+        var assembly = typeof(ChangelogReader).Assembly;
+        using var stream = assembly.GetManifestResourceStream(ResourceName);
+        if (stream is null)
+        {
+            throw new InvalidOperationException("CHANGELOG.md resource not embedded");
+        }
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test and verify it passes**
+
+```bash
+dotnet test /workspaces/abs-cli/AbsCli.sln --filter "FullyQualifiedName~ChangelogReaderTests"
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/AbsCli/Services/ChangelogReader.cs tests/AbsCli.Tests/Commands/ChangelogReaderTests.cs
+git commit -m "feat: add ChangelogReader.ExtractLatest"
+```
+
+---
+
+## Task 4: Cover the remaining `ExtractLatest` rules with tests
+
+Add the rest of the unit coverage promised by the spec. Each `Fact` is one assertion; if any fails, fix `ExtractLatest` and re-run.
+
+**Files:**
+- Modify: `tests/AbsCli.Tests/Commands/ChangelogReaderTests.cs`
+
+- [ ] **Step 1: Add the four remaining `Fact`s**
+
+Append to `ChangelogReaderTests`:
+
+```csharp
+    [Fact]
+    public void ExtractLatest_StopsBeforeNextVersionHeading()
+    {
+        var result = ChangelogReader.ExtractLatest(TwoEntries);
+        Assert.DoesNotContain("## 0.2.6", result);
+        Assert.DoesNotContain("older highlight", result);
+    }
+
+    [Fact]
+    public void ExtractLatest_IncludesSubHeadingsWithinLatestEntry()
+    {
+        var result = ChangelogReader.ExtractLatest(TwoEntries);
+        Assert.Contains("### Highlights", result);
+        Assert.Contains("### Fixes", result);
+        Assert.Contains("- latest highlight", result);
+        Assert.Contains("- fix: latest fix", result);
+    }
+
+    [Fact]
+    public void ExtractLatest_TrimsTrailingBlankLines()
+    {
+        var input =
+            "## 1.0.0 — 2026-01-01\n" +
+            "\n" +
+            "body\n" +
+            "\n" +
+            "\n";
+        var result = ChangelogReader.ExtractLatest(input);
+        Assert.EndsWith("body", result);
+        Assert.False(result.EndsWith("\n", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ExtractLatest_ThrowsWhenNoVersionHeadingPresent()
+    {
+        var input = "# Changelog\n\nNo entries yet.\n";
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ChangelogReader.ExtractLatest(input));
+        Assert.Equal("CHANGELOG.md has no version entries", ex.Message);
+    }
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+dotnet test /workspaces/abs-cli/AbsCli.sln --filter "FullyQualifiedName~ChangelogReaderTests"
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/AbsCli.Tests/Commands/ChangelogReaderTests.cs
+git commit -m "test: cover ExtractLatest stop/trim/error cases"
+```
+
+---
+
+## Task 5: Wire `ChangelogCommand` and register it
+
+Build the command surface; integration test follows in Task 6.
+
+**Files:**
+- Create: `src/AbsCli/Commands/ChangelogCommand.cs`
+- Modify: `src/AbsCli/Program.cs`
+
+- [ ] **Step 1: Create `ChangelogCommand.cs`**
+
+```csharp
+using System.CommandLine;
+using AbsCli.Services;
+
+namespace AbsCli.Commands;
+
+public static class ChangelogCommand
+{
+    public static Command Create()
+    {
+        var allOption = new Option<bool>(
+            "--all",
+            "Print the entire CHANGELOG.md instead of just the latest entry");
+        var command = new Command(
+            "changelog",
+            "Print release notes from the bundled CHANGELOG.md") { allOption };
+        command.AddExamples(
+            "abs-cli changelog",
+            "abs-cli changelog --all");
+        command.SetHandler((bool all) =>
+        {
+            var output = all ? ChangelogReader.ReadAll() : ChangelogReader.ReadLatest();
+            Console.Out.WriteLine(output);
+        }, allOption);
+        return command;
+    }
+}
+```
+
+Note: do **not** call `CommandHelper.BuildClient` — this command needs neither auth nor network.
+
+- [ ] **Step 2: Register the command in `Program.cs`**
+
+In `src/AbsCli/Program.cs`, add the registration alongside the existing top-level commands. Place it after `SelfTestCommand` to keep utility commands together:
+
+```csharp
+rootCommand.AddCommand(SelfTestCommand.Create());
+rootCommand.AddCommand(ChangelogCommand.Create());
+```
+
+- [ ] **Step 3: Build and smoke-run**
+
+```bash
+dotnet build /workspaces/abs-cli/AbsCli.sln -c Debug
+dotnet run --project /workspaces/abs-cli/src/AbsCli/AbsCli.csproj -- changelog
+```
+
+Expected: stdout begins with `## 0.2.7 — 2026-04-24` (or whatever the topmost entry in the repo's `CHANGELOG.md` currently is) and contains its `### Highlights`/`### Fixes` blocks. No login prompt. Exit 0.
+
+- [ ] **Step 4: Smoke-run `--all`**
+
+```bash
+dotnet run --project /workspaces/abs-cli/src/AbsCli/AbsCli.csproj -- changelog --all | head -3
+```
+
+Expected: first line is `# Changelog` (the file header).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/AbsCli/Commands/ChangelogCommand.cs src/AbsCli/Program.cs
+git commit -m "feat: add abs-cli changelog command"
+```
+
+---
+
+## Task 6: End-to-end integration test
+
+Verify the full command path through the parser, including the embedded resource.
+
+**Files:**
+- Create: `tests/AbsCli.Tests/Commands/ChangelogCommandTests.cs`
+
+- [ ] **Step 1: Write the integration test**
+
+The test reads the actual repo `CHANGELOG.md` to compute the expected first heading, then asserts the command's stdout starts with it. The repo path is resolved relative to the test assembly's `BaseDirectory` and walking up to the repo root.
+
+```csharp
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.IO;
+using System.CommandLine.Parsing;
+using AbsCli.Commands;
+using Xunit;
+
+namespace AbsCli.Tests.Commands;
+
+public class ChangelogCommandTests
+{
+    private static int Invoke(TestConsole console, params string[] args)
+    {
+        var root = new RootCommand();
+        root.AddCommand(ChangelogCommand.Create());
+        var parser = new CommandLineBuilder(root)
+            .UseDefaults()
+            .Build();
+        return parser.Invoke(args, console);
+    }
+
+    private static string FirstVersionHeading()
+    {
+        // tests/AbsCli.Tests/bin/Debug/net8.0 -> repo root is four levels up.
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 6 && dir is not null; i++)
+        {
+            var candidate = Path.Combine(dir, "CHANGELOG.md");
+            if (File.Exists(candidate))
+            {
+                foreach (var line in File.ReadLines(candidate))
+                {
+                    if (line.StartsWith("## ", StringComparison.Ordinal))
+                    {
+                        return line;
+                    }
+                }
+                throw new InvalidOperationException("Repo CHANGELOG.md has no version heading");
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Could not locate repo CHANGELOG.md from test base directory");
+    }
+
+    [Fact]
+    public void Default_PrintsLatestEntryStartingAtTopmostHeading()
+    {
+        var console = new TestConsole();
+        var exit = Invoke(console, "changelog");
+        var stdout = console.Out.ToString() ?? "";
+
+        Assert.Equal(0, exit);
+        Assert.StartsWith(FirstVersionHeading(), stdout);
+    }
+
+    [Fact]
+    public void All_PrintsFullFileStartingWithTopHeader()
+    {
+        var console = new TestConsole();
+        var exit = Invoke(console, "changelog", "--all");
+        var stdout = console.Out.ToString() ?? "";
+
+        Assert.Equal(0, exit);
+        Assert.StartsWith("# Changelog", stdout);
+    }
+
+    [Fact]
+    public void All_OutputIsLongerThanDefault()
+    {
+        var defaultConsole = new TestConsole();
+        Invoke(defaultConsole, "changelog");
+        var allConsole = new TestConsole();
+        Invoke(allConsole, "changelog", "--all");
+
+        var defaultLen = (defaultConsole.Out.ToString() ?? "").Length;
+        var allLen = (allConsole.Out.ToString() ?? "").Length;
+        Assert.True(allLen > defaultLen,
+            $"--all output ({allLen} chars) should be longer than default ({defaultLen})");
+    }
+}
+```
+
+- [ ] **Step 2: Run the integration tests**
+
+```bash
+dotnet test /workspaces/abs-cli/AbsCli.sln --filter "FullyQualifiedName~ChangelogCommandTests"
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/AbsCli.Tests/Commands/ChangelogCommandTests.cs
+git commit -m "test: end-to-end coverage for changelog command"
+```
+
+---
+
+## Task 7: Add a self-test check for the embedded resource
+
+Catch a future build that silently drops the embedded file.
+
+**Files:**
+- Modify: `src/AbsCli/Commands/SelfTestCommand.cs`
+
+- [ ] **Step 1: Add a `Check` block**
+
+Locate the last `Check(...)` block in `SelfTestCommand.cs`'s handler. Append a new section header and check immediately after it (before the summary `Console.Error.WriteLine` lines that report `pass`/`fail`):
+
+```csharp
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("=== Embedded resources ===");
+
+            Check("CHANGELOG.md embedded and parseable", () =>
+            {
+                var latest = AbsCli.Services.ChangelogReader.ReadLatest();
+                Assert(!string.IsNullOrWhiteSpace(latest), "ReadLatest returned empty");
+                Assert(latest.StartsWith("## ", StringComparison.Ordinal),
+                    $"ReadLatest did not start with '## ': '{latest[..Math.Min(40, latest.Length)]}'");
+            });
+```
+
+If the file already has a final summary section header, place the new section header just above it. The exact `Console.Error.WriteLine` summary lines below it must remain unchanged.
+
+- [ ] **Step 2: Run the self-test**
+
+```bash
+dotnet run --project /workspaces/abs-cli/src/AbsCli/AbsCli.csproj -- self-test
+```
+
+Expected: stderr includes `PASS: CHANGELOG.md embedded and parseable`. Exit 0.
+
+- [ ] **Step 3: Run the full unit-test suite to confirm no regressions**
+
+```bash
+dotnet test /workspaces/abs-cli/AbsCli.sln
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/AbsCli/Commands/SelfTestCommand.cs
+git commit -m "test: assert CHANGELOG.md is embedded in self-test"
+```
+
+---
+
+## Task 8: Format check + final verification
+
+Match the project's formatting and confirm everything still builds.
+
+**Files:** none new.
+
+- [ ] **Step 1: Run `dotnet format`**
+
+```bash
+dotnet format /workspaces/abs-cli/AbsCli.sln
+```
+
+Expected: no errors. Either there are no diffs, or the diffs are whitespace-only.
+
+- [ ] **Step 2: Verify formatting passes the CI check**
+
+```bash
+dotnet format /workspaces/abs-cli/AbsCli.sln --verify-no-changes
+```
+
+Expected: exit 0, no diagnostics.
+
+- [ ] **Step 3: Build and run the full test suite once more**
+
+```bash
+dotnet build /workspaces/abs-cli/AbsCli.sln -c Release
+dotnet test /workspaces/abs-cli/AbsCli.sln -c Release
+```
+
+Expected: build succeeds; all tests pass.
+
+- [ ] **Step 4: AOT publish smoke check**
+
+```bash
+dotnet publish /workspaces/abs-cli/src/AbsCli/AbsCli.csproj -c Release
+# Find the published binary path:
+find /workspaces/abs-cli/src/AbsCli/bin/Release -name abs-cli -type f -executable | head -1
+```
+
+Then run the published binary's `changelog` and `self-test`:
+
+```bash
+PUB=$(find /workspaces/abs-cli/src/AbsCli/bin/Release -name abs-cli -type f -executable | head -1)
+"$PUB" changelog | head -1
+"$PUB" self-test | tail -5
+```
+
+Expected: `changelog` prints a `## ` heading; `self-test` reports the new check as PASS and exits 0.
+
+- [ ] **Step 5: Commit any formatting fixes**
+
+If `dotnet format` made changes, commit them:
+
+```bash
+git add -u
+git commit -m "chore: dotnet format"
+```
+
+If there were no changes, skip this step.
+
+---
+
+## Task 9: Roadmap and CHANGELOG entries
+
+Document the new command. The version bump itself is part of the release process, not this plan — but the changelog entry and roadmap update belong with the work.
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `docs/roadmap.md`
+
+- [ ] **Step 1: Add an unreleased entry to `CHANGELOG.md`**
+
+At the top of `CHANGELOG.md` (just below the file header preamble, above `## 0.2.7`), add:
+
+```markdown
+## Unreleased
+
+### Highlights
+- `abs-cli changelog` prints release notes from the bundled CHANGELOG.md.
+  Default output is the latest version's entry; `--all` prints the full file.
+  The file is embedded as an assembly resource so the command works offline
+  and ships in a single artifact.
+
+### Features
+- feat: add abs-cli changelog command
+```
+
+The release process will rename `## Unreleased` to `## 0.3.0 — <date>` at version-bump time.
+
+- [ ] **Step 2: Remove the changelog idea from the roadmap**
+
+In `docs/roadmap.md`, delete this row from the Ideas table:
+
+```markdown
+| `abs-cli changelog` command | Print the most recent entry by default; a flag (e.g. `--all`) prints the full file. Source of truth is the bundled `CHANGELOG.md`. |
+```
+
+Leave the cover-handling row in place — it's a separate sub-project.
+
+- [ ] **Step 3: Verify the new entry round-trips through the command**
+
+```bash
+dotnet run --project /workspaces/abs-cli/src/AbsCli/AbsCli.csproj -- changelog | head -2
+```
+
+Expected: stdout begins with `## Unreleased`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md docs/roadmap.md
+git commit -m "docs: add changelog command entry and tidy roadmap"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+- Top-level command, `--all` flag → Task 5.
+- Latest-entry extraction algorithm (`## ` start, stop at next `## `, trim trailing blanks, heading included) → Tasks 3, 4.
+- Raw markdown output, no JSON envelope → Task 5 handler uses `Console.Out.WriteLine`.
+- Embedded resource at build, single-artifact ship → Task 1.
+- `ChangelogReader.ReadAll`, `ReadLatest` → Task 3.
+- Error handling (resource missing, no headings, empty file) → Task 3 implementation; Task 4 covers the no-headings unit case.
+- Unit tests (5 cases) → Tasks 2, 4.
+- Integration tests (parser end-to-end) → Task 6.
+- Self-test smoke → Task 7.
+- Login bypass open question → resolved during planning: not calling `CommandHelper.BuildClient` is sufficient, since `self-test` follows the same pattern. Noted in Task 5 Step 1.
+
+No spec section is uncovered.
+
+**Placeholder scan:** none. All steps include exact paths, exact commands, and full code blocks.
+
+**Type/name consistency:**
+
+- `ChangelogReader.ReadAll` / `ReadLatest` / `ExtractLatest` — used identically across Tasks 2-7.
+- Resource logical name `"CHANGELOG.md"` — consistent in csproj (Task 1) and `ResourceName` constant (Task 3).
+- Error messages `"CHANGELOG.md resource not embedded"` and `"CHANGELOG.md has no version entries"` — consistent across Task 3 implementation and Task 4 test assertion.
+- `--all` option name — consistent across Tasks 5, 6, 9.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -39,15 +39,22 @@ Two roadmap items being delivered together as the next minor release.
   before any command design — outcome may be a `covers` command or a
   documentation update, decided after investigation.
 
+### v0.3.x — .NET 10 LTS upgrade
+
+Scheduled for a v0.3.x patch after v0.3.0 ships.
+
+- **Upgrade target framework to .NET 10 LTS** — Move from `net8.0` to
+  `net10.0` once .NET 10 LTS is generally available. Verify AOT publish,
+  `System.CommandLine` 2.x compatibility, and `System.Text.Json`
+  source-gen behaviour. Spec/plan to follow.
+
 ---
 
 ## Ideas
 
 Not yet scoped — notes to pick up later.
 
-| Idea | Notes |
-|------|-------|
-| Upgrade to .NET 10 LTS | Move target framework from `net8.0` to `net10.0` once .NET 10 LTS is GA. Verify AOT publish, `System.CommandLine` 2.x compatibility, and `System.Text.Json` source-gen behaviour. Target: a v0.3.x patch after v0.3.0 ships. |
+_None currently. New ideas land here before getting scheduled into a release._
 
 ## Deferred features
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,9 +24,9 @@ compatibility, upload `relPath` + sanitize-drift coverage, batch-update verb fix
 
 ## In progress
 
-### v0.3.0 — Changelog command & cover handling
+### v0.3.0 — Changelog, cover handling & .NET 10 LTS
 
-Two roadmap items being delivered together as the next minor release.
+Three roadmap items being delivered together as the next minor release.
 
 - **`abs-cli changelog` command** — Print the most recent entry by default;
   `--all` prints the full file. Source of truth is the bundled
@@ -38,11 +38,6 @@ Two roadmap items being delivered together as the next minor release.
   interacts with `metadata covers` and `items update`. Scoping exercise
   before any command design — outcome may be a `covers` command or a
   documentation update, decided after investigation.
-
-### v0.3.x — .NET 10 LTS upgrade
-
-Scheduled for a v0.3.x patch after v0.3.0 ships.
-
 - **Upgrade target framework to .NET 10 LTS** — Move from `net8.0` to
   `net10.0` once .NET 10 LTS is generally available. Verify AOT publish,
   `System.CommandLine` 2.x compatibility, and `System.Text.Json`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,14 +22,32 @@ compatibility, upload `relPath` + sanitize-drift coverage, batch-update verb fix
 
 ---
 
+## In progress
+
+### v0.3.0 — Changelog command & cover handling
+
+Two roadmap items being delivered together as the next minor release.
+
+- **`abs-cli changelog` command** — Print the most recent entry by default;
+  `--all` prints the full file. Source of truth is the bundled
+  `CHANGELOG.md`, embedded in the assembly so the command works offline.
+  Spec: [docs/specs/2026-04-27-changelog-command.md](specs/2026-04-27-changelog-command.md).
+  Plan: [docs/plans/2026-04-27-changelog-command.md](plans/2026-04-27-changelog-command.md).
+- **Investigate cover handling** — How cover metadata upload works end-to-end:
+  which endpoints, request shapes, where ABS stores the image, how this
+  interacts with `metadata covers` and `items update`. Scoping exercise
+  before any command design — outcome may be a `covers` command or a
+  documentation update, decided after investigation.
+
+---
+
 ## Ideas
 
 Not yet scoped — notes to pick up later.
 
 | Idea | Notes |
 |------|-------|
-| Investigate cover handling | How cover metadata upload works end-to-end — which endpoints, request shapes, where ABS stores the image, how this interacts with `metadata covers` and `items update`. Scoping exercise before any command design. |
-| `abs-cli changelog` command | Print the most recent entry by default; a flag (e.g. `--all`) prints the full file. Source of truth is the bundled `CHANGELOG.md`. |
+| Upgrade to .NET 10 LTS | Move target framework from `net8.0` to `net10.0` once .NET 10 LTS is GA. Verify AOT publish, `System.CommandLine` 2.x compatibility, and `System.Text.Json` source-gen behaviour. Target: a v0.3.x patch after v0.3.0 ships. |
 
 ## Deferred features
 

--- a/docs/specs/2026-04-27-changelog-command.md
+++ b/docs/specs/2026-04-27-changelog-command.md
@@ -1,0 +1,205 @@
+# `abs-cli changelog` — design
+
+Status: approved 2026-04-27. Targets v0.3.0.
+
+## Summary
+
+Add a top-level `abs-cli changelog` command that prints release-note content
+from the bundled `CHANGELOG.md`. Default output is the latest version's entry;
+`--all` prints the full file. Output is raw markdown — readable by humans and
+parseable by AI agents using the file's `##` / `###` heading structure.
+
+Source of truth is the repo-root `CHANGELOG.md`, embedded into the assembly at
+build time so the command works offline and ships in a single artifact.
+
+## Motivation
+
+Listed on the roadmap. Agents and humans currently have no in-CLI way to ask
+"what changed in this version?" without leaving the terminal to read GitHub or
+the bundled file. Returning the authored markdown verbatim avoids re-encoding
+loss and keeps the command honest about its source.
+
+## Command surface
+
+```
+abs-cli changelog            # latest version's entry
+abs-cli changelog --all      # entire CHANGELOG.md
+```
+
+- Top-level command (sibling of `search`, `upload`, `tasks`, etc.).
+- One flag: `--all` (boolean). No value.
+- No login required. No network. Works offline.
+- Exit 0 on success. Non-zero only on internal misconfiguration (see below).
+
+## Output format
+
+Raw markdown, written to stdout via `Console.Out`. No JSON envelope, no
+ANSI rendering, no trailing prompt. The file's own structure is the contract:
+
+- `## <version> — <date>` introduces a release entry.
+- `### Highlights` / `### Features` / `### Fixes` / `### Docs` / `### Chores` /
+  `### Breaking changes` are the per-section sub-headings already used in the
+  file.
+
+The CLI does not parse subsections, reorder content, or add commentary.
+
+## Latest-entry extraction
+
+Algorithm for the default (no `--all`) path:
+
+1. Read the embedded `CHANGELOG.md` as UTF-8 text.
+2. Scan lines from top until the first line that starts with `## ` (two
+   hashes + space). This is the latest version heading.
+3. Emit that line and every subsequent line.
+4. Stop (exclusive) at the next line that starts with `## ` or at EOF.
+5. Trim trailing blank lines from the captured block.
+6. Write the result to stdout, terminated with a single newline.
+
+The `## ` heading line itself is included — it carries the version and date,
+which is the first thing an agent or human will want.
+
+`--all` simply writes the file verbatim.
+
+## Bundling
+
+`CHANGELOG.md` is embedded as an assembly manifest resource so it ships
+inside the AOT-published single-file binary.
+
+In `src/AbsCli/AbsCli.csproj`:
+
+```xml
+<ItemGroup>
+  <EmbeddedResource Include="..\..\CHANGELOG.md" LogicalName="CHANGELOG.md" />
+</ItemGroup>
+```
+
+The path is repo-relative so a single file remains the source of truth — the
+root `CHANGELOG.md` that contributors edit is the file the command serves.
+
+Read at runtime via:
+
+```csharp
+var stream = typeof(ChangelogCommand).Assembly
+    .GetManifestResourceStream("CHANGELOG.md");
+```
+
+## Components
+
+### `ChangelogCommand.cs` (new)
+
+Location: `src/AbsCli/Commands/ChangelogCommand.cs`.
+
+Responsibilities:
+- Define the `changelog` System.CommandLine `Command`.
+- Define the `--all` boolean option.
+- Set the handler: load resource → call `ChangelogReader.ReadAll` or
+  `ChangelogReader.ReadLatest` → write to stdout.
+- Wire help text (one-line description, examples). Follows the compact style
+  in `AuthorsCommand.cs` (the reference cited in `CLAUDE.md`).
+
+Registered alongside the other top-level commands wherever
+`Program.cs` / `RootCommand` composition currently lives.
+
+### `ChangelogReader` (new, static helper)
+
+Location: same file or `src/AbsCli/Services/ChangelogReader.cs` — pick whichever
+matches existing conventions for similarly small, command-local helpers.
+
+Two methods:
+
+```csharp
+public static string ReadAll();
+public static string ReadLatest();
+```
+
+`ReadAll` reads the embedded resource and returns its contents.
+`ReadLatest` reads the embedded resource, applies the extraction algorithm
+above, and returns the captured block.
+
+Both throw `InvalidOperationException` on failure modes below — never return
+empty/null.
+
+## Error handling
+
+Three failure modes, all internal misconfigurations rather than user errors:
+
+| Condition | Behavior |
+|-----------|----------|
+| `GetManifestResourceStream("CHANGELOG.md")` returns null | Throw `InvalidOperationException("CHANGELOG.md resource not embedded")` |
+| `ReadLatest` finds no line starting with `## ` | Throw `InvalidOperationException("CHANGELOG.md has no version entries")` |
+| Embedded file is empty | Same as previous |
+
+These propagate through the standard CLI error path (non-zero exit, stderr
+message). They cannot occur on a correctly built binary; the build/test
+pipeline is responsible for catching them, not end users.
+
+No user-input validation is needed — the only flag is a boolean and there is
+no network call.
+
+## Testing
+
+### Unit tests — `ChangelogReaderTests`
+
+Fixture: a small in-memory markdown string containing two `## ` entries and a
+preamble. Cover:
+
+- `ReadLatest` returns content starting with the topmost `## ` line.
+- `ReadLatest` stops before the second `## ` line.
+- `ReadLatest` includes `### ` sub-headings within the latest entry.
+- `ReadLatest` strips trailing blank lines from the captured block.
+- `ReadLatest` throws `InvalidOperationException` when input has no `## `.
+- `ReadAll` returns the input verbatim.
+
+(For these the helper needs a seam — either an internal overload that takes a
+string, or `ReadLatestFromString(string)` exposed via `InternalsVisibleTo`.
+Pick whichever fits existing patterns; the public `ReadLatest()` reads the
+embedded resource and delegates.)
+
+### Integration test
+
+Invoke the `changelog` command end-to-end through the same test host the other
+commands use. Assert:
+
+- stdout starts with `## ` (i.e. a version heading).
+- stdout contains the topmost version string from the actual repo
+  `CHANGELOG.md` (read the file directly in the test for the expected value).
+- Exit code is 0.
+- `--all` returns content whose length is greater than the default output's
+  length.
+
+### Self-test smoke
+
+Add a `Check` block to `SelfTestCommand.cs` that asserts:
+
+- `GetManifestResourceStream("CHANGELOG.md")` is non-null.
+- `ChangelogReader.ReadLatest()` returns a non-empty string starting with
+  `## `.
+
+This catches a build that silently drops the embedded resource.
+
+## Release-process integration
+
+`docs/release-process.md` (or wherever the version-bump checklist lives)
+should already have a "update CHANGELOG.md" step. No new step is needed —
+the embedded resource is rebuilt every time `dotnet publish` runs, so as long
+as `CHANGELOG.md` is updated before the release build, the shipped binary
+matches.
+
+## Out of scope (deferred)
+
+These were considered and explicitly rejected for v0.3.0. Add only when a real
+workflow demands them.
+
+- `--version <ver>` to fetch a specific historical entry.
+- `--versions <n>` to fetch the last N entries.
+- `--json` / structured output.
+- Pretty rendering via Spectre.Console.
+- Online fetch / GitHub release lookup.
+
+## Open questions
+
+- **Login bypass plumbing.** `changelog` does not require auth or network, so
+  it should not trip whatever pre-flight login check the other commands run.
+  The mechanism used by `self-test` and `--help` to skip that check needs to
+  be applied here too. Confirm the exact registration path during
+  implementation; no design impact expected.

--- a/src/AbsCli/AbsCli.csproj
+++ b/src/AbsCli/AbsCli.csproj
@@ -21,6 +21,10 @@
     <InternalsVisibleTo Include="AbsCli.Tests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\CHANGELOG.md" LogicalName="CHANGELOG.md" />
+  </ItemGroup>
+
   <!--
     Regenerates Commands/ResponseExamples.g.cs when any Models/*.cs or codegen
     tool source changes. Forward slashes only — MSBuild normalises them on

--- a/src/AbsCli/Commands/ChangelogCommand.cs
+++ b/src/AbsCli/Commands/ChangelogCommand.cs
@@ -20,7 +20,7 @@ public static class ChangelogCommand
         {
             var all = context.ParseResult.GetValueForOption(allOption);
             var output = all ? ChangelogReader.ReadAll() : ChangelogReader.ReadLatest();
-            context.Console.Out.Write(output + Environment.NewLine);
+            context.Console.Out.Write(output + "\n");
         });
         return command;
     }

--- a/src/AbsCli/Commands/ChangelogCommand.cs
+++ b/src/AbsCli/Commands/ChangelogCommand.cs
@@ -1,0 +1,26 @@
+using System.CommandLine;
+using AbsCli.Services;
+
+namespace AbsCli.Commands;
+
+public static class ChangelogCommand
+{
+    public static Command Create()
+    {
+        var allOption = new Option<bool>(
+            "--all",
+            "Print the entire CHANGELOG.md instead of just the latest entry");
+        var command = new Command(
+            "changelog",
+            "Print release notes from the bundled CHANGELOG.md") { allOption };
+        command.AddExamples(
+            "abs-cli changelog",
+            "abs-cli changelog --all");
+        command.SetHandler((bool all) =>
+        {
+            var output = all ? ChangelogReader.ReadAll() : ChangelogReader.ReadLatest();
+            Console.Out.WriteLine(output);
+        }, allOption);
+        return command;
+    }
+}

--- a/src/AbsCli/Commands/ChangelogCommand.cs
+++ b/src/AbsCli/Commands/ChangelogCommand.cs
@@ -16,11 +16,12 @@ public static class ChangelogCommand
         command.AddExamples(
             "abs-cli changelog",
             "abs-cli changelog --all");
-        command.SetHandler((bool all) =>
+        command.SetHandler((context) =>
         {
+            var all = context.ParseResult.GetValueForOption(allOption);
             var output = all ? ChangelogReader.ReadAll() : ChangelogReader.ReadLatest();
-            Console.Out.WriteLine(output);
-        }, allOption);
+            context.Console.Out.Write(output + Environment.NewLine);
+        });
         return command;
     }
 }

--- a/src/AbsCli/Commands/SelfTestCommand.cs
+++ b/src/AbsCli/Commands/SelfTestCommand.cs
@@ -438,6 +438,17 @@ public static class SelfTestCommand
                 Assert(sw.ToString().Trim() == "{\"raw\":true}", "raw passthrough failed");
             });
 
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("=== Embedded resources ===");
+
+            Check("CHANGELOG.md embedded and parseable", () =>
+            {
+                var latest = AbsCli.Services.ChangelogReader.ReadLatest();
+                Assert(!string.IsNullOrWhiteSpace(latest), "ReadLatest returned empty");
+                Assert(latest.StartsWith("## ", StringComparison.Ordinal),
+                    $"ReadLatest did not start with '## ': '{latest[..Math.Min(40, latest.Length)]}'");
+            });
+
             // Summary
             Console.Error.WriteLine("");
             Console.Error.WriteLine($"========================================");

--- a/src/AbsCli/Program.cs
+++ b/src/AbsCli/Program.cs
@@ -17,6 +17,7 @@ rootCommand.AddCommand(UploadCommand.Create());
 rootCommand.AddCommand(TasksCommand.Create());
 rootCommand.AddCommand(MetadataCommand.Create());
 rootCommand.AddCommand(SelfTestCommand.Create());
+rootCommand.AddCommand(ChangelogCommand.Create());
 
 var parser = new CommandLineBuilder(rootCommand)
     .UseDefaults()

--- a/src/AbsCli/Services/ChangelogReader.cs
+++ b/src/AbsCli/Services/ChangelogReader.cs
@@ -23,6 +23,7 @@ public static class ChangelogReader
             throw new InvalidOperationException("CHANGELOG.md has no version entries");
         }
 
+        changelog = changelog.Replace("\r\n", "\n");
         var lines = changelog.Split('\n');
         var startIndex = -1;
         for (var i = 0; i < lines.Length; i++)

--- a/src/AbsCli/Services/ChangelogReader.cs
+++ b/src/AbsCli/Services/ChangelogReader.cs
@@ -1,0 +1,81 @@
+using System.Text;
+
+namespace AbsCli.Services;
+
+public static class ChangelogReader
+{
+    private const string ResourceName = "CHANGELOG.md";
+
+    public static string ReadAll()
+    {
+        return ReadEmbeddedResource();
+    }
+
+    public static string ReadLatest()
+    {
+        return ExtractLatest(ReadEmbeddedResource());
+    }
+
+    internal static string ExtractLatest(string changelog)
+    {
+        if (string.IsNullOrEmpty(changelog))
+        {
+            throw new InvalidOperationException("CHANGELOG.md has no version entries");
+        }
+
+        var lines = changelog.Split('\n');
+        var startIndex = -1;
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].StartsWith("## ", StringComparison.Ordinal))
+            {
+                startIndex = i;
+                break;
+            }
+        }
+
+        if (startIndex < 0)
+        {
+            throw new InvalidOperationException("CHANGELOG.md has no version entries");
+        }
+
+        var endIndex = lines.Length;
+        for (var i = startIndex + 1; i < lines.Length; i++)
+        {
+            if (lines[i].StartsWith("## ", StringComparison.Ordinal))
+            {
+                endIndex = i;
+                break;
+            }
+        }
+
+        var lastNonBlank = endIndex - 1;
+        while (lastNonBlank > startIndex && string.IsNullOrWhiteSpace(lines[lastNonBlank]))
+        {
+            lastNonBlank--;
+        }
+
+        var sb = new StringBuilder();
+        for (var i = startIndex; i <= lastNonBlank; i++)
+        {
+            sb.Append(lines[i]);
+            if (i < lastNonBlank)
+            {
+                sb.Append('\n');
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static string ReadEmbeddedResource()
+    {
+        var assembly = typeof(ChangelogReader).Assembly;
+        using var stream = assembly.GetManifestResourceStream(ResourceName);
+        if (stream is null)
+        {
+            throw new InvalidOperationException("CHANGELOG.md resource not embedded");
+        }
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+}

--- a/tests/AbsCli.Tests/Commands/ChangelogCommandTests.cs
+++ b/tests/AbsCli.Tests/Commands/ChangelogCommandTests.cs
@@ -1,0 +1,81 @@
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.IO;
+using System.CommandLine.Parsing;
+using AbsCli.Commands;
+using Xunit;
+
+namespace AbsCli.Tests.Commands;
+
+public class ChangelogCommandTests
+{
+    private static int Invoke(TestConsole console, params string[] args)
+    {
+        var root = new RootCommand();
+        root.AddCommand(ChangelogCommand.Create());
+        var parser = new CommandLineBuilder(root)
+            .UseDefaults()
+            .Build();
+        return parser.Invoke(args, console);
+    }
+
+    private static string FirstVersionHeading()
+    {
+        // tests/AbsCli.Tests/bin/Debug/net8.0 -> repo root is four levels up.
+        // TrimEnd('/') normalises the trailing slash AppContext.BaseDirectory may include.
+        var dir = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, '/');
+        for (var i = 0; i < 7 && dir is not null; i++)
+        {
+            var candidate = Path.Combine(dir, "CHANGELOG.md");
+            if (File.Exists(candidate))
+            {
+                foreach (var line in File.ReadLines(candidate))
+                {
+                    if (line.StartsWith("## ", StringComparison.Ordinal))
+                    {
+                        return line;
+                    }
+                }
+                throw new InvalidOperationException("Repo CHANGELOG.md has no version heading");
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Could not locate repo CHANGELOG.md from test base directory");
+    }
+
+    [Fact]
+    public void Default_PrintsLatestEntryStartingAtTopmostHeading()
+    {
+        var console = new TestConsole();
+        var exit = Invoke(console, "changelog");
+        var stdout = console.Out.ToString() ?? "";
+
+        Assert.Equal(0, exit);
+        Assert.StartsWith(FirstVersionHeading(), stdout);
+    }
+
+    [Fact]
+    public void All_PrintsFullFileStartingWithTopHeader()
+    {
+        var console = new TestConsole();
+        var exit = Invoke(console, "changelog", "--all");
+        var stdout = console.Out.ToString() ?? "";
+
+        Assert.Equal(0, exit);
+        Assert.StartsWith("# Changelog", stdout);
+    }
+
+    [Fact]
+    public void All_OutputIsLongerThanDefault()
+    {
+        var defaultConsole = new TestConsole();
+        Invoke(defaultConsole, "changelog");
+        var allConsole = new TestConsole();
+        Invoke(allConsole, "changelog", "--all");
+
+        var defaultLen = (defaultConsole.Out.ToString() ?? "").Length;
+        var allLen = (allConsole.Out.ToString() ?? "").Length;
+        Assert.True(allLen > defaultLen,
+            $"--all output ({allLen} chars) should be longer than default ({defaultLen})");
+    }
+}

--- a/tests/AbsCli.Tests/Commands/ChangelogCommandTests.cs
+++ b/tests/AbsCli.Tests/Commands/ChangelogCommandTests.cs
@@ -21,15 +21,16 @@ public class ChangelogCommandTests
 
     private static string FirstVersionHeading()
     {
-        // tests/AbsCli.Tests/bin/Debug/net8.0 -> repo root is four levels up.
-        // TrimEnd('/') normalises the trailing slash AppContext.BaseDirectory may include.
+        // Walk up from the test assembly's base directory until we find AbsCli.sln,
+        // which marks the repo root. No fixed depth cap — the walk terminates at
+        // the filesystem root.
         var dir = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, '/');
-        for (var i = 0; i < 7 && dir is not null; i++)
+        while (dir is not null)
         {
-            var candidate = Path.Combine(dir, "CHANGELOG.md");
-            if (File.Exists(candidate))
+            if (File.Exists(Path.Combine(dir, "AbsCli.sln")))
             {
-                foreach (var line in File.ReadLines(candidate))
+                var changelog = Path.Combine(dir, "CHANGELOG.md");
+                foreach (var line in File.ReadLines(changelog))
                 {
                     if (line.StartsWith("## ", StringComparison.Ordinal))
                     {
@@ -40,7 +41,7 @@ public class ChangelogCommandTests
             }
             dir = Path.GetDirectoryName(dir);
         }
-        throw new InvalidOperationException("Could not locate repo CHANGELOG.md from test base directory");
+        throw new InvalidOperationException("Could not locate AbsCli.sln from test base directory");
     }
 
     [Fact]

--- a/tests/AbsCli.Tests/Commands/ChangelogReaderTests.cs
+++ b/tests/AbsCli.Tests/Commands/ChangelogReaderTests.cs
@@ -1,0 +1,32 @@
+using AbsCli.Services;
+using Xunit;
+
+namespace AbsCli.Tests.Commands;
+
+public class ChangelogReaderTests
+{
+    private const string TwoEntries =
+        "# Changelog\n" +
+        "\n" +
+        "All notable changes are documented here.\n" +
+        "\n" +
+        "## 0.2.7 — 2026-04-24\n" +
+        "\n" +
+        "### Highlights\n" +
+        "- latest highlight\n" +
+        "\n" +
+        "### Fixes\n" +
+        "- fix: latest fix\n" +
+        "\n" +
+        "## 0.2.6 — 2026-04-24\n" +
+        "\n" +
+        "### Highlights\n" +
+        "- older highlight\n";
+
+    [Fact]
+    public void ExtractLatest_ReturnsBlockStartingAtTopmostVersionHeading()
+    {
+        var result = ChangelogReader.ExtractLatest(TwoEntries);
+        Assert.StartsWith("## 0.2.7 — 2026-04-24", result);
+    }
+}

--- a/tests/AbsCli.Tests/Commands/ChangelogReaderTests.cs
+++ b/tests/AbsCli.Tests/Commands/ChangelogReaderTests.cs
@@ -29,4 +29,45 @@ public class ChangelogReaderTests
         var result = ChangelogReader.ExtractLatest(TwoEntries);
         Assert.StartsWith("## 0.2.7 — 2026-04-24", result);
     }
+
+    [Fact]
+    public void ExtractLatest_StopsBeforeNextVersionHeading()
+    {
+        var result = ChangelogReader.ExtractLatest(TwoEntries);
+        Assert.DoesNotContain("## 0.2.6", result);
+        Assert.DoesNotContain("older highlight", result);
+    }
+
+    [Fact]
+    public void ExtractLatest_IncludesSubHeadingsWithinLatestEntry()
+    {
+        var result = ChangelogReader.ExtractLatest(TwoEntries);
+        Assert.Contains("### Highlights", result);
+        Assert.Contains("### Fixes", result);
+        Assert.Contains("- latest highlight", result);
+        Assert.Contains("- fix: latest fix", result);
+    }
+
+    [Fact]
+    public void ExtractLatest_TrimsTrailingBlankLines()
+    {
+        var input =
+            "## 1.0.0 — 2026-01-01\n" +
+            "\n" +
+            "body\n" +
+            "\n" +
+            "\n";
+        var result = ChangelogReader.ExtractLatest(input);
+        Assert.EndsWith("body", result);
+        Assert.False(result.EndsWith("\n", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ExtractLatest_ThrowsWhenNoVersionHeadingPresent()
+    {
+        var input = "# Changelog\n\nNo entries yet.\n";
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ChangelogReader.ExtractLatest(input));
+        Assert.Equal("CHANGELOG.md has no version entries", ex.Message);
+    }
 }


### PR DESCRIPTION
## Summary

- Add top-level `abs-cli changelog` command. Default output is the latest version's entry from the bundled `CHANGELOG.md`; `--all` prints the full file. Output is raw markdown — readable by humans, parseable by AI agents.
- Embed `CHANGELOG.md` as an assembly manifest resource so the command works offline and ships in the AOT-published single-file binary. New self-test check guards against a future build dropping the resource.
- Restructure the roadmap: new `## In progress` → `### v0.3.0` section scoping three items (changelog command, cover-handling investigation, .NET 10 LTS upgrade). Ideas table emptied.

`CHANGELOG.md` itself is intentionally **not** edited in this PR — that file is owned by the release workflow on `release/v{version}` branches.

Spec: `docs/specs/2026-04-27-changelog-command.md` · Plan: `docs/plans/2026-04-27-changelog-command.md`.

## Test plan

- [x] 5 unit tests cover the `ExtractLatest` rules (start, stop, sub-headings, trim, throw-on-empty)
- [x] 3 integration tests exercise the command end-to-end through the System.CommandLine parser
- [x] Self-test reports \`PASS: CHANGELOG.md embedded and parseable\` (34 / 34)
- [x] Full unit-test suite green (103 / 103)
- [x] \`dotnet format --verify-no-changes\` clean
- [x] AOT Release publish: \`abs-cli changelog\` and \`abs-cli self-test\` both work from the published binary
- [ ] Reviewer: pull the branch, run \`abs-cli changelog | head -1\`, confirm output starts with the topmost \`## \` heading from \`CHANGELOG.md\` on \`main\` (currently \`## 0.2.7 — 2026-04-24\`)