### PR TITLE
chore: upgrade libraries and add dependency security gate

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <WarningsAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/docs/plans/2026-04-28-library-upgrades-and-security.md
+++ b/docs/plans/2026-04-28-library-upgrades-and-security.md
@@ -1,0 +1,665 @@
+# General library upgrades + dependency security — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Special handling — forced human handoff at Task 1.** Task 1 asks the operator to flip two GitHub repo Settings switches (Dependabot alerts + security updates). The orchestrator MUST stop, surface the prompt, and wait for confirmation before dispatching Task 2. A subagent that hits this handoff reports `BLOCKED_ON_USER_GITHUB_SETTINGS`; do not auto-continue.
+
+**Goal:** Bump all NuGet dependencies off long-stale pins (System.CommandLine 2.0.0-beta4 → 2.0.7, xUnit 2.5.3 → xunit.v3 3.2.2, Test SDK + coverlet to current stable), add a build-time NuGet Audit gate, and enable GitHub Dependabot vulnerability tooling — all in one PR with logically separated commits.
+
+**Architecture:** Three concerns delivered in sequence. Concern 1 is a new repo-root `Directory.Build.props` that turns NuGet Audit warnings into errors for all three csproj. Concern 2 swaps `xunit` for `xunit.v3` and bumps siblings. Concern 3 rewrites every command file plus `HelpExtensions.cs` and `Program.cs` against System.CommandLine 2.0's new API (`CommandLineConfiguration`, `SetAction`, `ParseResult.GetValue`, action-based help). Each concern is one commit (Concern 3 is the big one and may split if its diff is unreasonable). GitHub-side, Dependabot alerts and security updates are enabled via repo Settings (no `dependabot.yml` in the branch — vuln-only policy).
+
+**Tech Stack:** C# / .NET 10 / `System.CommandLine` 2.0.7 (target) / `xunit.v3` 3.2.2 (target) / `Microsoft.NET.Test.Sdk` + `coverlet.collector` (current stable) / NuGet Audit (built into SDK) / GitHub Dependabot (out-of-band).
+
+**Spec:** [docs/specs/2026-04-28-library-upgrades-and-security.md](../specs/2026-04-28-library-upgrades-and-security.md)
+
+---
+
+## File Structure
+
+**New files:**
+
+- `Directory.Build.props` (repo root) — NuGet Audit policy inherited by all three csproj.
+
+**Modified files:**
+
+- `src/AbsCli/AbsCli.csproj` — bump `System.CommandLine` from `2.0.0-beta4.22272.1` to `2.0.7`.
+- `tests/AbsCli.Tests/AbsCli.Tests.csproj` — replace `xunit` and `xunit.runner.visualstudio` (both 2.5.3) with `xunit.v3` 3.2.2 and its v3 runner; bump `Microsoft.NET.Test.Sdk` and `coverlet.collector` to current stable.
+- `src/AbsCli/Program.cs` — replace `CommandLineBuilder(...).UseDefaults().UseCustomHelpSections().Build()` invocation pipeline with the SCL 2.0 `CommandLineConfiguration` model.
+- `src/AbsCli/Commands/HelpExtensions.cs` — rewrite `UseCustomHelpSections` against the SCL 2.0 help model (action-based help; layout customisation moved). Public API surface that other commands use (`AddHelpSection`, `AddExamples`, `AddResponseExample<T>`, `AddResponseExample(Type, Type)`, `AddMediaUnionShapes`, `AddCommand` etc.) preserves its current signatures so command files don't need behavioural changes.
+- All `src/AbsCli/Commands/*.cs` (15 files) — `command.SetHandler(...)` → `command.SetAction(parseResult => …)`, `parseResult.GetValueForOption(opt)` → `parseResult.GetValue(opt)`. Mechanical pass.
+- `tests/AbsCli.Tests/Commands/HelpExtensionsTests.cs` — replace `CommandLineBuilder` usage with the 2.0 invocation model.
+- `tests/AbsCli.Tests/Commands/HelpOutputTests.cs` — same.
+- `tests/AbsCli.Tests/Commands/ChangelogCommandTests.cs` — same.
+
+**Files explicitly NOT modified:**
+
+- `CHANGELOG.md` — owned by release workflow.
+- `.github/workflows/build.yml` — no CI changes; existing gates suffice.
+- `.github/dependabot.yml` — not added (vuln-only policy).
+
+---
+
+## Task 0: Branch + spec/plan commit
+
+**Files:** none new for this step.
+
+- [ ] **Step 1: Confirm clean tree on main**
+
+```bash
+cd /workspaces/abs-cli
+git checkout main
+git pull
+git status
+```
+
+Expected: `On branch main`, working tree clean (gitignored `.mempalace/` is fine).
+
+- [ ] **Step 2: Create the branch**
+
+```bash
+git checkout -b feat/library-upgrades-and-security
+```
+
+- [ ] **Step 3: Commit the spec and plan together**
+
+```bash
+git add docs/specs/2026-04-28-library-upgrades-and-security.md docs/plans/2026-04-28-library-upgrades-and-security.md
+git commit -m "docs: add spec and plan for library upgrades and dependency security"
+```
+
+---
+
+## Task 1: GitHub Settings handoff — STOP and prompt operator
+
+This task has no commit. The operator must enable two GitHub repo Settings switches before any code work begins. Implementation cannot proceed otherwise (the spec's whole point is that vuln coverage is live by the time bumps land).
+
+**Files:** none.
+
+- [ ] **Step 1: STOP — surface prompt to operator verbatim**
+
+Output to the user:
+
+> **GitHub repo Settings change required.** Before I do any code work on this branch, please enable these two switches at `https://github.com/thomaslazar/abs-cli/settings/security_analysis`:
+>
+> 1. **Dependabot alerts** → Enable
+> 2. **Dependabot security updates** → Enable
+>
+> Both should show "Enabled" once flipped. No `dependabot.yml` is added — these settings give us alerts in the Security tab and auto-PRs only when a published advisory has a fix. Reply when both are on and I'll continue with Task 2.
+
+If running under subagent-driven development: the implementer subagent reports `BLOCKED_ON_USER_GITHUB_SETTINGS` here. The orchestrator surfaces the prompt and does **not** dispatch Task 2 until the operator confirms.
+
+---
+
+## Task 2: Add NuGet Audit policy
+
+Adds the repo-wide vuln-checking gate. If the current package set has any known vulns, this build will fail — flag immediately as a finding.
+
+**Files:**
+- Create: `Directory.Build.props` (repo root)
+
+- [ ] **Step 1: Create `Directory.Build.props`**
+
+At `/workspaces/abs-cli/Directory.Build.props`:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <WarningsAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
+  </PropertyGroup>
+</Project>
+```
+
+- [ ] **Step 2: Restore and build to confirm baseline is clean**
+
+```bash
+dotnet restore /workspaces/abs-cli/AbsCli.sln
+dotnet build /workspaces/abs-cli/AbsCli.sln -c Debug
+```
+
+Expected: build succeeds with 0 errors. `NU1901`/`NU1902`/`NU1903`/`NU1904` warnings (now promoted to errors) must be absent. If any fire, the pre-existing dep set has a known vuln — STOP and report the finding to the operator before continuing. Do not "fix" by silencing the warning code.
+
+- [ ] **Step 3: Run unit tests**
+
+```bash
+dotnet test /workspaces/abs-cli/AbsCli.sln
+```
+
+Expected: 103 / 103 pass.
+
+- [ ] **Step 4: Format check**
+
+```bash
+dotnet format /workspaces/abs-cli/AbsCli.sln --verify-no-changes
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Directory.Build.props
+git commit -m "chore: add NuGet Audit policy"
+```
+
+---
+
+## Task 3: Bump test packages to xUnit v3
+
+Replaces `xunit` 2.5.3 with `xunit.v3` 3.2.2 (+ matching v3 runner) and bumps `Microsoft.NET.Test.Sdk` + `coverlet.collector` to current stable. Test source code may need adjustments per the xUnit v3 migration guide.
+
+**Files:**
+- Modify: `tests/AbsCli.Tests/AbsCli.Tests.csproj`
+- Modify (likely): `tests/AbsCli.Tests/**/*.cs` if v3 migration requires it
+
+- [ ] **Step 1: Edit `tests/AbsCli.Tests/AbsCli.Tests.csproj`**
+
+Replace the `<ItemGroup>` containing the four package references:
+
+```xml
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+```
+
+with the v3 equivalents at current stable versions. Run:
+
+```bash
+cd /workspaces/abs-cli/tests/AbsCli.Tests
+dotnet remove package xunit
+dotnet remove package xunit.runner.visualstudio
+dotnet add package xunit.v3 --version 3.2.2
+dotnet add package xunit.v3.assert --version 3.2.2
+dotnet add package xunit.runner.visualstudio
+dotnet add package Microsoft.NET.Test.Sdk
+dotnet add package coverlet.collector
+```
+
+The `xunit.v3.assert` package may already be a transitive of `xunit.v3` — if `dotnet add` reports it's redundant, drop that line. The `xunit.runner.visualstudio` line resolves to the latest v3-compatible runner; if NuGet picks an old v2 build, pin explicitly to whatever the xUnit v3 release notes recommend.
+
+After the `dotnet add` commands, `tests/AbsCli.Tests/AbsCli.Tests.csproj` should have exact-version `<PackageReference>` entries for each package. Verify with:
+
+```bash
+grep -n PackageReference /workspaces/abs-cli/tests/AbsCli.Tests/AbsCli.Tests.csproj
+```
+
+Expected: each `Version` is exact (e.g. `Version="3.2.2"`, not `Version="3.*"` or floating).
+
+- [ ] **Step 2: Restore + build**
+
+```bash
+dotnet restore /workspaces/abs-cli/AbsCli.sln
+dotnet build /workspaces/abs-cli/AbsCli.sln -c Debug
+```
+
+If build errors fire from xUnit v3 changes, fix inline:
+
+- Namespace import differences — most v3 code keeps `using Xunit;` but a few classes moved.
+- `[Theory]` data-source attribute changes if any (we don't currently use `[Theory]`).
+- `Assert.*` signature changes if any (the project uses `Equal`, `True`, `False`, `Throws`, `StartsWith`, `EndsWith`, `Contains`, `DoesNotContain` — all stable across v2/v3).
+- `IClassFixture<T>` patterns if any (we don't currently use them).
+
+Reference: `https://xunit.net/docs/getting-started/v3/migration`. Apply only the migrations the build errors actually demand — don't proactively modernise tests beyond what compiling requires.
+
+- [ ] **Step 3: Run unit tests**
+
+```bash
+dotnet test /workspaces/abs-cli/AbsCli.sln
+```
+
+Expected: 103 / 103 pass. xUnit v3 may print a different summary line format; the count must remain 103.
+
+- [ ] **Step 4: Format check**
+
+```bash
+dotnet format /workspaces/abs-cli/AbsCli.sln --verify-no-changes
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/AbsCli.Tests/AbsCli.Tests.csproj
+# Add any test-source files that needed migration adjustments:
+git add tests/AbsCli.Tests/
+git commit -m "chore: bump test packages to xUnit v3"
+```
+
+---
+
+## Task 4: Bump System.CommandLine to 2.0.7 (atomic migration)
+
+The big one. The package bump alone breaks the build until every consumer is migrated. This task is one commit because partial migration doesn't compile. Internal sub-steps are sequenced for sanity but no intermediate commits.
+
+**Files:**
+- Modify: `src/AbsCli/AbsCli.csproj`
+- Modify: `src/AbsCli/Program.cs`
+- Modify: `src/AbsCli/Commands/HelpExtensions.cs`
+- Modify: All 15 files matching `src/AbsCli/Commands/*.cs` (except `HelpExtensions.cs` and `ResponseExamples.g.cs`)
+- Modify: `tests/AbsCli.Tests/Commands/HelpExtensionsTests.cs`
+- Modify: `tests/AbsCli.Tests/Commands/HelpOutputTests.cs`
+- Modify: `tests/AbsCli.Tests/Commands/ChangelogCommandTests.cs`
+
+- [ ] **Step 1: Bump the package version**
+
+In `src/AbsCli/AbsCli.csproj`, change:
+
+```xml
+<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+```
+
+to:
+
+```xml
+<PackageReference Include="System.CommandLine" Version="2.0.7" />
+```
+
+- [ ] **Step 2: Restore and observe the failure surface**
+
+```bash
+dotnet restore /workspaces/abs-cli/AbsCli.sln
+dotnet build /workspaces/abs-cli/AbsCli.sln -c Debug 2>&1 | head -50
+```
+
+Expected: many compiler errors. Read them — they tell you exactly which APIs need updating. The most common ones in this codebase will be:
+
+- `'CommandLineBuilder' does not exist` — used in `Program.cs` and three test files.
+- `'Command.SetHandler' has no equivalent overload` — used in every command file.
+- `'ParseResult.GetValueForOption' is obsolete or missing` — used in `ChangelogCommand.cs` (recent) and possibly elsewhere.
+- `'HelpBuilder.Default.GetLayout' / HelpSectionDelegate / HelpContext` — used in `HelpExtensions.cs`.
+
+- [ ] **Step 3: Migrate `src/AbsCli/Program.cs`**
+
+The current pattern:
+
+```csharp
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Parsing;
+using AbsCli.Commands;
+
+var rootCommand = new RootCommand("abs-cli — Audiobookshelf CLI");
+
+rootCommand.AddCommand(LoginCommand.Create());
+// ... 12 more AddCommand calls
+
+var parser = new CommandLineBuilder(rootCommand)
+    .UseDefaults()
+    .UseCustomHelpSections()
+    .Build();
+
+return await parser.InvokeAsync(args);
+```
+
+Migrate to the SCL 2.0 model. The exact shape depends on what the new API looks like at 2.0.7 — consult the official migration guide (`https://learn.microsoft.com/en-us/dotnet/standard/commandline/migrate-2.0-rc`) and 2.0.7 release notes. Target shape (subject to API surface):
+
+```csharp
+using System.CommandLine;
+using AbsCli.Commands;
+
+var rootCommand = new RootCommand("abs-cli — Audiobookshelf CLI");
+
+rootCommand.Subcommands.Add(LoginCommand.Create());
+// ... 12 more Subcommands.Add calls
+
+var configuration = new CommandLineConfiguration(rootCommand);
+HelpExtensions.ApplyCustomHelpSections(configuration);   // or whatever the new entrypoint is
+
+return await rootCommand.Parse(args, configuration).InvokeAsync();
+```
+
+The `AddCommand` method may still exist as a compat alias, in which case keeping `AddCommand` is fine. Prefer the new collection-init / `Subcommands.Add` pattern only if `AddCommand` is gone.
+
+- [ ] **Step 4: Migrate `src/AbsCli/Commands/HelpExtensions.cs`**
+
+This is the most invasive change. The current file uses beta4's `CommandLineBuilder.UseHelp(ctx => …)` + `HelpBuilder.CustomizeLayout` + `HelpSectionDelegate` + `HelpContext`. SCL 2.0 replaces this with action-based help — a `HelpAction` (or similar) on each command, customisable via the action's hook points.
+
+Public API the rest of the codebase calls — these signatures must remain unchanged:
+
+- `Command.AddHelpSection(string title, params string[] lines)`
+- `Command.AddHelpSection(string title, HelpSectionPosition position, params string[] lines)`
+- `Command.AddExamples(params string[] examples)`
+- `Command.GetExampleCount()`
+- `Command.AddResponseExample<T>()`
+- `Command.AddResponseExample(Type envelopeType, Type elementType)`
+- `Command.AddMediaUnionShapes()`
+
+Internal only:
+- `HelpExtensions.UseCustomHelpSections(this CommandLineBuilder builder)` is the entry point that gets called from `Program.cs`. Replace with whatever shape `Program.cs` ends up needing — likely a method like `ApplyCustomHelpSections(CommandLineConfiguration config)` or per-command `AttachCustomHelp(this Command command)` invoked recursively from `Program.cs`.
+
+The behaviour to preserve:
+
+- Top-positioned sections render before the default help layout.
+- Bottom-positioned sections render after Options.
+- Sections in the same position render in registration order.
+- Section format: `Title:` line, then `  ` (two-space)-indented lines, then a blank line.
+
+`HelpOutputTests` and `HelpExtensionsTests` already encode the expected output shape — they're your regression check after the rewrite.
+
+If the new help-action model can't reproduce the top-vs-bottom positioning 1:1, escalate as a design decision before proceeding (the test files will fail and you'll need direction).
+
+- [ ] **Step 5: Migrate the command files**
+
+For each of the 15 files in `src/AbsCli/Commands/` (excluding `HelpExtensions.cs` and `ResponseExamples.g.cs`):
+
+1. `AuthorsCommand.cs`
+2. `BackupCommand.cs`
+3. `ChangelogCommand.cs`
+4. `CommandHelper.cs`
+5. `ConfigCommand.cs`
+6. `ItemsCommand.cs`
+7. `LibrariesCommand.cs`
+8. `LoginCommand.cs`
+9. `MetadataCommand.cs`
+10. `SearchCommand.cs`
+11. `SelfTestCommand.cs`
+12. `SeriesCommand.cs`
+13. `TasksCommand.cs`
+14. `UploadCommand.cs`
+
+Apply these mechanical replacements:
+
+| Pattern | Replacement |
+|---------|-------------|
+| `command.SetHandler(handler, opt1, opt2, ...)` (positional binding) | `command.SetAction(parseResult => { var v1 = parseResult.GetValue(opt1); var v2 = parseResult.GetValue(opt2); … return handler(v1, v2, …); });` |
+| `command.SetHandler((InvocationContext ctx) => …)` | `command.SetAction(parseResult => …)` — drop `InvocationContext`; everything you need is on `ParseResult` |
+| `parseResult.GetValueForOption(opt)` | `parseResult.GetValue(opt)` |
+| `parseResult.GetValueForArgument(arg)` | `parseResult.GetValue(arg)` |
+| `context.Console.Out.Write(...)` (in `ChangelogCommand.cs`) | Use the SCL 2.0 equivalent — likely `parseResult.Configuration.Output.Write(...)` or just `Console.Out.Write(...)` again now that the `TestConsole`-vs-real-console issue may be moot under the new model |
+
+`ChangelogCommand.cs` specifically: the existing code uses `context.Console.Out.Write(output + "\n")` because that's how `TestConsole` capture worked under beta4. Under SCL 2.0 the test-console pattern likely changed too. Update this command and the corresponding `ChangelogCommandTests.cs` test together; the test must still capture the output somehow. If the new model doesn't expose a console-injection point, fall back to `Console.SetOut(writer)` in the test.
+
+`SelfTestCommand.cs` uses `command.SetHandler(() => …)` (no parameters) — the parameterless form. Migrate to `command.SetAction(parseResult => …)`.
+
+- [ ] **Step 6: Migrate the three test files using `CommandLineBuilder`**
+
+`tests/AbsCli.Tests/Commands/HelpExtensionsTests.cs`, `HelpOutputTests.cs`, `ChangelogCommandTests.cs` all wrap a `RootCommand` in a `CommandLineBuilder().UseDefaults().UseCustomHelpSections().Build()` and `parser.Invoke(args, console)`. Migrate each to the SCL 2.0 invocation model:
+
+```csharp
+// before
+var root = new RootCommand();
+root.AddCommand(SomeCommand.Create());
+var parser = new CommandLineBuilder(root).UseDefaults().UseCustomHelpSections().Build();
+parser.Invoke(args, console);
+
+// after (approximate — verify against 2.0.7 API)
+var root = new RootCommand();
+root.Subcommands.Add(SomeCommand.Create());
+var configuration = new CommandLineConfiguration(root) { Output = console.Out };
+HelpExtensions.ApplyCustomHelpSections(configuration);
+root.Parse(args, configuration).Invoke();
+```
+
+The `TestConsole` type from beta4's `System.CommandLine.IO` may be removed in 2.0. If so, replace with `StringWriter` redirected via the new `Configuration.Output` property (or whatever the field is named). Each test's assertion shape — `Assert.StartsWith`, `Assert.Contains` etc. — stays the same; only the plumbing changes.
+
+- [ ] **Step 7: Build clean**
+
+```bash
+dotnet build /workspaces/abs-cli/AbsCli.sln -c Debug
+```
+
+Expected: 0 errors, 0 warnings. Iterate on Steps 3-6 until clean.
+
+- [ ] **Step 8: Run unit tests**
+
+```bash
+dotnet test /workspaces/abs-cli/AbsCli.sln
+```
+
+Expected: 103 / 103 pass. The `HelpOutputTests` set is the regression check on the help-section rewrite — every assertion there must pass.
+
+- [ ] **Step 9: Format check**
+
+```bash
+dotnet format /workspaces/abs-cli/AbsCli.sln
+dotnet format /workspaces/abs-cli/AbsCli.sln --verify-no-changes
+```
+
+Expected: `--verify-no-changes` exits 0.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/AbsCli/AbsCli.csproj src/AbsCli/Program.cs src/AbsCli/Commands/ tests/AbsCli.Tests/Commands/
+git commit -m "chore: bump System.CommandLine to 2.0.7"
+```
+
+If the diff is large enough to be unreviewable as one commit (e.g. > 800 lines), split using `git reset HEAD~1` and re-stage in chunks:
+
+```bash
+git reset HEAD~1   # un-commit but keep changes staged
+git add src/AbsCli/AbsCli.csproj src/AbsCli/Program.cs src/AbsCli/Commands/HelpExtensions.cs
+git commit -m "chore: bump System.CommandLine to 2.0.7 — parser + help foundation"
+git add src/AbsCli/Commands/
+git commit -m "chore: migrate command files to System.CommandLine 2.0 API"
+git add tests/
+git commit -m "test: migrate test files to System.CommandLine 2.0 API"
+```
+
+Decide based on the actual diff size. Default is one commit unless diff > 800 lines.
+
+---
+
+## Task 5: Local AOT publish + self-test
+
+Verifies the SCL 2.0 migration didn't introduce AOT regressions. Most likely place for surprises: the new help-action model may require new trim hints.
+
+**Files:** none.
+
+- [ ] **Step 1: AOT publish for linux-x64**
+
+```bash
+dotnet publish /workspaces/abs-cli/src/AbsCli/AbsCli.csproj -c Release -r linux-x64 --self-contained true /p:PublishAot=true
+```
+
+Expected: completes with no errors and no new trim warnings beyond what we already see on `main` today.
+
+- [ ] **Step 2: Locate the binary**
+
+```bash
+ls -lh /workspaces/abs-cli/src/AbsCli/bin/Release/net10.0/linux-x64/publish/abs-cli
+```
+
+Expected: file exists. Size in the 9-11 MB range.
+
+- [ ] **Step 3: Run `--version`**
+
+```bash
+/workspaces/abs-cli/src/AbsCli/bin/Release/net10.0/linux-x64/publish/abs-cli --version
+```
+
+Expected: prints `0.2.7` (or whatever `<Version>` is in `AbsCli.csproj`).
+
+- [ ] **Step 4: Run `--help`**
+
+```bash
+/workspaces/abs-cli/src/AbsCli/bin/Release/net10.0/linux-x64/publish/abs-cli --help
+```
+
+Expected: command list renders. Top-level help should look the same as before the migration. Spot-check two or three command-level help outputs:
+
+```bash
+/workspaces/abs-cli/src/AbsCli/bin/Release/net10.0/linux-x64/publish/abs-cli authors --help
+/workspaces/abs-cli/src/AbsCli/bin/Release/net10.0/linux-x64/publish/abs-cli items list --help
+/workspaces/abs-cli/src/AbsCli/bin/Release/net10.0/linux-x64/publish/abs-cli changelog --help
+```
+
+Each should show the same Notes / Examples / Response shape sections as before the SCL bump. If a section is missing or out of position, that's a regression in the help-extension rewrite — fix in Task 4 and republish.
+
+- [ ] **Step 5: Run `self-test`**
+
+```bash
+/workspaces/abs-cli/src/AbsCli/bin/Release/net10.0/linux-x64/publish/abs-cli self-test
+```
+
+Expected: 34 / 34 pass.
+
+- [ ] **Step 6: Run `changelog`**
+
+```bash
+/workspaces/abs-cli/src/AbsCli/bin/Release/net10.0/linux-x64/publish/abs-cli changelog | head -1
+```
+
+Expected: stdout starts with `## ` (the topmost heading from the embedded `CHANGELOG.md`).
+
+This task produces no commit.
+
+---
+
+## Task 6: Live smoke test against ABS
+
+End-to-end exercise of the AOT binary against a real ABS API. The migrated SCL parser handles every command-line argument the smoke suite throws at it, so this is the integration check.
+
+**Files:** none.
+
+- [ ] **Step 1: Bring up dockerised ABS**
+
+```bash
+docker compose -f /workspaces/abs-cli/docker/docker-compose.yml up -d
+```
+
+- [ ] **Step 2: Resolve container IP**
+
+```bash
+ABS_IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+echo "ABS_IP=$ABS_IP"
+```
+
+Use the IP, not `host.docker.internal`, per the project's docker-host-IP guidance. If the container name differs:
+
+```bash
+docker ps --format '{{.Names}}' | grep audiobookshelf
+```
+
+- [ ] **Step 3: Wait for ABS readiness**
+
+```bash
+for i in $(seq 1 30); do
+    curl -sf "http://$ABS_IP/healthcheck" > /dev/null && echo "ready after ${i}s" && break
+    sleep 1
+done
+```
+
+Expected: ready within 30 seconds.
+
+- [ ] **Step 4: Seed test data**
+
+```bash
+ABS_URL=http://$ABS_IP bash /workspaces/abs-cli/docker/seed.sh
+```
+
+Expected: completes with no errors. Reports library ID, test creds.
+
+- [ ] **Step 5: Run smoke suite**
+
+```bash
+ABS_URL=http://$ABS_IP \
+CLI=/workspaces/abs-cli/src/AbsCli/bin/Release/net10.0/linux-x64/publish/abs-cli \
+bash /workspaces/abs-cli/docker/smoke-test.sh
+```
+
+Expected: tail summary `Results: 116 passed, 0 failed`. Any failure means the SCL migration introduced a behavioural change in argument parsing or output — diagnose, fix, republish, retest.
+
+- [ ] **Step 6: Tear down ABS**
+
+```bash
+docker compose -f /workspaces/abs-cli/docker/docker-compose.yml down
+```
+
+This task produces no commit.
+
+---
+
+## Task 7: Push branch and verify CI
+
+The 6-platform CI matrix is the final merge gate. Same drill as the .NET 10 PR.
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/library-upgrades-and-security
+```
+
+- [ ] **Step 2: Open PR**
+
+Use `gh pr create`. Title: `chore: upgrade libraries and add dependency security gate`. Body should mention:
+
+- Three concerns: NuGet Audit + Dependabot, test packages → xUnit v3, System.CommandLine → 2.0.7
+- GitHub Settings switches enabled out-of-band (call out so reviewer doesn't think they're missing)
+- Local verification: 103 unit tests, 34 self-test, AOT publish, 116-assertion live smoke
+- Reviewer to-do: pull, rebuild dev container if base image changed (it didn't on this branch), run tests locally
+
+Per `CLAUDE.md`: no `Co-Authored-By`, no AI-attribution footer. Present PR URL as a clickable link to the user.
+
+- [ ] **Step 3: Watch CI**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: all 8 jobs (`unit-test`, `smoke-test`, 6 `build` matrix entries) green. `update-homebrew` skipped (release-only).
+
+If a platform fails, diagnose by failure type:
+
+- `unit-test` red: xUnit v3 runner behaves differently in CI than locally — check the actual stack trace.
+- `smoke-test` red: the SCL migration introduced a CLI behavioural regression that local smoke didn't catch (different ABS image version in CI).
+- `build (any platform)` red: AOT trim warning got promoted to error on a platform our local publish doesn't catch. Most often `osx-x64` (Rosetta self-test) or the Windows variants.
+
+This task produces no commit.
+
+---
+
+## Self-Review
+
+**1. Spec coverage check**
+
+Walking the spec's "Scope (what changes)" sections:
+
+- **Concern 1 — Directory.Build.props** → Task 2 Step 1.
+- **Concern 1 — GitHub Settings** → Task 1 Step 1 (the operator handoff).
+- **Concern 2 — xUnit v3 + sibling test packages** → Task 3 Step 1.
+- **Concern 2 — test source migration** → Task 3 Step 2 inline guidance.
+- **Concern 3 — System.CommandLine 2.0.7 csproj bump** → Task 4 Step 1.
+- **Concern 3 — Program.cs migration** → Task 4 Step 3.
+- **Concern 3 — HelpExtensions.cs rewrite** → Task 4 Step 4.
+- **Concern 3 — command files migration** → Task 4 Step 5.
+- **Concern 3 — test files migration** → Task 4 Step 6.
+
+Spec's "Sequencing — forced order of work" → Tasks 1-4 in the same order.
+
+Spec's "Verification stages" → Task 2 verifies after Concern 1, Task 3 after Concern 2, Tasks 4 (build/test/format) + 5 (AOT/self-test) + 6 (smoke) + 7 (CI) after Concern 3.
+
+Spec's "Risks and mitigations" → addressed inline:
+- Help-builder semantic 1:1 risk → Task 4 Step 4 explicitly flags escalation if positioning breaks.
+- xUnit v3 runner risk → Task 3 Step 2 fallback note (drop to xUnit 2.9 if needed).
+- Pre-existing vuln risk → Task 2 Step 2 explicit instruction to STOP and surface as finding.
+
+No spec section is uncovered.
+
+**2. Placeholder scan**
+
+The plan contains a few "approximate" or "subject to API surface" phrases for the SCL 2.0 migration code samples (Task 4 Steps 3, 4, 6). These are not "TBD" placeholders — they're explicit acknowledgements that the SCL 2.0.7 API surface is the authoritative reference at implementation time, not a code snippet I write today. Each step instructs the implementer to consult specific docs (the migration guide URL) and apply patterns; the patterns are described concretely. This is the appropriate level of specificity given that I can't ship literal SCL 2.0.7 code without verifying against the actual package, and the guide-following step is part of the implementer's job.
+
+The fallback split-commit instruction in Task 4 Step 10 is explicit: "Default is one commit unless diff > 800 lines." That's a concrete decision rule, not vagueness.
+
+**3. Type/name consistency**
+
+- Branch name: `feat/library-upgrades-and-security` — Tasks 0 Step 2 and 7 Step 1.
+- Spec/plan filename: `2026-04-28-library-upgrades-and-security.md` — Task 0 Step 3.
+- `Directory.Build.props` (singular, capitalised correctly) — Task 2 Step 1, plus File Structure section.
+- `xunit.v3` package name (lowercase, dotted) — Task 3 Step 1.
+- `HelpExtensions.ApplyCustomHelpSections` — proposed new entrypoint name in Task 4 Steps 3 and 4 and 6 (consistent across all three uses).
+- `BLOCKED_ON_USER_GITHUB_SETTINGS` — Task 1 Step 1, header callout. Same spelling.
+- `116 passed, 0 failed` — smoke-test expected count, Task 6 Step 5.
+- `103 / 103` — unit-test expected count across Tasks 2, 3, 4, 5.
+- `34 / 34` — self-test expected count, Task 5 Step 5.
+- Commit message types — `chore`, `test`, `docs` used per project convention (`test` for the xUnit migration, `chore` for package bumps, `docs` for the spec/plan commit).
+
+No drift detected.

--- a/docs/specs/2026-04-28-library-upgrades-and-security.md
+++ b/docs/specs/2026-04-28-library-upgrades-and-security.md
@@ -1,0 +1,248 @@
+# General library upgrades + dependency security — design
+
+Status: approved 2026-04-28. Targets v0.3.0.
+
+## Summary
+
+Bring all NuGet dependencies off long-stale pins, switch xUnit from the v2
+line to v3, and add an opt-in vulnerability gate (NuGet Audit + GitHub
+Dependabot security updates). Three logical concerns delivered in one PR
+with clearly separated commits:
+
+1. **NuGet Audit policy** in a new repo-root `Directory.Build.props`, plus
+   GitHub Dependabot alerts + security updates enabled at the repo Settings
+   level (out-of-band, no branch artifact).
+2. **Test packages bumped** — `xunit.v3` 3.2.2 replaces `xunit` 2.5.3,
+   `Microsoft.NET.Test.Sdk` and `coverlet.collector` move to current stable.
+3. **`System.CommandLine` bumped** from `2.0.0-beta4.22272.1` to `2.0.7`
+   stable. API-rewriting bump that touches every `Commands/*.cs` plus
+   `HelpExtensions.cs` and `Program.cs`.
+
+All version strings remain exact pins (no floating ranges or wildcards).
+
+## Motivation
+
+`System.CommandLine` is pinned to a 2022-vintage beta. Test packages have
+been frozen at the v0.1 baseline for over a year. Neither has shifted under
+us, but each release that goes by widens the gap and any future
+vulnerability advisory leaves us without a recent pin to land on.
+
+Dependency security checking has not been wired up at all — there is no
+build-time vuln scan and no GitHub-side advisory subscription. The result
+is that a published CVE against any dep would not surface in this project
+until a human noticed.
+
+The three concerns are bundled because they all sit in the same NuGet
+hygiene workspace and the operator (`thomaslazar`) wants one PR review
+covering "package upgrades and security tightening" rather than three
+small, related ones.
+
+## Scope (what changes)
+
+### Concern 1 — NuGet Audit + GitHub Dependabot
+
+#### `Directory.Build.props` (new, repo root)
+
+```xml
+<Project>
+  <PropertyGroup>
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <WarningsAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
+  </PropertyGroup>
+</Project>
+```
+
+- `NuGetAudit=true` — explicit on (default in .NET 8+, but be explicit so
+  a future SDK regression doesn't silently disable it).
+- `NuGetAuditMode=all` — scan transitive dependencies, not just direct.
+- `WarningsAsErrors=NU190x` — the four NuGet audit warning codes get
+  promoted to build errors. CI fails on any vulnerable package.
+
+The file applies to all three csproj automatically via MSBuild's
+inherit-from-parent-directory rule. No csproj edits needed for this
+concern.
+
+#### GitHub repo Settings (out-of-band)
+
+- Settings → Code security → **Dependabot alerts** → Enable
+- Settings → Code security → **Dependabot security updates** → Enable
+
+These switches are clicks, not files. They live in repo configuration on
+the GitHub side. Implementation must STOP at the start of work and prompt
+the operator to flip both before any code lands. No `dependabot.yml` is
+added — routine version-bump PRs are explicitly out of scope (vuln-only
+policy, per Q4 of brainstorm).
+
+### Concern 2 — Test packages
+
+In `tests/AbsCli.Tests/AbsCli.Tests.csproj`:
+
+| Package | Current | Target |
+|---------|---------|--------|
+| `xunit` | 2.5.3 | **removed** |
+| `xunit.runner.visualstudio` | 2.5.3 | **removed** |
+| `xunit.v3` | — | added at 3.2.2 (stable, GA) |
+| `xunit.v3.assert` (or whatever sibling v3 packs ship) | — | added at the matching stable version |
+| `xunit.runner.visualstudio` (v3 line) | — | added at the version that pairs with `xunit.v3` 3.2.2 |
+| `Microsoft.NET.Test.Sdk` | 17.8.0 | current stable |
+| `coverlet.collector` | 6.0.0 | current stable |
+
+Exact versions of `Microsoft.NET.Test.Sdk` and `coverlet.collector` get
+locked when the implementer runs `dotnet add package` — whatever NuGet
+resolves at that moment is the pin. The package list above is approximate
+because xUnit v3 ships a different set of NuGets than v2 (assertion
+package may be separate; runner package name differs). The implementer
+follows the official xUnit v3 migration doc and pins whatever resolves.
+
+Test source code under `tests/AbsCli.Tests/**/*.cs` may need:
+
+- Namespace updates (xUnit v3 keeps `using Xunit;` but reorganises some
+  internals).
+- Assertion adjustments if v3 changed any signatures we use (the project
+  uses `Assert.Equal`, `Assert.True`, `Assert.False`, `Assert.Throws`,
+  `Assert.StartsWith`, `Assert.EndsWith`, `Assert.Contains`,
+  `Assert.DoesNotContain` — all of these are stable across the v2/v3
+  boundary, so changes here are unlikely).
+- Test-attribute changes if any. The project uses `[Fact]` exclusively —
+  `[Fact]` is unchanged in v3.
+
+The implementer follows the xUnit v3 migration guide
+(`https://xunit.net/docs/getting-started/v3/migration`) for any
+codebase-wide adjustments.
+
+### Concern 3 — `System.CommandLine`
+
+In `src/AbsCli/AbsCli.csproj`:
+
+```diff
+-<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
++<PackageReference Include="System.CommandLine" Version="2.0.7" />
+```
+
+This is the bulk of the work. Between `beta4` (July 2022) and `2.0.7`
+(April 2026) the API was rewritten. Known rewrites that affect this
+codebase:
+
+| Current usage | 2.0.7 equivalent |
+|---------------|------------------|
+| `new CommandLineBuilder(rootCommand).UseDefaults().UseCustomHelpSections().Build()` | `new CommandLineConfiguration(rootCommand) { ... }` plus invocation pipeline migration |
+| `command.SetHandler(handler, options...)` | `command.SetAction(parseResult => …)` |
+| `parseResult.GetValueForOption(opt)` | `parseResult.GetValue(opt)` |
+| `parser.InvokeAsync(args)` | `rootCommand.Parse(args).InvokeAsync()` |
+| `parser.Invoke(args, console)` | `rootCommand.Parse(args, configuration).Invoke()` |
+| Custom help-builder code in `HelpExtensions.cs` (`UseCustomHelpSections`, `AddHelpSection`, top/bottom positioning) | rewritten against the new help-model API; details emerge during implementation |
+| `Option<T>(name, description)` constructor | name in 2.0 must start with `--`; project already uses `--` prefix everywhere, so this is a no-op |
+
+Files affected (every command file plus the help extension and program
+entry point):
+
+- `src/AbsCli/Program.cs`
+- `src/AbsCli/Commands/AuthorsCommand.cs`
+- `src/AbsCli/Commands/BackupCommand.cs`
+- `src/AbsCli/Commands/ChangelogCommand.cs`
+- `src/AbsCli/Commands/CommandHelper.cs`
+- `src/AbsCli/Commands/ConfigCommand.cs`
+- `src/AbsCli/Commands/HelpExtensions.cs`
+- `src/AbsCli/Commands/ItemsCommand.cs`
+- `src/AbsCli/Commands/LibrariesCommand.cs`
+- `src/AbsCli/Commands/LoginCommand.cs`
+- `src/AbsCli/Commands/MetadataCommand.cs`
+- `src/AbsCli/Commands/SearchCommand.cs`
+- `src/AbsCli/Commands/SelfTestCommand.cs`
+- `src/AbsCli/Commands/SeriesCommand.cs`
+- `src/AbsCli/Commands/TasksCommand.cs`
+- `src/AbsCli/Commands/UploadCommand.cs`
+- `tests/AbsCli.Tests/Commands/HelpExtensionsTests.cs` (uses `CommandLineBuilder`)
+- `tests/AbsCli.Tests/Commands/HelpOutputTests.cs` (uses `CommandLineBuilder`)
+- `tests/AbsCli.Tests/Commands/ChangelogCommandTests.cs` (uses `CommandLineBuilder`)
+
+The migration is mechanical (find + adapt patterns), not architectural,
+but the surface area is wide. Implementer should expect to keep the
+existing command shape, options, examples, and help-section semantics —
+the user-facing CLI behaviour does not change.
+
+### Files explicitly NOT modified
+
+- `CHANGELOG.md` — owned by release workflow, never feature branches.
+- `.github/workflows/build.yml` — no CI changes; existing `dotnet test` and
+  AOT publish remain the gates.
+- `.github/dependabot.yml` — not added (vuln-only policy).
+- `docker/*` — unrelated.
+
+## Sequencing — forced order of work
+
+1. **STOP at start.** Prompt the operator to flip the two GitHub Settings
+   switches (Dependabot alerts + security updates). Do not begin code
+   work until the operator confirms both show "Enabled" in repo settings.
+   No commit at this step.
+2. **Concern 1 commit.** Add `Directory.Build.props`. Run `dotnet restore`
+   and `dotnet build` to confirm the current package set is clean (no
+   `NU1901`/`NU1902`/`NU1903`/`NU1904` errors raised). If it isn't, the
+   pre-existing dep set has a known vuln — surface as a finding and
+   address before continuing. Commit.
+3. **Concern 2 commit.** Replace `xunit` + `xunit.runner.visualstudio`
+   with the v3 packages, bump `Microsoft.NET.Test.Sdk` and
+   `coverlet.collector`. Adjust any test code the v3 migration requires.
+   Run unit tests; expect 103 / 103 unchanged. `dotnet format` clean.
+   Commit.
+4. **Concern 3 commit (or commit series).** Bump `System.CommandLine` to
+   2.0.7. Rewrite each command file to the new API. Rewrite custom
+   help-builder code in `HelpExtensions.cs`. Update `Program.cs` parser
+   construction. Run unit tests; all 103 must pass. AOT publish; run
+   self-test (34 / 34); run live smoke test (`docker/smoke-test.sh`)
+   against a freshly seeded ABS — all 116 assertions must pass. Commit
+   may be split into smaller per-area commits if the diff would otherwise
+   be too large to review (e.g. one commit for `Program.cs` + parser
+   migration, one for command files, one for help extensions). The
+   implementer decides based on the actual diff.
+
+Each step ends with `dotnet format --verify-no-changes` clean, so a
+formatting nit doesn't sneak in via the bumps.
+
+## Verification stages (after each commit)
+
+1. `dotnet build /workspaces/abs-cli/AbsCli.sln -c Debug` — clean.
+2. `dotnet test /workspaces/abs-cli/AbsCli.sln` — 103 / 103.
+3. `dotnet format /workspaces/abs-cli/AbsCli.sln --verify-no-changes` —
+   exit 0.
+
+Plus, after Concern 3 (the SCL bump):
+
+4. AOT Release publish for linux-x64 — succeeds.
+5. `abs-cli self-test` against the AOT binary — 34 / 34.
+6. `abs-cli changelog` against the AOT binary — prints the topmost `## `
+   heading.
+7. `docker/smoke-test.sh` against a live, seeded ABS using the AOT binary
+   and the container IP (per the project's docker-host-IP guidance) —
+   116 / 116.
+8. Push branch; the existing CI matrix runs unit-test, smoke-test, and
+   the 6-platform AOT build matrix. All green is the merge gate.
+
+If any stage surfaces a real issue (vuln in pre-existing deps, xUnit v3
+test incompatibility, SCL behavioural regression), stop and treat as a
+scoped finding — fix in branch if cheap, escalate if not.
+
+## Risks and mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `System.CommandLine 2.0.7` help-builder API can't reproduce `UseCustomHelpSections` semantics 1:1 | Medium | Implementer rewrites against new API; if user-facing help drifts, escalate as a design decision. Reference: existing `HelpOutputTests` capture the expected output, regression-checking the rewrite. |
+| `xunit.v3 3.2.2` test runner has trouble with this project's source-link patterns | Low | Catch via Concern 2 unit-test run; if hit, fall back to xUnit 2.9 (still a bump from 2.5.3, no major migration cost). |
+| Pre-existing dep has a known vuln that NU190x flags after `Directory.Build.props` lands | Low | Concern 1 step deliberately catches this before any bumps. Address as a separate first commit if found. |
+| `Microsoft.NET.Test.Sdk` current stable conflicts with the rest of test stack | Low | Pin to a known-compatible version per `xunit.v3` 3.2.2 release notes. |
+| AOT publish behaviour changes under SCL 2.0 (e.g. new reflection requirements) | Low | Existing self-test exercises serialisation paths; if AOT introduces new trim warnings, address inline. |
+| GitHub Dependabot security updates aren't enabled in time and a CVE drops mid-PR | Negligible | Step 1 of the plan explicitly gates on the switches being on. |
+
+## Out of scope (deferred)
+
+- `xunit.v3` 4.x preview series. Stay on 3.2.2 stable.
+- `System.CommandLine` 3.0 preview series. Stay on 2.0.7 stable.
+- A `.github/dependabot.yml` for routine non-vuln version bumps.
+- Replacing `coverlet.collector` with another coverage tool.
+- Any source-code refactor beyond what the SCL API rewrite forces.
+- New unit tests that aren't there already.
+
+## Open questions
+
+None. All decisions made during brainstorming.

--- a/src/AbsCli/AbsCli.csproj
+++ b/src/AbsCli/AbsCli.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AbsCli/Commands/AuthorsCommand.cs
+++ b/src/AbsCli/Commands/AuthorsCommand.cs
@@ -16,14 +16,14 @@ public static class AuthorsCommand
             "removed or re-tagged, the scanner deletes the author on its next run",
             "(unless a custom image is set). To remove an author, update the books",
             "that reference it.");
-        command.AddCommand(CreateListCommand());
-        command.AddCommand(CreateGetCommand());
+        command.Subcommands.Add(CreateListCommand());
+        command.Subcommands.Add(CreateGetCommand());
         return command;
     }
 
     private static Command CreateListCommand()
     {
-        var libraryOption = new Option<string?>("--library", "Library ID or name");
+        var libraryOption = new Option<string?>("--library") { Description = "Library ID or name" };
         var command = new Command("list",
             "List authors in a library (returns all, no pagination)") { libraryOption };
         command.AddExamples(
@@ -31,36 +31,36 @@ public static class AuthorsCommand
             "abs-cli authors list | jq '.authors[] | {name, numBooks}'",
             "abs-cli authors list | jq '.authors | sort_by(.numBooks) | reverse | .[:5]'");
         command.AddResponseExample<AuthorListResponse>();
-
-        command.SetHandler(async (string? library) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var library = parseResult.GetValue(libraryOption);
             var (client, config) = CommandHelper.BuildClient(libraryOverride: library);
             var libraryId = CommandHelper.RequireLibrary(config);
             var service = new AuthorsService(client);
             var result = await service.ListAsync(libraryId);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.AuthorListResponse);
-        }, libraryOption);
-
+            return 0;
+        });
         return command;
     }
 
     private static Command CreateGetCommand()
     {
-        var idOption = new Option<string>("--id", "Author ID") { IsRequired = true };
+        var idOption = new Option<string>("--id") { Description = "Author ID", Required = true };
         var command = new Command("get", "Get a single author") { idOption };
         command.AddExamples(
             "abs-cli authors get --id \"aut_abc123\"",
             "abs-cli authors get --id \"aut_abc123\" | jq '.name'");
         command.AddResponseExample<AuthorItem>();
-
-        command.SetHandler(async (string id) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var id = parseResult.GetValue(idOption)!;
             var (client, _) = CommandHelper.BuildClient();
             var service = new AuthorsService(client);
             var result = await service.GetAsync(id);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.AuthorItem);
-        }, idOption);
-
+            return 0;
+        });
         return command;
     }
 }

--- a/src/AbsCli/Commands/BackupCommand.cs
+++ b/src/AbsCli/Commands/BackupCommand.cs
@@ -10,12 +10,12 @@ public static class BackupCommand
     public static Command Create()
     {
         var command = new Command("backup", "Manage server backups");
-        command.AddCommand(CreateCreateCommand());
-        command.AddCommand(CreateListCommand());
-        command.AddCommand(CreateApplyCommand());
-        command.AddCommand(CreateDownloadCommand());
-        command.AddCommand(CreateDeleteCommand());
-        command.AddCommand(CreateUploadCommand());
+        command.Subcommands.Add(CreateCreateCommand());
+        command.Subcommands.Add(CreateListCommand());
+        command.Subcommands.Add(CreateApplyCommand());
+        command.Subcommands.Add(CreateDownloadCommand());
+        command.Subcommands.Add(CreateDeleteCommand());
+        command.Subcommands.Add(CreateUploadCommand());
         return command;
     }
 
@@ -26,15 +26,14 @@ public static class BackupCommand
             "abs-cli backup create",
             "abs-cli backup create | jq '.backups | length'");
         command.AddResponseExample<BackupListResponse>();
-
-        command.SetHandler(async () =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             var (client, _) = CommandHelper.BuildClient();
             var service = new BackupService(client);
             var result = await service.CreateAsync();
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.BackupListResponse);
+            return 0;
         });
-
         return command;
     }
 
@@ -45,99 +44,99 @@ public static class BackupCommand
             "abs-cli backup list",
             "abs-cli backup list | jq '.backups[] | {id, filename, datePretty}'");
         command.AddResponseExample<BackupListResponse>();
-
-        command.SetHandler(async () =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             var (client, _) = CommandHelper.BuildClient();
             var service = new BackupService(client);
             var result = await service.ListAsync();
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.BackupListResponse);
+            return 0;
         });
-
         return command;
     }
 
     private static Command CreateApplyCommand()
     {
-        var idOption = new Option<string>("--id", "Backup ID") { IsRequired = true };
+        var idOption = new Option<string>("--id") { Description = "Backup ID", Required = true };
         var command = new Command("apply", "Apply (restore) a server backup") { idOption };
         command.AddExamples(
             "abs-cli backup apply --id \"2024-01-15T0000\"",
             "abs-cli backup apply --id \"2024-01-15T0000\" | jq '.success'");
-
-        command.SetHandler(async (string id) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var id = parseResult.GetValue(idOption)!;
             var (client, _) = CommandHelper.BuildClient();
             var service = new BackupService(client);
             var result = await service.ApplyAsync(id);
             ConsoleOutput.WriteRawJson(result);
-        }, idOption);
-
+            return 0;
+        });
         return command;
     }
 
     private static Command CreateDownloadCommand()
     {
-        var idOption = new Option<string>("--id", "Backup ID") { IsRequired = true };
-        var outputOption = new Option<string>("--output", "Output file path (use .audiobookshelf extension — required for re-upload)") { IsRequired = true };
+        var idOption = new Option<string>("--id") { Description = "Backup ID", Required = true };
+        var outputOption = new Option<string>("--output") { Description = "Output file path (use .audiobookshelf extension — required for re-upload)", Required = true };
         var command = new Command("download", "Download a server backup to a local file") { idOption, outputOption };
         command.AddExamples(
             "abs-cli backup download --id \"2024-01-15T0000\" --output backup.audiobookshelf",
             "abs-cli backup download --id \"2024-01-15T0000\" --output /tmp/abs-backup.audiobookshelf");
-
-        command.SetHandler(async (string id, string output) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var id = parseResult.GetValue(idOption)!;
+            var output = parseResult.GetValue(outputOption)!;
             var (client, _) = CommandHelper.BuildClient();
             var service = new BackupService(client);
             await service.DownloadAsync(id, output);
-        }, idOption, outputOption);
-
+            return 0;
+        });
         return command;
     }
 
     private static Command CreateDeleteCommand()
     {
-        var idOption = new Option<string>("--id", "Backup ID") { IsRequired = true };
+        var idOption = new Option<string>("--id") { Description = "Backup ID", Required = true };
         var command = new Command("delete", "Delete a server backup") { idOption };
         command.AddExamples(
             "abs-cli backup delete --id \"2024-01-15T0000\"",
             "abs-cli backup delete --id \"2024-01-15T0000\" | jq '.backups | length'");
         command.AddResponseExample<BackupListResponse>();
-
-        command.SetHandler(async (string id) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var id = parseResult.GetValue(idOption)!;
             var (client, _) = CommandHelper.BuildClient();
             var service = new BackupService(client);
             var result = await service.DeleteAsync(id);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.BackupListResponse);
-        }, idOption);
-
+            return 0;
+        });
         return command;
     }
 
     private static Command CreateUploadCommand()
     {
-        var fileOption = new Option<string>("--file", "Path to backup file (must have .audiobookshelf extension)") { IsRequired = true };
+        var fileOption = new Option<string>("--file") { Description = "Path to backup file (must have .audiobookshelf extension)", Required = true };
         var command = new Command("upload", "Upload a backup file to the server") { fileOption };
         command.AddExamples(
             "abs-cli backup upload --file backup.audiobookshelf",
             "abs-cli backup upload --file /tmp/abs-backup.audiobookshelf | jq '.backups | length'");
         command.AddResponseExample<BackupListResponse>();
-
-        command.SetHandler(async (string file) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var file = parseResult.GetValue(fileOption)!;
             if (!File.Exists(file))
             {
                 ConsoleOutput.WriteError($"File not found: {file}");
                 Environment.Exit(1);
-                return;
+                return 1;
             }
             var (client, _) = CommandHelper.BuildClient();
             var service = new BackupService(client);
             var result = await service.UploadAsync(file);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.BackupListResponse);
-        }, fileOption);
-
+            return 0;
+        });
         return command;
     }
 }

--- a/src/AbsCli/Commands/ChangelogCommand.cs
+++ b/src/AbsCli/Commands/ChangelogCommand.cs
@@ -7,20 +7,22 @@ public static class ChangelogCommand
 {
     public static Command Create()
     {
-        var allOption = new Option<bool>(
-            "--all",
-            "Print the entire CHANGELOG.md instead of just the latest entry");
+        var allOption = new Option<bool>("--all")
+        {
+            Description = "Print the entire CHANGELOG.md instead of just the latest entry"
+        };
         var command = new Command(
             "changelog",
             "Print release notes from the bundled CHANGELOG.md") { allOption };
         command.AddExamples(
             "abs-cli changelog",
             "abs-cli changelog --all");
-        command.SetHandler((context) =>
+        command.SetAction(parseResult =>
         {
-            var all = context.ParseResult.GetValueForOption(allOption);
+            var all = parseResult.GetValue(allOption);
             var output = all ? ChangelogReader.ReadAll() : ChangelogReader.ReadLatest();
-            context.Console.Out.Write(output + "\n");
+            parseResult.InvocationConfiguration.Output.Write(output + "\n");
+            return 0;
         });
         return command;
     }

--- a/src/AbsCli/Commands/ConfigCommand.cs
+++ b/src/AbsCli/Commands/ConfigCommand.cs
@@ -9,8 +9,8 @@ public static class ConfigCommand
     public static Command Create()
     {
         var command = new Command("config", "Manage abs-cli configuration");
-        command.AddCommand(CreateGetCommand());
-        command.AddCommand(CreateSetCommand());
+        command.Subcommands.Add(CreateGetCommand());
+        command.Subcommands.Add(CreateSetCommand());
         return command;
     }
 
@@ -20,12 +20,10 @@ public static class ConfigCommand
         command.AddExamples(
             "abs-cli config get",
             "abs-cli config get | jq '.server'");
-
-        command.SetHandler(() =>
+        command.SetAction(parseResult =>
         {
             var configManager = new ConfigManager();
             var config = configManager.Load();
-
             var display = new Dictionary<string, string>
             {
                 ["server"] = config.Server ?? "(not set)",
@@ -34,18 +32,16 @@ public static class ConfigCommand
                 ["defaultLibrary"] = config.DefaultLibrary ?? "(not set)",
                 ["configPath"] = ConfigManager.DefaultConfigPath()
             };
-
             ConsoleOutput.WriteJson(display);
+            return 0;
         });
-
         return command;
     }
 
     private static Command CreateSetCommand()
     {
-        var keyArg = new Argument<string>("key", "Configuration key (server, defaultLibrary)");
-        var valueArg = new Argument<string>("value", "Configuration value");
-
+        var keyArg = new Argument<string>("key") { Description = "Configuration key (server, defaultLibrary)" };
+        var valueArg = new Argument<string>("value") { Description = "Configuration value" };
         var command = new Command("set", "Set a configuration value")
         {
             keyArg,
@@ -54,12 +50,12 @@ public static class ConfigCommand
         command.AddExamples(
             "abs-cli config set server https://abs.example.com",
             "abs-cli config set defaultLibrary \"lib_abc123\"");
-
-        command.SetHandler((string key, string value) =>
+        command.SetAction(parseResult =>
         {
+            var key = parseResult.GetValue(keyArg)!;
+            var value = parseResult.GetValue(valueArg)!;
             var configManager = new ConfigManager();
             var config = configManager.Load();
-
             switch (key)
             {
                 case "server":
@@ -71,13 +67,12 @@ public static class ConfigCommand
                 default:
                     ConsoleOutput.WriteError($"Unknown config key: '{key}'. Valid keys: server, defaultLibrary");
                     Environment.Exit(1);
-                    return;
+                    return 1;
             }
-
             configManager.Save(config);
             Console.Error.WriteLine($"Set {key} = {value}");
-        }, keyArg, valueArg);
-
+            return 0;
+        });
         return command;
     }
 }

--- a/src/AbsCli/Commands/HelpExtensions.cs
+++ b/src/AbsCli/Commands/HelpExtensions.cs
@@ -1,6 +1,6 @@
 using System.CommandLine;
-using System.CommandLine.Builder;
 using System.CommandLine.Help;
+using System.CommandLine.Invocation;
 
 namespace AbsCli.Commands;
 
@@ -88,19 +88,15 @@ public static class HelpExtensions
         {
             var trimmed = lines[i].TrimStart();
             if (!trimmed.StartsWith("\"results\":", StringComparison.Ordinal)) continue;
-
             var indent = new string(' ', lines[i].Length - trimmed.Length);
-
             int closeIdx = i;
             while (closeIdx < lines.Length &&
                    !lines[closeIdx].TrimStart().StartsWith("]", StringComparison.Ordinal))
                 closeIdx++;
             if (closeIdx == lines.Length) break;
-
             var elementIndented = string.Join("\n",
                 elementJson.Split('\n').Select(l => indent + "  " + l));
             var trailing = lines[closeIdx].TrimStart().StartsWith("],", StringComparison.Ordinal) ? "]," : "]";
-
             var output = new List<string>();
             output.AddRange(lines.Take(i));
             output.Add($"{indent}\"results\": [");
@@ -112,32 +108,45 @@ public static class HelpExtensions
         return envelopeJson;
     }
 
-    public static CommandLineBuilder UseCustomHelpSections(this CommandLineBuilder builder)
+    /// <summary>
+    /// Replaces the default <see cref="HelpAction"/> on the root command's
+    /// <see cref="HelpOption"/> with a wrapper that writes Top-positioned
+    /// sections before the default layout and Bottom-positioned sections
+    /// after it. The HelpOption is recursive by default, so the wrapper also
+    /// fires for every subcommand <c>--help</c>.
+    /// </summary>
+    public static void UseCustomHelpSections(RootCommand root)
     {
-        builder.UseHelp(ctx =>
-        {
-            ctx.HelpBuilder.CustomizeLayout(_ =>
-            {
-                var defaultLayout = HelpBuilder.Default.GetLayout().ToList();
-                var withTop = new List<HelpSectionDelegate> { helpCtx => WriteSections(helpCtx, HelpSectionPosition.Top) };
-                withTop.AddRange(defaultLayout);
-                withTop.Add(helpCtx => WriteSections(helpCtx, HelpSectionPosition.Bottom));
-                return withTop;
-            });
-        });
-        return builder;
+        var helpOption = root.Options.OfType<HelpOption>().FirstOrDefault();
+        if (helpOption?.Action is HelpAction defaultAction)
+            helpOption.Action = new CustomHelpAction(defaultAction);
     }
 
-    private static void WriteSections(HelpContext ctx, HelpSectionPosition position)
+    private sealed class CustomHelpAction : SynchronousCommandLineAction
     {
-        if (!CommandSections.TryGetValue(ctx.Command, out var sections)) return;
+        private readonly HelpAction _inner;
+        public CustomHelpAction(HelpAction inner) { _inner = inner; }
 
+        public override int Invoke(ParseResult parseResult)
+        {
+            var command = parseResult.CommandResult.Command;
+            var output = parseResult.InvocationConfiguration.Output;
+            WriteSections(command, output, HelpSectionPosition.Top);
+            var rc = _inner.Invoke(parseResult);
+            WriteSections(command, output, HelpSectionPosition.Bottom);
+            return rc;
+        }
+    }
+
+    private static void WriteSections(Command command, TextWriter output, HelpSectionPosition position)
+    {
+        if (!CommandSections.TryGetValue(command, out var sections)) return;
         foreach (var section in sections.Where(s => s.Position == position))
         {
-            ctx.Output.WriteLine($"{section.Title}:");
+            output.WriteLine($"{section.Title}:");
             foreach (var line in section.Lines)
-                ctx.Output.WriteLine($"  {line}");
-            ctx.Output.WriteLine();
+                output.WriteLine($"  {line}");
+            output.WriteLine();
         }
     }
 }

--- a/src/AbsCli/Commands/HelpExtensions.cs
+++ b/src/AbsCli/Commands/HelpExtensions.cs
@@ -115,11 +115,15 @@ public static class HelpExtensions
     /// after it. The HelpOption is recursive by default, so the wrapper also
     /// fires for every subcommand <c>--help</c>.
     /// </summary>
-    public static void UseCustomHelpSections(RootCommand root)
+    public static void UseCustomHelpSections(this RootCommand root)
     {
-        var helpOption = root.Options.OfType<HelpOption>().FirstOrDefault();
-        if (helpOption?.Action is HelpAction defaultAction)
-            helpOption.Action = new CustomHelpAction(defaultAction);
+        var helpOption = root.Options.OfType<HelpOption>().FirstOrDefault()
+            ?? throw new InvalidOperationException(
+                "RootCommand has no HelpOption — cannot install CustomHelpAction.");
+        if (helpOption.Action is not HelpAction defaultAction)
+            throw new InvalidOperationException(
+                $"HelpOption.Action is {helpOption.Action?.GetType().Name ?? "null"}, expected HelpAction.");
+        helpOption.Action = new CustomHelpAction(defaultAction);
     }
 
     private sealed class CustomHelpAction : SynchronousCommandLineAction

--- a/src/AbsCli/Commands/ItemsCommand.cs
+++ b/src/AbsCli/Commands/ItemsCommand.cs
@@ -10,25 +10,24 @@ public static class ItemsCommand
     public static Command Create()
     {
         var command = new Command("items", "Manage library items");
-        command.AddCommand(CreateListCommand());
-        command.AddCommand(CreateGetCommand());
-        command.AddCommand(CreateSearchCommand());
-        command.AddCommand(CreateUpdateCommand());
-        command.AddCommand(CreateBatchUpdateCommand());
-        command.AddCommand(CreateBatchGetCommand());
-        command.AddCommand(CreateScanCommand());
+        command.Subcommands.Add(CreateListCommand());
+        command.Subcommands.Add(CreateGetCommand());
+        command.Subcommands.Add(CreateSearchCommand());
+        command.Subcommands.Add(CreateUpdateCommand());
+        command.Subcommands.Add(CreateBatchUpdateCommand());
+        command.Subcommands.Add(CreateBatchGetCommand());
+        command.Subcommands.Add(CreateScanCommand());
         return command;
     }
 
     private static Command CreateListCommand()
     {
-        var libraryOption = new Option<string?>("--library", "Library ID or name");
-        var filterOption = new Option<string?>("--filter", "Filter expression (e.g. 'genres=Sci Fi')");
-        var sortOption = new Option<string?>("--sort", "Sort field (e.g. 'media.metadata.title')");
-        var descOption = new Option<bool>("--desc", "Sort descending");
-        var limitOption = new Option<int>("--limit", () => 50, "Results per page (default 50, pass higher value to retrieve more)");
-        var pageOption = new Option<int?>("--page", "Page number (0-indexed)");
-
+        var libraryOption = new Option<string?>("--library") { Description = "Library ID or name" };
+        var filterOption = new Option<string?>("--filter") { Description = "Filter expression (e.g. 'genres=Sci Fi')" };
+        var sortOption = new Option<string?>("--sort") { Description = "Sort field (e.g. 'media.metadata.title')" };
+        var descOption = new Option<bool>("--desc") { Description = "Sort descending" };
+        var limitOption = new Option<int>("--limit") { Description = "Results per page (default 50, pass higher value to retrieve more)", DefaultValueFactory = _ => 50 };
+        var pageOption = new Option<int?>("--page") { Description = "Page number (0-indexed)" };
         var command = new Command("list",
             "List library items with optional filtering, sorting, and pagination (defaults to 50 results)")
         {
@@ -64,47 +63,50 @@ public static class ItemsCommand
             "abs-cli items list | jq '.results[] | select(.media.metadata.isbn == null)'");
         command.AddResponseExample(typeof(PaginatedResponse), typeof(LibraryItemMinified));
         command.AddMediaUnionShapes();
-
-        command.SetHandler(async (string? library, string? filter, string? sort,
-            bool desc, int limit, int? page) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var library = parseResult.GetValue(libraryOption);
+            var filter = parseResult.GetValue(filterOption);
+            var sort = parseResult.GetValue(sortOption);
+            var desc = parseResult.GetValue(descOption);
+            var limit = parseResult.GetValue(limitOption);
+            var page = parseResult.GetValue(pageOption);
             var (client, config) = CommandHelper.BuildClient(libraryOverride: library);
             var libraryId = CommandHelper.RequireLibrary(config);
             var service = new ItemsService(client);
             var result = await service.ListAsync(libraryId, filter, sort, desc, limit, page);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.PaginatedResponse);
-        }, libraryOption, filterOption, sortOption, descOption, limitOption, pageOption);
-
+            return 0;
+        });
         return command;
     }
 
     private static Command CreateGetCommand()
     {
-        var idOption = new Option<string>("--id", "Item ID") { IsRequired = true };
+        var idOption = new Option<string>("--id") { Description = "Item ID", Required = true };
         var command = new Command("get", "Get a single library item by ID") { idOption };
         command.AddExamples(
             "abs-cli items get --id \"li_abc123\"",
             "abs-cli items get --id \"li_abc123\" | jq '.media.metadata'");
         command.AddResponseExample<LibraryItemMinified>();
         command.AddMediaUnionShapes();
-
-        command.SetHandler(async (string id) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var id = parseResult.GetValue(idOption)!;
             var (client, _) = CommandHelper.BuildClient();
             var service = new ItemsService(client);
             var result = await service.GetAsync(id);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.LibraryItemMinified);
-        }, idOption);
-
+            return 0;
+        });
         return command;
     }
 
     private static Command CreateSearchCommand()
     {
-        var queryOption = new Option<string>("--query", "Search text") { IsRequired = true };
-        var libraryOption = new Option<string?>("--library", "Library ID or name");
-        var limitOption = new Option<int>("--limit", () => 50, "Max results (default 50, pass higher value to retrieve more)");
-
+        var queryOption = new Option<string>("--query") { Description = "Search text", Required = true };
+        var libraryOption = new Option<string?>("--library") { Description = "Library ID or name" };
+        var limitOption = new Option<int>("--limit") { Description = "Max results (default 50, pass higher value to retrieve more)", DefaultValueFactory = _ => 50 };
         var command = new Command("search",
             "Search across a library (substring match, case-insensitive, defaults to 50 results). Alias for 'abs-cli search' — same endpoint, same response shape.")
         {
@@ -133,24 +135,25 @@ public static class ItemsCommand
             "abs-cli items search --query \"978-0\" --limit 20");
         command.AddResponseExample<SearchResult>();
         command.AddMediaUnionShapes();
-
-        command.SetHandler(async (string query, string? library, int limit) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var query = parseResult.GetValue(queryOption)!;
+            var library = parseResult.GetValue(libraryOption);
+            var limit = parseResult.GetValue(limitOption);
             var (client, config) = CommandHelper.BuildClient(libraryOverride: library);
             var libraryId = CommandHelper.RequireLibrary(config);
             var service = new ItemsService(client);
             var result = await service.SearchAsync(libraryId, query, limit);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.SearchResult);
-        }, queryOption, libraryOption, limitOption);
-
+            return 0;
+        });
         return command;
     }
 
     private static Command CreateUpdateCommand()
     {
-        var idOption = new Option<string>("--id", "Item ID") { IsRequired = true };
-        var inputOption = new Option<string>("--input", "JSON input (string or file path)") { IsRequired = true };
-
+        var idOption = new Option<string>("--id") { Description = "Item ID", Required = true };
+        var inputOption = new Option<string>("--input") { Description = "JSON input (string or file path)", Required = true };
         var command = new Command("update", "Update a single item's metadata") { idOption, inputOption };
         command.AddExamples(
             "abs-cli items update --id \"li_abc123\" --input '{\"metadata\":{\"title\":\"New Title\"}}'",
@@ -158,32 +161,33 @@ public static class ItemsCommand
             "abs-cli items update --id \"li_abc123\" --input '{\"metadata\":{\"genres\":[\"Fantasy\",\"Epic\"]}}'");
         command.AddResponseExample<UpdateMediaResponse>();
         command.AddMediaUnionShapes();
-
-        command.SetHandler(async (string id, string input) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var id = parseResult.GetValue(idOption)!;
+            var input = parseResult.GetValue(inputOption)!;
             var jsonBody = CommandHelper.ReadJsonInput(input);
             var (client, _) = CommandHelper.BuildClient();
             var service = new ItemsService(client);
             var result = await service.UpdateMediaAsync(id, jsonBody);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.UpdateMediaResponse);
-        }, idOption, inputOption);
-
+            return 0;
+        });
         return command;
     }
 
     private static Command CreateBatchUpdateCommand()
     {
-        var inputOption = new Option<string?>("--input", "JSON file path");
-        var stdinOption = new Option<bool>("--stdin", "Read JSON from stdin");
-
+        var inputOption = new Option<string?>("--input") { Description = "JSON file path" };
+        var stdinOption = new Option<bool>("--stdin") { Description = "Read JSON from stdin" };
         var command = new Command("batch-update", "Batch update multiple items") { inputOption, stdinOption };
         command.AddExamples(
             "abs-cli items batch-update --input updates.json",
             "cat updates.json | abs-cli items batch-update --stdin");
         command.AddResponseExample<BatchUpdateResponse>();
-
-        command.SetHandler(async (string? input, bool stdin) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var input = parseResult.GetValue(inputOption);
+            var stdin = parseResult.GetValue(stdinOption);
             string jsonBody;
             if (stdin) jsonBody = await Console.In.ReadToEndAsync();
             else if (input != null) jsonBody = CommandHelper.ReadJsonInput(input);
@@ -191,32 +195,31 @@ public static class ItemsCommand
             {
                 ConsoleOutput.WriteError("Provide --input <file> or --stdin");
                 Environment.Exit(1);
-                return;
+                return 1;
             }
-
             var (client, _) = CommandHelper.BuildClient();
             var service = new ItemsService(client);
             var result = await service.BatchUpdateAsync(jsonBody);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.BatchUpdateResponse);
-        }, inputOption, stdinOption);
-
+            return 0;
+        });
         return command;
     }
 
     private static Command CreateBatchGetCommand()
     {
-        var inputOption = new Option<string?>("--input", "JSON file with libraryItemIds");
-        var stdinOption = new Option<bool>("--stdin", "Read JSON from stdin");
-
+        var inputOption = new Option<string?>("--input") { Description = "JSON file with libraryItemIds" };
+        var stdinOption = new Option<bool>("--stdin") { Description = "Read JSON from stdin" };
         var command = new Command("batch-get", "Batch get multiple items by ID") { inputOption, stdinOption };
         command.AddExamples(
             "abs-cli items batch-get --input ids.json",
             "echo '{\"libraryItemIds\":[\"li_abc\",\"li_def\"]}' | abs-cli items batch-get --stdin");
         command.AddResponseExample<BatchGetResponse>();
         command.AddMediaUnionShapes();
-
-        command.SetHandler(async (string? input, bool stdin) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var input = parseResult.GetValue(inputOption);
+            var stdin = parseResult.GetValue(stdinOption);
             string jsonBody;
             if (stdin) jsonBody = await Console.In.ReadToEndAsync();
             else if (input != null) jsonBody = CommandHelper.ReadJsonInput(input);
@@ -224,33 +227,34 @@ public static class ItemsCommand
             {
                 ConsoleOutput.WriteError("Provide --input <file> or --stdin");
                 Environment.Exit(1);
-                return;
+                return 1;
             }
-
             var (client, _) = CommandHelper.BuildClient();
             var service = new ItemsService(client);
             var result = await service.BatchGetAsync(jsonBody);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.BatchGetResponse);
-        }, inputOption, stdinOption);
-
+            return 0;
+        });
         return command;
     }
 
     private static Command CreateScanCommand()
     {
-        var idOption = new Option<string>("--id", "Item ID") { IsRequired = true };
+        var idOption = new Option<string>("--id") { Description = "Item ID", Required = true };
         var command = new Command("scan", "Scan a single library item (admin-only, sync)") { idOption };
         command.AddExamples(
             "abs-cli items scan --id \"li_abc123\"",
             "abs-cli items scan --id \"li_abc123\" | jq '.result'");
         command.AddResponseExample<ScanResult>();
-        command.SetHandler(async (string id) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var id = parseResult.GetValue(idOption)!;
             var (client, _) = CommandHelper.BuildClient();
             var service = new ItemsService(client);
             var result = await service.ScanAsync(id);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.ScanResult);
-        }, idOption);
+            return 0;
+        });
         return command;
     }
 }

--- a/src/AbsCli/Commands/LibrariesCommand.cs
+++ b/src/AbsCli/Commands/LibrariesCommand.cs
@@ -10,73 +10,77 @@ public static class LibrariesCommand
     public static Command Create()
     {
         var command = new Command("libraries", "Manage libraries");
-        command.AddCommand(CreateListCommand());
-        command.AddCommand(CreateGetCommand());
-        command.AddCommand(CreateScanCommand());
+        command.Subcommands.Add(CreateListCommand());
+        command.Subcommands.Add(CreateGetCommand());
+        command.Subcommands.Add(CreateScanCommand());
         return command;
     }
 
     private static Command CreateListCommand()
     {
-        var serverOption = new Option<string?>("--server", "Server URL override");
-        var tokenOption = new Option<string?>("--token", "Token override");
-
+        var serverOption = new Option<string?>("--server") { Description = "Server URL override" };
+        var tokenOption = new Option<string?>("--token") { Description = "Token override" };
         var command = new Command("list", "List all libraries") { serverOption, tokenOption };
         command.AddExamples(
             "abs-cli libraries list",
             "abs-cli libraries list | jq '.libraries[].name'");
         command.AddResponseExample<LibraryListResponse>();
-
-        command.SetHandler(async (string? server, string? token) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var server = parseResult.GetValue(serverOption);
+            var token = parseResult.GetValue(tokenOption);
             var (client, _) = CommandHelper.BuildClient(serverOverride: server, tokenOverride: token);
             var service = new LibrariesService(client);
             var result = await service.ListAsync();
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.LibraryListResponse);
-        }, serverOption, tokenOption);
-
+            return 0;
+        });
         return command;
     }
 
     private static Command CreateGetCommand()
     {
-        var idOption = new Option<string>("--id", "Library ID") { IsRequired = true };
-        var serverOption = new Option<string?>("--server", "Server URL override");
-        var tokenOption = new Option<string?>("--token", "Token override");
-
+        var idOption = new Option<string>("--id") { Description = "Library ID", Required = true };
+        var serverOption = new Option<string?>("--server") { Description = "Server URL override" };
+        var tokenOption = new Option<string?>("--token") { Description = "Token override" };
         var command = new Command("get", "Get a single library") { idOption, serverOption, tokenOption };
         command.AddExamples(
             "abs-cli libraries get --id \"lib_abc123\"",
             "abs-cli libraries get --id \"lib_abc123\" | jq '.name'");
         command.AddResponseExample<Library>();
-
-        command.SetHandler(async (string id, string? server, string? token) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var id = parseResult.GetValue(idOption)!;
+            var server = parseResult.GetValue(serverOption);
+            var token = parseResult.GetValue(tokenOption);
             var (client, _) = CommandHelper.BuildClient(serverOverride: server, tokenOverride: token);
             var service = new LibrariesService(client);
             var result = await service.GetAsync(id);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.Library);
-        }, idOption, serverOption, tokenOption);
-
+            return 0;
+        });
         return command;
     }
 
     private static Command CreateScanCommand()
     {
-        var idOption = new Option<string?>("--id", "Library ID (or default from config)");
-        var forceOption = new Option<bool>("--force", "Force full rescan");
+        var idOption = new Option<string?>("--id") { Description = "Library ID (or default from config)" };
+        var forceOption = new Option<bool>("--force") { Description = "Force full rescan" };
         var command = new Command("scan", "Trigger a library scan (admin-only, async)") { idOption, forceOption };
         command.AddExamples(
             "abs-cli libraries scan",
             "abs-cli libraries scan --force",
             "abs-cli libraries scan --id \"lib_abc123\"");
-        command.SetHandler(async (string? id, bool force) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var id = parseResult.GetValue(idOption);
+            var force = parseResult.GetValue(forceOption);
             var (client, config) = CommandHelper.BuildClient(libraryOverride: id);
             var libraryId = CommandHelper.RequireLibrary(config);
             var service = new LibrariesService(client);
             await service.ScanAsync(libraryId, force);
-        }, idOption, forceOption);
+            return 0;
+        });
         return command;
     }
 }

--- a/src/AbsCli/Commands/LoginCommand.cs
+++ b/src/AbsCli/Commands/LoginCommand.cs
@@ -9,10 +9,10 @@ public static class LoginCommand
 {
     public static Command Create()
     {
-        var serverOption = new Option<string?>(
-            "--server",
-            "Audiobookshelf server URL");
-
+        var serverOption = new Option<string?>("--server")
+        {
+            Description = "Audiobookshelf server URL"
+        };
         var command = new Command("login", "Authenticate with an Audiobookshelf server")
         {
             serverOption
@@ -20,42 +20,34 @@ public static class LoginCommand
         command.AddExamples(
             "abs-cli login --server https://abs.example.com",
             "abs-cli login");
-
-        command.SetHandler(async (string? server) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var server = parseResult.GetValue(serverOption);
             var configManager = new ConfigManager();
-
             if (server == null)
             {
                 Console.Error.Write("Server URL: ");
                 server = Console.ReadLine()?.Trim();
             }
-
             if (string.IsNullOrEmpty(server))
             {
                 ConsoleOutput.WriteError("Server URL is required.");
                 Environment.Exit(1);
             }
-
             Console.Error.Write("Username: ");
             var username = Console.ReadLine()?.Trim();
-
             Console.Error.Write("Password: ");
             var password = ReadPassword();
-
             if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
             {
                 ConsoleOutput.WriteError("Username and password are required.");
                 Environment.Exit(1);
             }
-
             var tempConfig = new AppConfig { Server = server };
             var client = new AbsApiClient(tempConfig, configManager);
-
             try
             {
-                var loginResponse = await client.LoginAsync(username, password);
-
+                var loginResponse = await client.LoginAsync(username!, password!);
                 var config = configManager.Load();
                 // Server changed — drop the previous defaultLibrary so we don't
                 // carry a stale ID that doesn't exist on the new server.
@@ -65,16 +57,12 @@ public static class LoginCommand
                 config.Server = server;
                 config.AccessToken = loginResponse.User.AccessToken;
                 config.RefreshToken = loginResponse.User.RefreshToken;
-
                 if (config.DefaultLibrary == null && loginResponse.UserDefaultLibraryId != null)
                     config.DefaultLibrary = loginResponse.UserDefaultLibraryId;
-
                 configManager.Save(config);
                 AbsApiClient.CheckServerVersion(loginResponse.ServerSettings?.Version);
-
                 var version = loginResponse.ServerSettings?.Version ?? "unknown";
                 Console.Error.WriteLine($"Logged in as {loginResponse.User.Username} to {server} (ABS {version})");
-
                 if (config.DefaultLibrary != null)
                     Console.Error.WriteLine($"Default library: {config.DefaultLibrary}");
                 else
@@ -85,8 +73,8 @@ public static class LoginCommand
                 ConsoleOutput.WriteError($"Login failed: {ex.Message}");
                 Environment.Exit(2);
             }
-        }, serverOption);
-
+            return 0;
+        });
         return command;
     }
 

--- a/src/AbsCli/Commands/MetadataCommand.cs
+++ b/src/AbsCli/Commands/MetadataCommand.cs
@@ -10,17 +10,17 @@ public static class MetadataCommand
     public static Command Create()
     {
         var command = new Command("metadata", "Search metadata providers");
-        command.AddCommand(CreateSearchCommand());
-        command.AddCommand(CreateProvidersCommand());
-        command.AddCommand(CreateCoversCommand());
+        command.Subcommands.Add(CreateSearchCommand());
+        command.Subcommands.Add(CreateProvidersCommand());
+        command.Subcommands.Add(CreateCoversCommand());
         return command;
     }
 
     private static Command CreateSearchCommand()
     {
-        var providerOption = new Option<string>("--provider", "Metadata provider (e.g. audible)") { IsRequired = true };
-        var titleOption = new Option<string>("--title", "Book title to search") { IsRequired = true };
-        var authorOption = new Option<string?>("--author", "Author name to narrow results");
+        var providerOption = new Option<string>("--provider") { Description = "Metadata provider (e.g. audible)", Required = true };
+        var titleOption = new Option<string>("--title") { Description = "Book title to search", Required = true };
+        var authorOption = new Option<string?>("--author") { Description = "Author name to narrow results" };
         var command = new Command("search", "Search for book metadata from a provider")
         {
             providerOption, titleOption, authorOption
@@ -28,13 +28,17 @@ public static class MetadataCommand
         command.AddExamples(
             "abs-cli metadata search --provider audible --title \"The Way of Kings\"",
             "abs-cli metadata search --provider audible --title \"Mistborn\" --author \"Brandon Sanderson\"");
-        command.SetHandler(async (string provider, string title, string? author) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var provider = parseResult.GetValue(providerOption)!;
+            var title = parseResult.GetValue(titleOption)!;
+            var author = parseResult.GetValue(authorOption);
             var (client, _) = CommandHelper.BuildClient();
             var service = new MetadataService(client);
             var result = await service.SearchAsync(provider, title, author);
             ConsoleOutput.WriteRawJson(result);
-        }, providerOption, titleOption, authorOption);
+            return 0;
+        });
         return command;
     }
 
@@ -45,21 +49,22 @@ public static class MetadataCommand
             "abs-cli metadata providers",
             "abs-cli metadata providers | jq '.providers.books[].value'");
         command.AddResponseExample<MetadataProvidersResponse>();
-        command.SetHandler(async () =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             var (client, _) = CommandHelper.BuildClient();
             var service = new MetadataService(client);
             var result = await service.ListProvidersAsync();
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.MetadataProvidersResponse);
+            return 0;
         });
         return command;
     }
 
     private static Command CreateCoversCommand()
     {
-        var providerOption = new Option<string>("--provider", "Cover provider") { IsRequired = true };
-        var titleOption = new Option<string>("--title", "Book title to search") { IsRequired = true };
-        var authorOption = new Option<string?>("--author", "Author name to narrow results");
+        var providerOption = new Option<string>("--provider") { Description = "Cover provider", Required = true };
+        var titleOption = new Option<string>("--title") { Description = "Book title to search", Required = true };
+        var authorOption = new Option<string?>("--author") { Description = "Author name to narrow results" };
         var command = new Command("covers", "Search for book cover images")
         {
             providerOption, titleOption, authorOption
@@ -68,13 +73,17 @@ public static class MetadataCommand
             "abs-cli metadata covers --provider audible --title \"The Way of Kings\"",
             "abs-cli metadata covers --provider audible --title \"Mistborn\" --author \"Brandon Sanderson\"");
         command.AddResponseExample<CoverSearchResponse>();
-        command.SetHandler(async (string provider, string title, string? author) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var provider = parseResult.GetValue(providerOption)!;
+            var title = parseResult.GetValue(titleOption)!;
+            var author = parseResult.GetValue(authorOption);
             var (client, _) = CommandHelper.BuildClient();
             var service = new MetadataService(client);
             var result = await service.SearchCoversAsync(provider, title, author);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.CoverSearchResponse);
-        }, providerOption, titleOption, authorOption);
+            return 0;
+        });
         return command;
     }
 }

--- a/src/AbsCli/Commands/SearchCommand.cs
+++ b/src/AbsCli/Commands/SearchCommand.cs
@@ -9,10 +9,9 @@ public static class SearchCommand
 {
     public static Command Create()
     {
-        var queryOption = new Option<string>("--query", "Search text") { IsRequired = true };
-        var libraryOption = new Option<string?>("--library", "Library ID or name");
-        var limitOption = new Option<int>("--limit", () => 50, "Max results (default 50, pass higher value to retrieve more)");
-
+        var queryOption = new Option<string>("--query") { Description = "Search text", Required = true };
+        var libraryOption = new Option<string?>("--library") { Description = "Library ID or name" };
+        var limitOption = new Option<int>("--limit") { Description = "Max results (default 50, pass higher value to retrieve more)", DefaultValueFactory = _ => 50 };
         var command = new Command("search", "Search across a library (defaults to 50 results)")
         {
             queryOption, libraryOption, limitOption
@@ -37,16 +36,18 @@ public static class SearchCommand
             "abs-cli search --query \"Fantasy\" | jq '.book[].libraryItem.media.metadata.title'");
         command.AddResponseExample<SearchResult>();
         command.AddMediaUnionShapes();
-
-        command.SetHandler(async (string query, string? library, int limit) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var query = parseResult.GetValue(queryOption)!;
+            var library = parseResult.GetValue(libraryOption);
+            var limit = parseResult.GetValue(limitOption);
             var (client, config) = CommandHelper.BuildClient(libraryOverride: library);
             var libraryId = CommandHelper.RequireLibrary(config);
             var service = new SearchService(client);
             var result = await service.SearchAsync(libraryId, query, limit);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.SearchResult);
-        }, queryOption, libraryOption, limitOption);
-
+            return 0;
+        });
         return command;
     }
 }

--- a/src/AbsCli/Commands/SelfTestCommand.cs
+++ b/src/AbsCli/Commands/SelfTestCommand.cs
@@ -14,7 +14,7 @@ public static class SelfTestCommand
         var command = new Command("self-test",
             "Verify AOT binary integrity — exercises all serialization paths without network access");
 
-        command.SetHandler(() =>
+        command.SetAction(parseResult =>
         {
             var pass = 0;
             var fail = 0;

--- a/src/AbsCli/Commands/SeriesCommand.cs
+++ b/src/AbsCli/Commands/SeriesCommand.cs
@@ -19,17 +19,16 @@ public static class SeriesCommand
             "Neither 'series list' nor 'series get' returns the books in a series —",
             "they return series entities only. To list books in a specific series:",
             "  abs-cli items list --filter \"series=<series-id>\" --sort sequence");
-        command.AddCommand(CreateListCommand());
-        command.AddCommand(CreateGetCommand());
+        command.Subcommands.Add(CreateListCommand());
+        command.Subcommands.Add(CreateGetCommand());
         return command;
     }
 
     private static Command CreateListCommand()
     {
-        var libraryOption = new Option<string?>("--library", "Library ID or name");
-        var limitOption = new Option<int>("--limit", () => 50, "Results per page (default 50, pass higher value to retrieve more)");
-        var pageOption = new Option<int?>("--page", "Page number (0-indexed)");
-
+        var libraryOption = new Option<string?>("--library") { Description = "Library ID or name" };
+        var limitOption = new Option<int>("--limit") { Description = "Results per page (default 50, pass higher value to retrieve more)", DefaultValueFactory = _ => 50 };
+        var pageOption = new Option<int?>("--page") { Description = "Page number (0-indexed)" };
         var command = new Command("list",
             "List series in a library (defaults to 50 results)")
         { libraryOption, limitOption, pageOption };
@@ -38,36 +37,38 @@ public static class SeriesCommand
             "abs-cli series list --limit 10 --page 0",
             "abs-cli series list --limit 100 | jq '.results[].name'");
         command.AddResponseExample(typeof(PaginatedResponse), typeof(SeriesItem));
-
-        command.SetHandler(async (string? library, int limit, int? page) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var library = parseResult.GetValue(libraryOption);
+            var limit = parseResult.GetValue(limitOption);
+            var page = parseResult.GetValue(pageOption);
             var (client, config) = CommandHelper.BuildClient(libraryOverride: library);
             var libraryId = CommandHelper.RequireLibrary(config);
             var service = new SeriesService(client);
             var result = await service.ListAsync(libraryId, limit, page);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.PaginatedResponse);
-        }, libraryOption, limitOption, pageOption);
-
+            return 0;
+        });
         return command;
     }
 
     private static Command CreateGetCommand()
     {
-        var idOption = new Option<string>("--id", "Series ID") { IsRequired = true };
+        var idOption = new Option<string>("--id") { Description = "Series ID", Required = true };
         var command = new Command("get", "Get a single series") { idOption };
         command.AddExamples(
             "abs-cli series get --id \"se_abc123\"",
             "abs-cli series get --id \"se_abc123\" | jq '.name'");
         command.AddResponseExample<SeriesItem>();
-
-        command.SetHandler(async (string id) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
+            var id = parseResult.GetValue(idOption)!;
             var (client, _) = CommandHelper.BuildClient();
             var service = new SeriesService(client);
             var result = await service.GetAsync(id);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.SeriesItem);
-        }, idOption);
-
+            return 0;
+        });
         return command;
     }
 }

--- a/src/AbsCli/Commands/TasksCommand.cs
+++ b/src/AbsCli/Commands/TasksCommand.cs
@@ -10,7 +10,7 @@ public static class TasksCommand
     public static Command Create()
     {
         var command = new Command("tasks", "Manage server tasks");
-        command.AddCommand(CreateListCommand());
+        command.Subcommands.Add(CreateListCommand());
         return command;
     }
 
@@ -22,12 +22,13 @@ public static class TasksCommand
             "abs-cli tasks list | jq '.tasks[] | select(.isFinished==false)'",
             "abs-cli tasks list | jq '.tasks[] | {action, title, isFinished}'");
         command.AddResponseExample<TaskListResponse>();
-        command.SetHandler(async () =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             var (client, _) = CommandHelper.BuildClient();
             var service = new TasksService(client);
             var result = await service.ListAsync();
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.TaskListResponse);
+            return 0;
         });
         return command;
     }

--- a/src/AbsCli/Commands/UploadCommand.cs
+++ b/src/AbsCli/Commands/UploadCommand.cs
@@ -10,19 +10,25 @@ public static class UploadCommand
 {
     public static Command Create()
     {
-        var libraryOption = new Option<string?>("--library", "Library ID or name");
-        var folderOption = new Option<string?>("--folder", "Folder ID (auto-resolved if library has one folder)");
-        var titleOption = new Option<string>("--title", "Book title") { IsRequired = true };
-        var authorOption = new Option<string?>("--author", "Book author");
-        var seriesOption = new Option<string?>("--series", "Series name");
-        var sequenceOption = new Option<string?>("--sequence", "Series sequence (requires --series). Any non-empty string — integer (\"1\"), decimal (\"1.5\"), or free-form (\"0\", \"II\"). Becomes the \"N. -\" prefix on the item folder.");
-        var waitOption = new Option<bool>("--wait",
-            "After upload, poll until the item appears in the library (up to ~2min) and return its full LibraryItemMinified. Without --wait, a terse UploadReceipt is returned immediately.");
-        var filesOption = new Option<string[]>("--files", "File paths to upload (mutually exclusive with --files-manifest)") { AllowMultipleArgumentsPerToken = true };
-        var prefixSourceDirOption = new Option<bool>("--prefix-source-dir",
-            "Prefix each upload filename with its parent directory name (avoids collisions when files from multiple source dirs share basenames)");
-        var manifestOption = new Option<string?>("--files-manifest",
-            "Path to JSON manifest mapping {src, as} pairs (or '-' for stdin). Mutually exclusive with --files and --prefix-source-dir.");
+        var libraryOption = new Option<string?>("--library") { Description = "Library ID or name" };
+        var folderOption = new Option<string?>("--folder") { Description = "Folder ID (auto-resolved if library has one folder)" };
+        var titleOption = new Option<string>("--title") { Description = "Book title", Required = true };
+        var authorOption = new Option<string?>("--author") { Description = "Book author" };
+        var seriesOption = new Option<string?>("--series") { Description = "Series name" };
+        var sequenceOption = new Option<string?>("--sequence") { Description = "Series sequence (requires --series). Any non-empty string — integer (\"1\"), decimal (\"1.5\"), or free-form (\"0\", \"II\"). Becomes the \"N. -\" prefix on the item folder." };
+        var waitOption = new Option<bool>("--wait")
+        {
+            Description = "After upload, poll until the item appears in the library (up to ~2min) and return its full LibraryItemMinified. Without --wait, a terse UploadReceipt is returned immediately."
+        };
+        var filesOption = new Option<string[]>("--files") { Description = "File paths to upload (mutually exclusive with --files-manifest)", AllowMultipleArgumentsPerToken = true };
+        var prefixSourceDirOption = new Option<bool>("--prefix-source-dir")
+        {
+            Description = "Prefix each upload filename with its parent directory name (avoids collisions when files from multiple source dirs share basenames)"
+        };
+        var manifestOption = new Option<string?>("--files-manifest")
+        {
+            Description = "Path to JSON manifest mapping {src, as} pairs (or '-' for stdin). Mutually exclusive with --files and --prefix-source-dir."
+        };
         var command = new Command("upload", "Upload audiobook files to a library")
         {
             libraryOption, folderOption, titleOption, authorOption,
@@ -74,47 +80,47 @@ public static class UploadCommand
         command.AddResponseExample<UploadReceipt>();
         command.AddHelpSection("Response shape (with --wait, on success)",
             "LibraryItemMinified — same shape as 'abs-cli items get --help'.");
-        command.SetHandler(async (context) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
-            var library = context.ParseResult.GetValueForOption(libraryOption);
-            var folder = context.ParseResult.GetValueForOption(folderOption);
-            var title = context.ParseResult.GetValueForOption(titleOption)!;
-            var author = context.ParseResult.GetValueForOption(authorOption);
-            var series = context.ParseResult.GetValueForOption(seriesOption);
-            var sequence = context.ParseResult.GetValueForOption(sequenceOption);
-            var wait = context.ParseResult.GetValueForOption(waitOption);
-            var files = context.ParseResult.GetValueForOption(filesOption) ?? Array.Empty<string>();
-            var prefixSourceDir = context.ParseResult.GetValueForOption(prefixSourceDirOption);
-            var manifestPath = context.ParseResult.GetValueForOption(manifestOption);
+            var library = parseResult.GetValue(libraryOption);
+            var folder = parseResult.GetValue(folderOption);
+            var title = parseResult.GetValue(titleOption)!;
+            var author = parseResult.GetValue(authorOption);
+            var series = parseResult.GetValue(seriesOption);
+            var sequence = parseResult.GetValue(sequenceOption);
+            var wait = parseResult.GetValue(waitOption);
+            var files = parseResult.GetValue(filesOption) ?? Array.Empty<string>();
+            var prefixSourceDir = parseResult.GetValue(prefixSourceDirOption);
+            var manifestPath = parseResult.GetValue(manifestOption);
             if (sequence != null && series == null)
             {
                 ConsoleOutput.WriteError("--sequence requires --series.");
                 Environment.Exit(1);
-                return;
+                return 1;
             }
             if (sequence != null && string.IsNullOrWhiteSpace(sequence))
             {
                 ConsoleOutput.WriteError("--sequence must be a non-empty string.");
                 Environment.Exit(1);
-                return;
+                return 1;
             }
             if (manifestPath != null && files.Length > 0)
             {
                 ConsoleOutput.WriteError("--files and --files-manifest are mutually exclusive.");
                 Environment.Exit(1);
-                return;
+                return 1;
             }
             if (manifestPath != null && prefixSourceDir)
             {
                 ConsoleOutput.WriteError("--prefix-source-dir and --files-manifest are mutually exclusive.");
                 Environment.Exit(1);
-                return;
+                return 1;
             }
             if (manifestPath == null && files.Length == 0)
             {
                 ConsoleOutput.WriteError("Pass --files <path>... or --files-manifest <path|->.");
                 Environment.Exit(1);
-                return;
+                return 1;
             }
             var uploadList = manifestPath != null
                 ? await BuildFromManifestAsync(manifestPath)
@@ -125,7 +131,7 @@ public static class UploadCommand
                 {
                     ConsoleOutput.WriteError($"File not found: {entry.LocalPath}");
                     Environment.Exit(1);
-                    return;
+                    return 1;
                 }
             }
             CheckForDuplicates(uploadList);
@@ -151,7 +157,7 @@ public static class UploadCommand
                         $"ABS may still be scanning — re-run: abs-cli items list --sort addedAt --desc --limit 5");
                     ConsoleOutput.WriteJson(receipt, AppJsonContext.Default.UploadReceipt);
                     Environment.Exit(1);
-                    return;
+                    return 1;
                 }
                 ConsoleOutput.WriteJson(item, AppJsonContext.Default.LibraryItemMinified);
             }
@@ -159,6 +165,7 @@ public static class UploadCommand
             {
                 ConsoleOutput.WriteJson(receipt, AppJsonContext.Default.UploadReceipt);
             }
+            return 0;
         });
         return command;
     }

--- a/src/AbsCli/Program.cs
+++ b/src/AbsCli/Program.cs
@@ -1,27 +1,22 @@
 using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.Parsing;
 using AbsCli.Commands;
 
 var rootCommand = new RootCommand("abs-cli — Audiobookshelf CLI");
 
-rootCommand.AddCommand(LoginCommand.Create());
-rootCommand.AddCommand(ConfigCommand.Create());
-rootCommand.AddCommand(LibrariesCommand.Create());
-rootCommand.AddCommand(ItemsCommand.Create());
-rootCommand.AddCommand(SeriesCommand.Create());
-rootCommand.AddCommand(AuthorsCommand.Create());
-rootCommand.AddCommand(SearchCommand.Create());
-rootCommand.AddCommand(BackupCommand.Create());
-rootCommand.AddCommand(UploadCommand.Create());
-rootCommand.AddCommand(TasksCommand.Create());
-rootCommand.AddCommand(MetadataCommand.Create());
-rootCommand.AddCommand(SelfTestCommand.Create());
-rootCommand.AddCommand(ChangelogCommand.Create());
+rootCommand.Subcommands.Add(LoginCommand.Create());
+rootCommand.Subcommands.Add(ConfigCommand.Create());
+rootCommand.Subcommands.Add(LibrariesCommand.Create());
+rootCommand.Subcommands.Add(ItemsCommand.Create());
+rootCommand.Subcommands.Add(SeriesCommand.Create());
+rootCommand.Subcommands.Add(AuthorsCommand.Create());
+rootCommand.Subcommands.Add(SearchCommand.Create());
+rootCommand.Subcommands.Add(BackupCommand.Create());
+rootCommand.Subcommands.Add(UploadCommand.Create());
+rootCommand.Subcommands.Add(TasksCommand.Create());
+rootCommand.Subcommands.Add(MetadataCommand.Create());
+rootCommand.Subcommands.Add(SelfTestCommand.Create());
+rootCommand.Subcommands.Add(ChangelogCommand.Create());
 
-var parser = new CommandLineBuilder(rootCommand)
-    .UseDefaults()
-    .UseCustomHelpSections()
-    .Build();
+HelpExtensions.UseCustomHelpSections(rootCommand);
 
-return await parser.InvokeAsync(args);
+return await rootCommand.Parse(args).InvokeAsync();

--- a/src/AbsCli/Program.cs
+++ b/src/AbsCli/Program.cs
@@ -17,6 +17,6 @@ rootCommand.Subcommands.Add(MetadataCommand.Create());
 rootCommand.Subcommands.Add(SelfTestCommand.Create());
 rootCommand.Subcommands.Add(ChangelogCommand.Create());
 
-HelpExtensions.UseCustomHelpSections(rootCommand);
+rootCommand.UseCustomHelpSections();
 
 return await rootCommand.Parse(args).InvokeAsync();

--- a/tests/AbsCli.Tests/AbsCli.Tests.csproj
+++ b/tests/AbsCli.Tests/AbsCli.Tests.csproj
@@ -10,10 +10,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -31,8 +37,7 @@
     `dotnet run` for end-to-end validation of the tool binary.
   -->
   <ItemGroup>
-    <Compile Include="..\..\tools\GenerateResponseExamples\SampleJsonWalker.cs"
-             Link="Commands\SampleJsonWalker.cs" />
+    <Compile Include="..\..\tools\GenerateResponseExamples\SampleJsonWalker.cs" Link="Commands\SampleJsonWalker.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/AbsCli.Tests/Commands/ChangelogCommandTests.cs
+++ b/tests/AbsCli.Tests/Commands/ChangelogCommandTests.cs
@@ -1,7 +1,4 @@
 using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.IO;
-using System.CommandLine.Parsing;
 using AbsCli.Commands;
 using Xunit;
 
@@ -9,14 +6,12 @@ namespace AbsCli.Tests.Commands;
 
 public class ChangelogCommandTests
 {
-    private static int Invoke(TestConsole console, params string[] args)
+    private static int Invoke(StringWriter output, params string[] args)
     {
         var root = new RootCommand();
-        root.AddCommand(ChangelogCommand.Create());
-        var parser = new CommandLineBuilder(root)
-            .UseDefaults()
-            .Build();
-        return parser.Invoke(args, console);
+        root.Subcommands.Add(ChangelogCommand.Create());
+        var config = new InvocationConfiguration { Output = output };
+        return root.Parse(args).Invoke(config);
     }
 
     private static string FirstVersionHeading()
@@ -47,10 +42,9 @@ public class ChangelogCommandTests
     [Fact]
     public void Default_PrintsLatestEntryStartingAtTopmostHeading()
     {
-        var console = new TestConsole();
-        var exit = Invoke(console, "changelog");
-        var stdout = console.Out.ToString() ?? "";
-
+        var output = new StringWriter();
+        var exit = Invoke(output, "changelog");
+        var stdout = output.ToString();
         Assert.Equal(0, exit);
         Assert.StartsWith(FirstVersionHeading(), stdout);
     }
@@ -58,10 +52,9 @@ public class ChangelogCommandTests
     [Fact]
     public void All_PrintsFullFileStartingWithTopHeader()
     {
-        var console = new TestConsole();
-        var exit = Invoke(console, "changelog", "--all");
-        var stdout = console.Out.ToString() ?? "";
-
+        var output = new StringWriter();
+        var exit = Invoke(output, "changelog", "--all");
+        var stdout = output.ToString();
         Assert.Equal(0, exit);
         Assert.StartsWith("# Changelog", stdout);
     }
@@ -69,13 +62,12 @@ public class ChangelogCommandTests
     [Fact]
     public void All_OutputIsLongerThanDefault()
     {
-        var defaultConsole = new TestConsole();
-        Invoke(defaultConsole, "changelog");
-        var allConsole = new TestConsole();
-        Invoke(allConsole, "changelog", "--all");
-
-        var defaultLen = (defaultConsole.Out.ToString() ?? "").Length;
-        var allLen = (allConsole.Out.ToString() ?? "").Length;
+        var defaultOut = new StringWriter();
+        Invoke(defaultOut, "changelog");
+        var allOut = new StringWriter();
+        Invoke(allOut, "changelog", "--all");
+        var defaultLen = defaultOut.ToString().Length;
+        var allLen = allOut.ToString().Length;
         Assert.True(allLen > defaultLen,
             $"--all output ({allLen} chars) should be longer than default ({defaultLen})");
     }

--- a/tests/AbsCli.Tests/Commands/HelpExtensionsTests.cs
+++ b/tests/AbsCli.Tests/Commands/HelpExtensionsTests.cs
@@ -1,7 +1,4 @@
 using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.IO;
-using System.CommandLine.Parsing;
 using AbsCli.Commands;
 
 namespace AbsCli.Tests.Commands;
@@ -10,14 +7,12 @@ public class HelpExtensionsTests
 {
     private static string RenderHelp(Command command)
     {
-        var console = new TestConsole();
         var root = new RootCommand { command };
-        var parser = new CommandLineBuilder(root)
-            .UseDefaults()
-            .UseCustomHelpSections()
-            .Build();
-        parser.Invoke(new[] { command.Name, "--help" }, console);
-        return console.Out.ToString() ?? "";
+        HelpExtensions.UseCustomHelpSections(root);
+        var output = new StringWriter();
+        var config = new InvocationConfiguration { Output = output };
+        root.Parse(new[] { command.Name, "--help" }).Invoke(config);
+        return output.ToString();
     }
 
     [Fact]
@@ -25,9 +20,7 @@ public class HelpExtensionsTests
     {
         var cmd = new Command("demo", "Demo command");
         cmd.AddHelpSection("Notes", HelpSectionPosition.Top, "Top-placed content");
-
         var output = RenderHelp(cmd);
-
         var notesIdx = output.IndexOf("Notes:", StringComparison.Ordinal);
         var optionsIdx = output.IndexOf("Options:", StringComparison.Ordinal);
         Assert.True(notesIdx >= 0, "Notes section missing");
@@ -40,9 +33,7 @@ public class HelpExtensionsTests
     {
         var cmd = new Command("demo", "Demo command");
         cmd.AddHelpSection("Examples", HelpSectionPosition.Bottom, "abs-cli demo");
-
         var output = RenderHelp(cmd);
-
         var examplesIdx = output.IndexOf("Examples:", StringComparison.Ordinal);
         var optionsIdx = output.IndexOf("Options:", StringComparison.Ordinal);
         Assert.True(examplesIdx > optionsIdx, "Examples should render after Options");
@@ -53,9 +44,7 @@ public class HelpExtensionsTests
     {
         var cmd = new Command("demo", "Demo command");
         cmd.AddHelpSection("Examples", "abs-cli demo");
-
         var output = RenderHelp(cmd);
-
         var examplesIdx = output.IndexOf("Examples:", StringComparison.Ordinal);
         var optionsIdx = output.IndexOf("Options:", StringComparison.Ordinal);
         Assert.True(examplesIdx > optionsIdx, "Default overload must remain Bottom-placed");
@@ -66,7 +55,6 @@ public class HelpExtensionsTests
     {
         var cmd = new Command("demo", "Demo");
         cmd.AddResponseExample<AbsCli.Models.AuthorItem>();
-
         var output = RenderHelp(cmd);
         Assert.Contains("Response shape:", output);
         Assert.Contains("\"numBooks\"", output);
@@ -79,7 +67,6 @@ public class HelpExtensionsTests
         cmd.AddResponseExample(
             typeof(AbsCli.Models.PaginatedResponse),
             typeof(AbsCli.Models.LibraryItemMinified));
-
         var output = RenderHelp(cmd);
         Assert.Contains("Response shape:", output);
         Assert.Contains("\"results\"", output);

--- a/tests/AbsCli.Tests/Commands/HelpExtensionsTests.cs
+++ b/tests/AbsCli.Tests/Commands/HelpExtensionsTests.cs
@@ -8,7 +8,7 @@ public class HelpExtensionsTests
     private static string RenderHelp(Command command)
     {
         var root = new RootCommand { command };
-        HelpExtensions.UseCustomHelpSections(root);
+        root.UseCustomHelpSections();
         var output = new StringWriter();
         var config = new InvocationConfiguration { Output = output };
         root.Parse(new[] { command.Name, "--help" }).Invoke(config);

--- a/tests/AbsCli.Tests/Commands/HelpOutputTests.cs
+++ b/tests/AbsCli.Tests/Commands/HelpOutputTests.cs
@@ -16,7 +16,7 @@ public class HelpOutputTests
         root.Subcommands.Add(TasksCommand.Create());
         root.Subcommands.Add(MetadataCommand.Create());
         root.Subcommands.Add(SearchCommand.Create());
-        HelpExtensions.UseCustomHelpSections(root);
+        root.UseCustomHelpSections();
         var output = new StringWriter();
         var config = new InvocationConfiguration { Output = output };
         var args = path.Concat(new[] { "--help" }).ToArray();

--- a/tests/AbsCli.Tests/Commands/HelpOutputTests.cs
+++ b/tests/AbsCli.Tests/Commands/HelpOutputTests.cs
@@ -1,7 +1,4 @@
 using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.IO;
-using System.CommandLine.Parsing;
 using AbsCli.Commands;
 
 namespace AbsCli.Tests.Commands;
@@ -11,24 +8,20 @@ public class HelpOutputTests
     private static string RenderHelp(params string[] path)
     {
         var root = new RootCommand();
-        root.AddCommand(AuthorsCommand.Create());
-        root.AddCommand(SeriesCommand.Create());
-        root.AddCommand(ItemsCommand.Create());
-        root.AddCommand(LibrariesCommand.Create());
-        root.AddCommand(BackupCommand.Create());
-        root.AddCommand(TasksCommand.Create());
-        root.AddCommand(MetadataCommand.Create());
-        root.AddCommand(SearchCommand.Create());
-
-        var parser = new CommandLineBuilder(root)
-            .UseDefaults()
-            .UseCustomHelpSections()
-            .Build();
-
-        var console = new TestConsole();
+        root.Subcommands.Add(AuthorsCommand.Create());
+        root.Subcommands.Add(SeriesCommand.Create());
+        root.Subcommands.Add(ItemsCommand.Create());
+        root.Subcommands.Add(LibrariesCommand.Create());
+        root.Subcommands.Add(BackupCommand.Create());
+        root.Subcommands.Add(TasksCommand.Create());
+        root.Subcommands.Add(MetadataCommand.Create());
+        root.Subcommands.Add(SearchCommand.Create());
+        HelpExtensions.UseCustomHelpSections(root);
+        var output = new StringWriter();
+        var config = new InvocationConfiguration { Output = output };
         var args = path.Concat(new[] { "--help" }).ToArray();
-        parser.Invoke(args, console);
-        return console.Out.ToString() ?? "";
+        root.Parse(args).Invoke(config);
+        return output.ToString();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Three library-hygiene concerns delivered as one PR with logically separated commits.

- **NuGet Audit policy** — new `Directory.Build.props` at repo root turns audit warnings (`NU1901`/`NU1902`/`NU1903`/`NU1904`) into build errors, audit-mode `all` (transitive scanning). Inherited by all three csproj. Confirmed: current package set produces zero audit findings.
- **Test packages bumped to xUnit v3** — `xunit` 2.5.3 → `xunit.v3` 3.2.2, `xunit.runner.visualstudio` → 3.1.5, `Microsoft.NET.Test.Sdk` → 18.4.0, `coverlet.collector` → 10.0.0. Zero test source changes — `using Xunit;` and all our `Assert.*` usage works as-is in v3.
- **System.CommandLine bumped from `2.0.0-beta4` (July 2022) to `2.0.7` stable** — atomic migration across `Program.cs`, `HelpExtensions.cs`, all 14 command files, and 3 test files. `CommandLineBuilder` → `CommandLineConfiguration`, `SetHandler` → `SetAction`, `GetValueForOption` → `GetValue`. Custom help-builder rewritten as `CustomHelpAction : SynchronousCommandLineAction` wrapping the default `HelpAction` and replacing it on `HelpOption` once on the root (recursively applied to subcommands by SCL). User-facing help-output format identical to beta4 — verified by existing `HelpOutputTests` + `HelpExtensionsTests` passing without assertion changes.

GitHub-side, **Dependabot alerts and security updates were enabled in repo Settings** (out-of-band, no `dependabot.yml` in branch). Vuln-only policy: zero PR noise on routine version bumps; auto-PR only when an advisory has a fix. NuGet Audit is the build-time channel; Dependabot is the publish-time channel.

All version strings exact-pinned (no floating ranges).

Spec: `docs/specs/2026-04-28-library-upgrades-and-security.md` · Plan: `docs/plans/2026-04-28-library-upgrades-and-security.md`.

## Test plan

- [x] Local Debug build clean: 0 warnings, 0 errors at every commit
- [x] Full unit test suite green at every commit: 103 / 103
- [x] `dotnet format --verify-no-changes` exit 0 at every commit
- [x] AOT Release publish on `linux-x64`: succeeds, 8.6 MB binary (down from 8.9 MB pre-SCL-bump — improved trimmer)
- [x] `abs-cli self-test` against the AOT binary: 34 / 34
- [x] `abs-cli changelog` against the AOT binary: prints topmost `## ` heading
- [x] Help-output spot-check on AOT binary: top-positioned `Notes:` renders before `Description:`, bottom sections render after `Options:` with correct indent
- [x] Live smoke test (`docker/smoke-test.sh`) against a freshly seeded ABS using the AOT binary: 116 / 116
- [ ] Reviewer: pull the branch, run `dotnet test` locally; confirm xUnit v3 runner works in your environment
- [ ] CI: 6-platform AOT matrix green