### PR TITLE
fix: use 'best' provider for smoke cover-URL lookup

### DIFF
--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -874,15 +874,18 @@ if [ -n "$SERVER_COVER_PATH" ]; then
 fi
 
 # --- Mode 3: --url (POST with {url}; ABS server downloads) ---
-# Uses the google metadata provider against a known-seeded book to obtain a
-# real cover URL. Google + Storm Front (or whichever the first seeded book
-# is) is reliable enough to run unconditionally.
+# Looks up the first seeded item's title/author in-flight so the cover
+# query always tracks whatever the current seed actually contains, then
+# asks ABS's `best` meta-provider for cover URLs. `best` aggregates across
+# Google, FantLab, Amazon, etc., which is far more reliable than pinning
+# to any single provider (e.g. Google returns no covers at all for some
+# seeded titles like "Rivers of London").
 item_json=$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null)
 item_title=$(echo "$item_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['media']['metadata'].get('title') or '')")
 item_author=$(echo "$item_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['media']['metadata'].get('authorName') or '')")
 
 if [ -n "$item_title" ]; then
-    covers_json=$($CLI metadata covers --provider google --title "$item_title" --author "$item_author" 2>/dev/null)
+    covers_json=$($CLI metadata covers --provider best --title "$item_title" --author "$item_author" 2>/dev/null)
     cover_url=$(echo "$covers_json" | python3 -c "import sys,json; d=json.load(sys.stdin); r=d.get('results',[]); print(r[0] if r else '')" 2>/dev/null)
 
     if [ -n "$cover_url" ]; then
@@ -905,7 +908,7 @@ if [ -n "$item_title" ]; then
 
         $CLI items cover remove --id "$FIRST_ITEM_ID" > /dev/null 2>&1
     else
-        fail "metadata covers returned a URL for seeded book" "google returned no URLs for '$item_title'"
+        fail "metadata covers returned a URL for seeded book" "best returned no URLs for '$item_title'"
     fi
 else
     fail "items get readable for --url cover test" "could not read item title"


### PR DESCRIPTION
## Summary
- The `items cover set --url` smoke block queried Google for cover URLs against the first seeded item's title. When ABS started returning "Rivers of London" as the first item, Google's books API returned zero covers for it and the smoke failed (`metadata covers returned a URL for seeded book — google returned no URLs for 'Rivers of London'`), blocking the 0.4.0 release preflight.
- Switch the provider from `google` to ABS's `best` meta-provider — it aggregates across Google, FantLab, Amazon, etc. and returns results for every currently-seeded title (verified: 12 results for Rivers of London, 9 for Storm Front).
- The item title/author are still looked up dynamically against `FIRST_ITEM_ID` so the query continues to track whatever the seed actually contains.

## Test plan
- [x] `bash docker/smoke-test.sh` against a clean local docker-compose dev stack — 155 passed, 0 failed
- [x] `dotnet test` — 132/132 pass (unchanged, no code change)