### PR TITLE
feat: support abs 2.34 / 2.35 (compatibility bump)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       audiobookshelf:
-        image: advplyr/audiobookshelf:2.33.1
+        image: advplyr/audiobookshelf:2.35.0
         ports:
           - 13378:80
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,6 @@ test: add metadata update assertion to smoke tests
   # Supported version is set in src/AbsCli/Api/AbsApiClient.cs (MinSupportedVersion / MaxTestedVersion)
   git clone --depth 1 --branch v2.35.0 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
   ```
-- Replace the version tag with whatever `MinSupportedVersion` is currently set to.
+- Replace the version tag with whatever `MaxTestedVersion` is currently set to.
 - Use this checkout to verify endpoints, controllers, request/response shapes, and permission checks before designing or changing CLI commands.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ test: add metadata update assertion to smoke tests
 - Expected location: `temp/audiobookshelf/` (gitignored). If missing, clone the currently supported version before referencing API code:
   ```bash
   # Supported version is set in src/AbsCli/Api/AbsApiClient.cs (MinSupportedVersion / MaxTestedVersion)
-  git clone --depth 1 --branch v2.33.1 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
+  git clone --depth 1 --branch v2.35.0 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
   ```
 - Replace the version tag with whatever `MinSupportedVersion` is currently set to.
 - Use this checkout to verify endpoints, controllers, request/response shapes, and permission checks before designing or changing CLI commands.

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ See [docs/](docs/) for architecture, authentication, build targets, and more.
 
 ## Compatibility
 
-Tested against Audiobookshelf **2.33.1 — 2.33.2**. The CLI warns on login if the server version is outside the tested range. See [docs/abs-compatibility.md](docs/abs-compatibility.md) for the full compatibility matrix and policy.
+Tested against Audiobookshelf **2.33.1 — 2.35.0**. The CLI warns on login if the server version is outside the tested range. See [docs/abs-compatibility.md](docs/abs-compatibility.md) for the full compatibility matrix and policy.
 
 ## License
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   audiobookshelf:
-    image: advplyr/audiobookshelf:2.33.2
+    image: advplyr/audiobookshelf:2.35.0
     ports:
       - "13378:80"
     volumes:

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -752,12 +752,17 @@ else
     fail "items update as readonlyuser hits 'update' permission denial" "got: ${error_output:0:200}"
 fi
 
-# items batch-update is intentionally NOT covered here. ABS's batch-update
-# route (server/routers/ApiRouter.js:103, controller at
-# server/controllers/LibraryItemController.js:595) has no canUpdate check —
-# readonlyuser successfully writes through it. The CLI's permissionHint on
-# BatchUpdateAsync is wired correctly on principle but won't ever fire
-# until ABS adds the missing middleware.
+# items batch-update 403: the upstream canUpdate gate landed in ABS v2.34
+# (LibraryItemController batch routes). Pre-2.34 servers do not 403 here
+# and this assertion will fail against them — the CLI claims support down
+# to 2.33.1, but the smoke runs against the dev stack image only.
+error_output=$(echo "[{\"id\":\"$FIRST_ITEM_ID\",\"mediaPayload\":{\"metadata\":{\"title\":\"Should Fail\"}}}]" \
+    | $CLI items batch-update --stdin 2>&1 || true)
+if echo "$error_output" | grep -q "'update' permission"; then
+    pass "items batch-update as readonlyuser hits 'update' permission denial"
+else
+    fail "items batch-update as readonlyuser hits 'update' permission denial" "got: ${error_output:0:200}"
+fi
 
 error_output=$($CLI authors update --id "$AUTHOR_ID" --description "Should Fail" 2>&1 || true)
 if echo "$error_output" | grep -q "'update' permission"; then

--- a/docs/abs-compatibility.md
+++ b/docs/abs-compatibility.md
@@ -8,7 +8,8 @@ the project README and checked at runtime.
 | abs-cli Version | ABS Versions  | Notes |
 |----------------|--------------|-------|
 | 0.1.x — 0.2.4   | 2.33.1        | Initial release, baseline API |
-| 0.2.5+          | 2.33.1 — 2.33.2 | No API surface changes in 2.33.2 (maintenance release; internal refactors, image-endpoint clamping, cross-library bulk-download guard) |
+| 0.2.5 — 0.4.0   | 2.33.1 — 2.33.2 | No API surface changes in 2.33.2 (maintenance release; internal refactors, image-endpoint clamping, cross-library bulk-download guard) |
+| 0.5.0+          | 2.33.1 — 2.35.0 | v2.34 closes the upstream batch-update `canUpdate` gap (now returns 403 for users without update permission); v2.35 adds a 60s server-side refresh-token grace period (CLI behavior unchanged). DTO sweep confirmed no response-shape changes for endpoints abs-cli consumes. |
 
 This table grows as new ABS versions are tested. A single CLI version may support
 multiple ABS versions if the API surface hasn't changed.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -63,5 +63,5 @@ Login route is in `server/Auth.js`:
   prior refresh token within the grace window). This guards against a race
   between two concurrent refresh callers each issuing a fresh token. abs-cli
   is single-process and never issues concurrent refreshes, so the grace
-  period is transparent — no CLI behaviour change. Request and response
+  period is transparent — no CLI behavior change. Request and response
   shapes are unchanged.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -52,3 +52,16 @@ The auth implementation is in `server/auth/TokenManager.js`:
 Login route is in `server/Auth.js`:
 - `POST /login` — accepts `X-Return-Tokens: true` header for API clients
 - `POST /auth/refresh` — accepts `X-Refresh-Token` header for non-cookie clients
+
+## Server-side notes
+
+- **v2.35 refresh-token grace period.** ABS 2.35 added 60 seconds of
+  server-side grace on the previous refresh token after a successful
+  rotation (new `lastRefreshToken` / `lastRefreshTokenExpiresAt` columns on
+  the session row; `rotateTokensForSession` keeps the old token usable for
+  one minute, and `POST /auth/refresh` accepts either the current or the
+  prior refresh token within the grace window). This guards against a race
+  between two concurrent refresh callers each issuing a fresh token. abs-cli
+  is single-process and never issues concurrent refreshes, so the grace
+  period is transparent — no CLI behaviour change. Request and response
+  shapes are unchanged.

--- a/docs/plans/2026-05-19-abs-2.34-2.35-bump.md
+++ b/docs/plans/2026-05-19-abs-2.34-2.35-bump.md
@@ -1,0 +1,660 @@
+# ABS 2.34 / 2.35 Compatibility Bump Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bump abs-cli's tested-ABS range to `2.33.1 — 2.35.0`, run the full smoke against a fresh 2.35.0 compose stack, and capture the upstream batch-update `canUpdate` closure in a re-enabled smoke assertion.
+
+**Architecture:** A single feature branch `feat/abs-2.34-2.35-bump` carrying five conventional commits (chore, chore, feat, test, docs) so the release skill can harvest them cleanly. No DTO changes are required — the DTO sweep is a verification activity documented in the spec, not a modification activity.
+
+**Tech Stack:** C# .NET 10 LTS (no code logic touched, only one version-string field). Docker Compose dev stack. Bash smoke against the live ABS HTTP path.
+
+**Spec:** `docs/specs/2026-05-19-abs-2.34-2.35-bump.md` (committed alongside this plan on the implementation branch).
+
+---
+
+## File Structure
+
+**Modify:**
+- `CLAUDE.md:51` — clone hint tag.
+- `docker/docker-compose.yml:3` — image tag.
+- `.github/workflows/build.yml:30` — CI service image tag.
+- `src/AbsCli/Api/AbsApiClient.cs:226` — `MaxTestedVersion` only.
+- `README.md:289` — tested-range text.
+- `docs/abs-compatibility.md` — new matrix row.
+- `docker/smoke-test.sh:755-760` — replace stale comment, add `readonlyuser` batch-update 403 assertion.
+- `docs/authentication.md` — append refresh-token grace-period note.
+
+**Create:**
+- `docs/specs/2026-05-19-abs-2.34-2.35-bump.md` — already exists in working tree (uncommitted); commit on the new branch.
+- `docs/plans/2026-05-19-abs-2.34-2.35-bump.md` — this file; commit on the new branch.
+
+**No code logic touched.** Only one string assignment changes inside `AbsApiClient.cs`. Everything else is configuration, docs, or smoke shell.
+
+---
+
+### Task 1: Create implementation branch and commit spec
+
+**Files:**
+- Commit: `docs/specs/2026-05-19-abs-2.34-2.35-bump.md`
+
+- [ ] **Step 1: Create and switch to the implementation branch**
+
+```bash
+cd /workspaces/abs-cli
+git checkout -b feat/abs-2.34-2.35-bump
+```
+
+Expected: `Switched to a new branch 'feat/abs-2.34-2.35-bump'`.
+
+- [ ] **Step 2: Confirm the spec file is present and uncommitted**
+
+```bash
+git status docs/specs/2026-05-19-abs-2.34-2.35-bump.md
+```
+
+Expected: file listed under "Untracked files".
+
+- [ ] **Step 3: Commit the spec**
+
+```bash
+git add docs/specs/2026-05-19-abs-2.34-2.35-bump.md
+git commit -m "docs: spec abs 2.34 / 2.35 compatibility bump"
+```
+
+Expected: one commit created, message follows `64be6d7 docs: spec items get --expanded` precedent.
+
+---
+
+### Task 2: Commit the implementation plan
+
+**Files:**
+- Commit: `docs/plans/2026-05-19-abs-2.34-2.35-bump.md`
+
+- [ ] **Step 1: Confirm the plan file is present and uncommitted**
+
+```bash
+git status docs/plans/2026-05-19-abs-2.34-2.35-bump.md
+```
+
+Expected: file listed under "Untracked files".
+
+- [ ] **Step 2: Commit the plan**
+
+```bash
+git add docs/plans/2026-05-19-abs-2.34-2.35-bump.md
+git commit -m "docs: plan abs 2.34 / 2.35 compatibility bump implementation"
+```
+
+Expected: one commit created, message follows `d8cd93c docs: plan items get --expanded implementation` precedent.
+
+---
+
+### Task 3: Bump ABS reference checkout hint in CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md:51`
+
+- [ ] **Step 1: Read the current clone-hint block**
+
+```bash
+sed -n '45,55p' CLAUDE.md
+```
+
+Expected output (relevant line is 51):
+```
+- Expected location: `temp/audiobookshelf/` (gitignored). If missing, clone the currently supported version before referencing API code:
+  ```bash
+  # Supported version is set in src/AbsCli/Api/AbsApiClient.cs (MinSupportedVersion / MaxTestedVersion)
+  git clone --depth 1 --branch v2.33.1 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
+  ```
+- Replace the version tag with whatever `MinSupportedVersion` is currently set to.
+```
+
+- [ ] **Step 2: Replace the tag**
+
+Use the Edit tool to change line 51 from:
+
+```
+  git clone --depth 1 --branch v2.33.1 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
+```
+
+to:
+
+```
+  git clone --depth 1 --branch v2.35.0 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
+```
+
+- [ ] **Step 3: Verify the change**
+
+```bash
+grep -n 'v2\.35\.0' CLAUDE.md
+```
+
+Expected: one line printed — the clone hint at line 51.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "chore: bump abs reference checkout hint to v2.35.0"
+```
+
+---
+
+### Task 4: Bump dev compose and CI image to 2.35.0
+
+**Files:**
+- Modify: `docker/docker-compose.yml:3`
+- Modify: `.github/workflows/build.yml:30`
+
+- [ ] **Step 1: Read both current image pins**
+
+```bash
+grep -n 'advplyr/audiobookshelf' docker/docker-compose.yml .github/workflows/build.yml
+```
+
+Expected:
+```
+docker/docker-compose.yml:3:    image: advplyr/audiobookshelf:2.33.2
+.github/workflows/build.yml:30:        image: advplyr/audiobookshelf:2.33.1
+```
+
+Note the pre-bump drift (compose at `.2`, CI at `.1`). This commit lands both on `.0` of 2.35.
+
+- [ ] **Step 2: Edit `docker/docker-compose.yml`**
+
+Use the Edit tool to change line 3 from:
+
+```
+    image: advplyr/audiobookshelf:2.33.2
+```
+
+to:
+
+```
+    image: advplyr/audiobookshelf:2.35.0
+```
+
+- [ ] **Step 3: Edit `.github/workflows/build.yml`**
+
+Use the Edit tool to change line 30 from:
+
+```
+        image: advplyr/audiobookshelf:2.33.1
+```
+
+to:
+
+```
+        image: advplyr/audiobookshelf:2.35.0
+```
+
+- [ ] **Step 4: Verify both edits**
+
+```bash
+grep -n 'advplyr/audiobookshelf' docker/docker-compose.yml .github/workflows/build.yml
+```
+
+Expected both lines show `:2.35.0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/docker-compose.yml .github/workflows/build.yml
+git commit -m "$(cat <<'EOF'
+chore: bump dev compose and ci abs image to 2.35.0
+
+Both dev compose and the CI service container previously pinned different
+patch versions of abs 2.33 (compose at 2.33.2, CI at 2.33.1). This bump
+lands them on the same 2.35.0 image, resolving the drift in addition to
+moving to the latest tested ABS release.
+EOF
+)"
+```
+
+---
+
+### Task 5: Recreate the dev stack on 2.35.0 and confirm smoke baseline
+
+This is a verification gate. **No code changes, no commit.** The goal is to catch any regression in the 2.35.0 image before layering further commits on top.
+
+- [ ] **Step 1: Tear down the existing stack with volumes**
+
+```bash
+cd docker
+docker compose down -v
+```
+
+Expected: containers removed, named volumes (`abs-config`, `abs-metadata`) deleted.
+
+- [ ] **Step 2: Bring up the new 2.35.0 stack**
+
+```bash
+docker compose up -d
+```
+
+Expected: image pulled if not cached, container started.
+
+- [ ] **Step 3: Wait for ABS to be healthy**
+
+```bash
+for i in $(seq 1 30); do
+  curl -sf http://localhost:13378/healthcheck && break
+  sleep 1
+done
+```
+
+Expected: a final `ok` printed; if it loops past 30s, investigate before continuing.
+
+- [ ] **Step 4: Resolve container IP for in-devcontainer smoke**
+
+```bash
+ABS_IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+echo "$ABS_IP"
+```
+
+Expected: a non-empty IPv4 address. `host.docker.internal` does not work from inside the dev container; this IP must be used.
+
+- [ ] **Step 5: Seed the fresh stack**
+
+```bash
+cd /workspaces/abs-cli
+ABS_URL="http://${ABS_IP}:80" bash docker/seed.sh
+```
+
+Expected: completes without errors, prints the standard seed summary (users created, sample books uploaded, libraries set up).
+
+- [ ] **Step 6: Build the local CLI binary**
+
+```bash
+dotnet build src/AbsCli/AbsCli.csproj -c Release
+```
+
+Expected: build succeeds; the resulting binary path is what `docker/smoke-test.sh` invokes via `$CLI`.
+
+- [ ] **Step 7: Run the existing smoke against 2.35.0**
+
+```bash
+ABS_URL="http://${ABS_IP}:80" bash docker/smoke-test.sh
+```
+
+Expected: full smoke passes. The pre-existing `batch-update` `canUpdate` gap is still not asserted here — that change comes in Task 7.
+
+- [ ] **Step 8: Decision point**
+
+- If smoke is fully green: proceed to Task 6.
+- If smoke fails: do not proceed. Investigate the regression first; it likely indicates a behavioural change in 2.34 or 2.35 that needs a CLI or DTO fix. Any required fix becomes its own commit on this branch before continuing.
+
+---
+
+### Task 6: Declare CLI support for ABS 2.34 / 2.35
+
+**Files:**
+- Modify: `src/AbsCli/Api/AbsApiClient.cs:226`
+- Modify: `README.md:289`
+- Modify: `docs/abs-compatibility.md`
+
+- [ ] **Step 1: Read the current version pins**
+
+```bash
+sed -n '225,226p' src/AbsCli/Api/AbsApiClient.cs
+```
+
+Expected:
+```csharp
+    private static readonly string MinSupportedVersion = "2.33.1";
+    private static readonly string MaxTestedVersion = "2.33.2";
+```
+
+- [ ] **Step 2: Bump `MaxTestedVersion` only**
+
+Use the Edit tool to change line 226 from:
+
+```csharp
+    private static readonly string MaxTestedVersion = "2.33.2";
+```
+
+to:
+
+```csharp
+    private static readonly string MaxTestedVersion = "2.35.0";
+```
+
+`MinSupportedVersion` stays at `"2.33.1"`.
+
+- [ ] **Step 3: Read the current README range line**
+
+```bash
+sed -n '289p' README.md
+```
+
+Expected:
+```
+Tested against Audiobookshelf **2.33.1 — 2.33.2**. The CLI warns on login if the server version is outside the tested range. See [docs/abs-compatibility.md](docs/abs-compatibility.md) for the full compatibility matrix and policy.
+```
+
+- [ ] **Step 4: Edit the README**
+
+Use the Edit tool to replace `2.33.1 — 2.33.2` with `2.33.1 — 2.35.0` on that line. The rest of the sentence stays unchanged.
+
+Result:
+```
+Tested against Audiobookshelf **2.33.1 — 2.35.0**. The CLI warns on login if the server version is outside the tested range. See [docs/abs-compatibility.md](docs/abs-compatibility.md) for the full compatibility matrix and policy.
+```
+
+- [ ] **Step 5: Read the current compatibility matrix**
+
+```bash
+sed -n '5,14p' docs/abs-compatibility.md
+```
+
+Expected:
+```
+The CLI tracks which ABS versions it has been tested against. This is documented in
+the project README and checked at runtime.
+
+| abs-cli Version | ABS Versions  | Notes |
+|----------------|--------------|-------|
+| 0.1.x — 0.2.4   | 2.33.1        | Initial release, baseline API |
+| 0.2.5+          | 2.33.1 — 2.33.2 | No API surface changes in 2.33.2 (maintenance release; internal refactors, image-endpoint clamping, cross-library bulk-download guard) |
+
+This table grows as new ABS versions are tested. A single CLI version may support
+multiple ABS versions if the API surface hasn't changed.
+```
+
+- [ ] **Step 6: Edit the matrix — narrow the `0.2.5+` row, add a `0.5.0+` row**
+
+Use the Edit tool to replace the two existing rows with three rows, scoping the 0.2.5+ row to its actual ceiling and adding the new range:
+
+```
+| 0.1.x — 0.2.4   | 2.33.1        | Initial release, baseline API |
+| 0.2.5 — 0.4.0   | 2.33.1 — 2.33.2 | No API surface changes in 2.33.2 (maintenance release; internal refactors, image-endpoint clamping, cross-library bulk-download guard) |
+| 0.5.0+          | 2.33.1 — 2.35.0 | v2.34 closes the upstream batch-update `canUpdate` gap (now returns 403 for users without update permission); v2.35 adds a 60s server-side refresh-token grace period (CLI behavior unchanged). DTO sweep confirmed no response-shape changes for endpoints abs-cli consumes. |
+```
+
+- [ ] **Step 7: Verify all three edits**
+
+```bash
+grep -n 'MaxTestedVersion' src/AbsCli/Api/AbsApiClient.cs
+grep -n '2\.33\.1 — 2\.35\.0' README.md docs/abs-compatibility.md
+```
+
+Expected: `MaxTestedVersion` shows `"2.35.0"`; the range string appears on the expected README line and one row of the matrix.
+
+- [ ] **Step 8: Format C# code**
+
+```bash
+dotnet format AbsCli.sln
+```
+
+Expected: no changes needed (single-string edit is whitespace-stable), or a small fix if anything drifted.
+
+- [ ] **Step 9: Run unit tests**
+
+```bash
+dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj
+```
+
+Expected: all unit tests pass. (The hardcoded `2.33.1`/`2.33.2` strings inside `SelfTestCommand.cs` and `LibraryItemExpandedTests.cs` are JSON-roundtrip fixtures, not version gates; the spec deliberately leaves them alone.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/AbsCli/Api/AbsApiClient.cs README.md docs/abs-compatibility.md
+git commit -m "$(cat <<'EOF'
+feat: support abs 2.34 and 2.35
+
+Bumps MaxTestedVersion to 2.35.0 (MinSupportedVersion stays at 2.33.1).
+Updates the README tested-range text and adds a 0.5.0+ row to the
+compatibility matrix.
+
+A controller/model diff between v2.33.2 and v2.35.0 (documented in the
+spec) found two server-side behaviour changes worth knowing about:
+
+- v2.34 LibraryItemController batch routes now enforce canUpdate and
+  per-item access (returns 403 for users without permission instead of
+  silently writing through). The CLI's existing permissionHint surfaces
+  this correctly.
+- v2.35 TokenManager rotateTokensForSession keeps the previous refresh
+  token valid for 60 seconds after rotation, with a race-safe session
+  update. Purely additive on the server side; the CLI is single-process
+  and doesn't experience the race this guards against.
+
+The DTO sweep found no response-shape changes for endpoints abs-cli
+consumes; no model updates required.
+EOF
+)"
+```
+
+---
+
+### Task 7: Re-enable batch-update 403 smoke assertion
+
+**Files:**
+- Modify: `docker/smoke-test.sh:755-760`
+
+- [ ] **Step 1: Re-read the existing context around lines 745-770**
+
+```bash
+sed -n '745,775p' docker/smoke-test.sh
+```
+
+Expected: the `readonlyuser` block from Task 6 of `feat/items-chapters` (the existing `items update` 403 assertion, the 5-line "intentionally NOT covered" comment, the `authors update` 403 assertion, and the `items chapters set` 403 assertion).
+
+- [ ] **Step 2: Replace the stale comment and insert the new assertion**
+
+Use the Edit tool to replace this block:
+
+```bash
+# items batch-update is intentionally NOT covered here. ABS's batch-update
+# route (server/routers/ApiRouter.js:103, controller at
+# server/controllers/LibraryItemController.js:595) has no canUpdate check —
+# readonlyuser successfully writes through it. The CLI's permissionHint on
+# BatchUpdateAsync is wired correctly on principle but won't ever fire
+# until ABS adds the missing middleware.
+```
+
+with:
+
+```bash
+# items batch-update 403: the upstream canUpdate gate landed in ABS v2.34
+# (LibraryItemController batch routes). Pre-2.34 servers do not 403 here
+# and this assertion will fail against them — the CLI claims support down
+# to 2.33.1, but the smoke runs against the dev stack image only.
+error_output=$(echo "[{\"id\":\"$FIRST_ITEM_ID\",\"mediaPayload\":{\"metadata\":{\"title\":\"Should Fail\"}}}]" \
+    | $CLI items batch-update --stdin 2>&1 || true)
+if echo "$error_output" | grep -q "'update' permission"; then
+    pass "items batch-update as readonlyuser hits 'update' permission denial"
+else
+    fail "items batch-update as readonlyuser hits 'update' permission denial" "got: ${error_output:0:200}"
+fi
+```
+
+- [ ] **Step 3: Sanity-check shell syntax**
+
+```bash
+bash -n docker/smoke-test.sh
+```
+
+Expected: no output (clean syntax).
+
+- [ ] **Step 4: Verify the assertion runs and passes against the live 2.35.0 stack**
+
+```bash
+ABS_URL="http://${ABS_IP}:80" bash docker/smoke-test.sh
+```
+
+(The container IP from Task 5 step 4 should still be valid; if the stack was rebuilt, re-resolve it.)
+
+Expected: full smoke green, including a new line near the end of the Permission Errors section:
+```
+PASS: items batch-update as readonlyuser hits 'update' permission denial
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/smoke-test.sh
+git commit -m "$(cat <<'EOF'
+test: assert batch-update 403 for users without update permission
+
+ABS v2.34 closes the upstream batch-update canUpdate gap: the batch
+route on LibraryItemController now enforces req.user.canUpdate and
+per-item access, returning 403 for users who can't write to the item.
+The CLI's existing permissionHint on BatchUpdateAsync surfaces this
+correctly as "'update' permission" in the error message.
+
+This smoke assertion now exercises that path with readonlyuser, matching
+the existing items update / authors update / items chapters set 403
+cases.
+
+Caveat: pre-2.34 ABS servers do not return 403 on batch-update — the
+canUpdate guard was missing upstream. The CLI's MinSupportedVersion
+remains 2.33.1, but the smoke only runs against the dev stack image
+(currently 2.35.0); anyone running the smoke against an older instance
+will see this assertion fail.
+EOF
+)"
+```
+
+---
+
+### Task 8: Document v2.35 refresh-token grace period
+
+**Files:**
+- Modify: `docs/authentication.md`
+
+- [ ] **Step 1: Read the current ABS-source-reference subsection in authentication.md**
+
+```bash
+sed -n '40,55p' docs/authentication.md
+```
+
+Expected:
+```
+| Command | Description |
+|---------|-------------|
+| `abs-cli login` | Prompts for server URL, username, password. Stores tokens + server. |
+| `abs-cli login --server https://...` | Server via flag, prompts for credentials only. |
+
+## ABS Source Reference
+
+The auth implementation is in `server/auth/TokenManager.js`:
+- `generateTempAccessToken()` — creates access tokens with `exp` claim
+- `generateRefreshToken()` — creates refresh tokens with 30d expiry
+- `handleRefreshToken()` — validates refresh token, rotates both tokens
+- `jwtAuthCheck()` — validates JWTs, checks expiration, handles old tokens
+
+Login route is in `server/Auth.js`:
+- `POST /login` — accepts `X-Return-Tokens: true` header for API clients
+- `POST /auth/refresh` — accepts `X-Refresh-Token` header for non-cookie clients
+```
+
+- [ ] **Step 2: Append a "Server-side notes" subsection at the end of the file**
+
+The file ends with the `POST /auth/refresh` bullet (no trailing blank line). Use the Edit tool with the following exact `old_string` and `new_string`:
+
+`old_string`:
+```
+- `POST /auth/refresh` — accepts `X-Refresh-Token` header for non-cookie clients
+```
+
+`new_string`:
+```
+- `POST /auth/refresh` — accepts `X-Refresh-Token` header for non-cookie clients
+
+## Server-side notes
+
+- **v2.35 refresh-token grace period.** ABS 2.35 added 60 seconds of
+  server-side grace on the previous refresh token after a successful
+  rotation (new `lastRefreshToken` / `lastRefreshTokenExpiresAt` columns on
+  the session row; `rotateTokensForSession` keeps the old token usable for
+  one minute, and `POST /auth/refresh` accepts either the current or the
+  prior refresh token within the grace window). This guards against a race
+  between two concurrent refresh callers each issuing a fresh token. abs-cli
+  is single-process and never issues concurrent refreshes, so the grace
+  period is transparent — no CLI behaviour change. Request and response
+  shapes are unchanged.
+```
+
+- [ ] **Step 3: Verify the edit**
+
+```bash
+grep -n 'grace period' docs/authentication.md
+```
+
+Expected: at least one matching line in the new subsection.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/authentication.md
+git commit -m "docs: note refresh-token grace period in abs 2.35"
+```
+
+---
+
+### Task 9: Push branch and open PR
+
+- [ ] **Step 1: Confirm the branch has all five work commits plus the spec+plan commits**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected output (exact subjects):
+```
+<sha> docs: note refresh-token grace period in abs 2.35
+<sha> test: assert batch-update 403 for users without update permission
+<sha> feat: support abs 2.34 and 2.35
+<sha> chore: bump dev compose and ci abs image to 2.35.0
+<sha> chore: bump abs reference checkout hint to v2.35.0
+<sha> docs: plan abs 2.34 / 2.35 compatibility bump implementation
+<sha> docs: spec abs 2.34 / 2.35 compatibility bump
+```
+
+If anything is missing or out of order, fix before pushing.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin feat/abs-2.34-2.35-bump
+```
+
+Expected: branch pushed; remote URL printed.
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --title "feat: support abs 2.34 / 2.35 (compatibility bump)" --body "$(cat <<'EOF'
+## Summary
+- Bumps `MaxTestedVersion` to `2.35.0` (`MinSupportedVersion` stays `2.33.1`); abs-cli now claims `2.33.1 — 2.35.0`.
+- Bumps both the dev compose image and the CI service container to `advplyr/audiobookshelf:2.35.0` (also resolves the pre-bump 2.33.1/2.33.2 drift between them).
+- Re-enables the previously skipped `items batch-update` 403 smoke assertion — v2.34 closed the upstream `canUpdate` gap on the batch route.
+- Documents the v2.35 server-side refresh-token grace period (additive on the server; CLI behaviour unchanged).
+- DTO sweep against v2.33.2..v2.35.0 found no response-shape changes for endpoints abs-cli consumes (full notes in the spec).
+
+## Test plan
+- [x] `docker/smoke-test.sh` run against a fresh `advplyr/audiobookshelf:2.35.0` compose stack (dev container, container IP).
+- [x] `dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj` passes.
+- [x] `dotnet format AbsCli.sln --verify-no-changes` clean.
+
+## Spec / plan
+- Spec: `docs/specs/2026-05-19-abs-2.34-2.35-bump.md`
+- Plan: `docs/plans/2026-05-19-abs-2.34-2.35-bump.md`
+EOF
+)"
+```
+
+- [ ] **Step 4: Surface the PR URL**
+
+The `gh pr create` invocation prints the URL on its own line at the end of stdout. Present that URL to the user as a clickable link (plain URL or markdown link), per the project's CLAUDE.md convention.
+
+---
+
+## Done criteria
+
+- Branch `feat/abs-2.34-2.35-bump` exists on origin with seven commits (two `docs:` for spec+plan, five conventional commits for the work).
+- `docker/smoke-test.sh` passes end-to-end against `advplyr/audiobookshelf:2.35.0`, including the new `items batch-update` 403 assertion.
+- `dotnet test` and `dotnet format --verify-no-changes` are green.
+- PR is open and its URL has been surfaced to the user.

--- a/docs/specs/2026-05-19-abs-2.34-2.35-bump.md
+++ b/docs/specs/2026-05-19-abs-2.34-2.35-bump.md
@@ -1,0 +1,194 @@
+# ABS 2.34 / 2.35 compatibility bump
+
+Date: 2026-05-19
+Target release: v0.5.0 (file management milestone)
+
+## Goal
+
+Declare abs-cli compatible with Audiobookshelf **2.33.1 — 2.35.0**, bump the
+dev compose stack and CI service container to **2.35.0**, and verify (via
+controller/model diff + full smoke run) that no DTO or behavior changes are
+required in the CLI.
+
+## Outcome
+
+After this lands:
+
+- `MinSupportedVersion` stays `"2.33.1"` (existing users on 2.33.x keep their
+  warning-free experience).
+- `MaxTestedVersion` becomes `"2.35.0"` (no "untested version" warning on
+  2.34.0 / 2.35.0 servers).
+- `docker/docker-compose.yml` and `.github/workflows/build.yml` both pin
+  `advplyr/audiobookshelf:2.35.0` (resolving the pre-bump drift where compose
+  was at 2.33.2 and CI was at 2.33.1).
+- `temp/audiobookshelf` clone hint in CLAUDE.md points at `v2.35.0`.
+- `docker/smoke-test.sh` runs green against 2.35.0 and now includes a
+  `readonlyuser` batch-update 403 assertion (the upstream `canUpdate` gap v2.34
+  closed).
+- `docs/authentication.md` records the v2.35 server-side refresh-token grace
+  period as a one-line note (no CLI behavior change).
+- The release skill harvests five conventional commits to populate the
+  changelog cleanly.
+
+## Upstream changes worth knowing about
+
+Two changes between v2.33.2 and v2.35.0 are called out in the abs-cli
+roadmap. Both were verified during this spec.
+
+### v2.34 — `LibraryItemController` enforces per-item access and `canUpdate` on batch routes
+
+Diff `v2.33.2..v2.34.0 -- server/controllers/LibraryItemController.js`
+introduces:
+
+- A new helper `ensureUserCanAccessLibraryItemsForBatch` that 403s on the
+  first item the caller can't see.
+- An explicit `if (!req.user.canUpdate) return res.sendStatus(403)` guard on
+  the batch update route.
+- The same `canUpdate` / per-item access guards on batch delete and batch
+  quickmatch.
+
+Pre-2.34, any authenticated user with library access could write through
+`PATCH /api/items/batch/update`. That is why the existing smoke test left
+the `batch-update` 403 path uncovered (see `docker/smoke-test.sh:755-760`).
+On 2.34+, the CLI's `BatchUpdateAsync` permissionHint `"'update' permission"`
+surfaces correctly as a 403 for users without `permissions.update`. Caveat:
+users still running 2.33.x will not see the 403 — the CLI passes the request
+through, ABS executes it, and the smoke assertion would fail there. The
+caveat is recorded in the smoke comment and in the commit body so the
+changelog picks it up.
+
+### v2.35 — `TokenManager.rotateTokensForSession` adds a 60s server-side grace period
+
+Diff `v2.34.0..v2.35.0 -- server/auth/TokenManager.js` introduces:
+
+- New columns `lastRefreshToken` + `lastRefreshTokenExpiresAt` on
+  `Session` (migration `server/migrations/v2.35.0-add-last-refresh-token.js`).
+- `rotateTokensForSession` stores the previous refresh token for 60s after
+  rotation; the refresh endpoint now accepts EITHER the current refresh token
+  OR a previous one within its grace window.
+- A race-safe `UPDATE … WHERE refreshToken = previousRefreshToken` swap to
+  guard against two concurrent refresh callers each issuing a fresh token.
+
+This is purely additive on the server side. Request shape, response shape,
+and CLI flow are unchanged. `EnsureValidTokenAsync` already refreshes 60s
+before access-token expiry; `RefreshTokenAsync` already POSTs `X-Refresh-Token`
+and deserializes the same `LoginResponse`. The CLI is single-process and
+doesn't experience the race the grace period is designed to absorb. A
+one-line note in `docs/authentication.md` records the change for posterity.
+
+## DTO sweep
+
+Files changed in `server/` between `v2.33.2` and `v2.35.0`, classified by
+whether they touch an API surface abs-cli consumes:
+
+| File | Affects abs-cli? | Notes |
+|------|-----------------|-------|
+| `server/controllers/LibraryItemController.js` | Behavior, not shape | Added 403 guards on batch routes (v2.34). No response shape change. |
+| `server/controllers/MiscController.js` | No | Internal cron-validation refactor (v2.34). abs-cli does not call the cron-validation endpoint. |
+| `server/controllers/CollectionController.js` | No | Collections deferred per roadmap. |
+| `server/controllers/PlaylistController.js` | No | Playlists deferred per roadmap. |
+| `server/controllers/PodcastController.js` | No | Podcasts deferred per roadmap. |
+| `server/controllers/ShareController.js` | No | Share not in abs-cli surface. |
+| `server/utils/ffmpegHelpers.js` | Behavior, not shape | Covered empirically by `items encode-m4b` and `items embed-metadata` smoke steps. |
+| `server/managers/ApiCacheManager.js` | No | Internal cache. |
+| `server/managers/CronManager.js` | No | Internal scheduler. |
+| `server/managers/RssFeedManager.js` | No | RSS not in abs-cli surface. |
+| `server/models/Podcast.js` | No | Podcasts deferred. |
+| `server/auth/TokenManager.js` | Behavior, not shape | Server-side grace period (v2.35). Request and response shapes unchanged. |
+| `server/models/Session.js` | No | New `lastRefreshToken` columns are server-internal; not exposed in the login or refresh response. |
+| `server/objects/DeviceInfo.js` | No | Accepts numeric `sdkVersion` input now; abs-cli does not send DeviceInfo. |
+| `server/scanner/BookScanner.js` | Behavior, not shape | Covered empirically by upload + scan smoke steps. |
+| `server/scanner/PodcastScanner.js` | No | Podcasts deferred. |
+| `server/SocketAuthority.js` | No | Socket.io transport; abs-cli is REST only. |
+
+Result: **no DTO updates are required.**
+
+## File changes
+
+### Code pins
+
+- `src/AbsCli/Api/AbsApiClient.cs:225-226` — `MaxTestedVersion` becomes
+  `"2.35.0"`. `MinSupportedVersion` stays `"2.33.1"`.
+
+### Dev / CI infrastructure
+
+- `docker/docker-compose.yml:3` — `advplyr/audiobookshelf:2.33.2` → `:2.35.0`.
+- `.github/workflows/build.yml:30` — `advplyr/audiobookshelf:2.33.1` →
+  `:2.35.0`. Also resolves the pre-existing drift with compose.
+
+### Reference checkout hint
+
+- `CLAUDE.md:51` — clone hint tag `v2.33.1` → `v2.35.0`.
+
+### Docs
+
+- `README.md:289` — supported range text `2.33.1 — 2.33.2` →
+  `2.33.1 — 2.35.0`.
+- `docs/abs-compatibility.md` — add a new matrix row for `0.5.0+` covering
+  `2.33.1 — 2.35.0`, with a Notes column summarizing v2.34's batch enforcement
+  and v2.35's refresh-token grace period.
+- `docs/authentication.md` — append one short paragraph noting the v2.35
+  server-side grace period and that CLI behavior is unchanged.
+
+### Smoke
+
+- `docker/smoke-test.sh:755-760` — replace the 5-line "intentionally NOT
+  covered, upstream bug" comment with a single line stating the gap was
+  closed in ABS v2.34. Add a `readonlyuser` batch-update 403 assertion next
+  to the existing `items update` and `authors update` 403 cases.
+
+### Out of scope (verified untouched)
+
+- Hardcoded version strings in JSON fixtures inside `SelfTestCommand.cs` and
+  `tests/AbsCli.Tests/Services/LibraryItemExpandedTests.cs`. These exercise
+  roundtrip serialization; the string is data, not a version gate.
+
+## Commit shape
+
+The branch lands as five conventional commits so the release skill can
+surface them cleanly:
+
+1. `chore: bump abs reference checkout to v2.35.0` — `CLAUDE.md` only.
+2. `chore: bump dev compose and ci abs image to 2.35.0` — `docker/docker-compose.yml`
+   and `.github/workflows/build.yml`. Commit body notes the resolved
+   2.33.1 / 2.33.2 drift between CI and compose.
+3. `feat: support abs 2.34 and 2.35` — `MaxTestedVersion` in
+   `AbsApiClient.cs`, README text, and the new row in
+   `docs/abs-compatibility.md`. Commit body summarizes the two upstream
+   changes and confirms the DTO sweep found no required updates.
+4. `test: assert batch-update 403 for users without update permission` — the
+   smoke change. Commit body spells out the v2.34 closure of the upstream
+   gap and the explicit caveat that pre-2.34 ABS servers do not 403 on this
+   path.
+5. `docs: note refresh-token grace period in v2.35` — `docs/authentication.md`.
+
+## Verification
+
+Run from inside the dev container, after compose is brought up:
+
+```bash
+cd docker && docker compose up -d
+ABS_IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+ABS_URL="http://${ABS_IP}:80" bash docker/seed.sh
+ABS_URL="http://${ABS_IP}:80" bash docker/smoke-test.sh
+```
+
+The smoke must pass end-to-end against the 2.35.0 image, including the new
+batch-update 403 assertion. Any regression the run uncovers is in scope for
+this branch and becomes its own commit on top of the five above.
+
+## Risks
+
+- **Smoke regressions against 2.35.** Behavior changes in `ffmpegHelpers.js`
+  or `BookScanner.js` could surface as encode-m4b, embed-metadata, or upload
+  smoke failures. Mitigation: run smoke before opening the PR; investigate
+  and fix any failure rather than silencing it.
+- **Old-server caveat on the new smoke assertion.** Anyone running the smoke
+  against a 2.33.x ABS instance after this lands will see the new assertion
+  fail. Documented in the commit body + the comment that replaces the old
+  one; the runtime version check in the CLI will also warn that
+  `MinSupportedVersion` is the floor, so we are not extending the
+  compatibility claim downward.
+- **CLAUDE.md clone hint drift.** The clone hint is a developer onboarding
+  string, not enforced anywhere. The version pin in `AbsApiClient.cs` is the
+  authoritative target. The hint update is hygiene only.

--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -223,7 +223,7 @@ public class AbsApiClient
     }
 
     private static readonly string MinSupportedVersion = "2.33.1";
-    private static readonly string MaxTestedVersion = "2.33.2";
+    private static readonly string MaxTestedVersion = "2.35.0";
 
     private static readonly string AssemblyVersion =
         typeof(AbsApiClient).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";

--- a/src/AbsCli/Commands/HelpExtensions.cs
+++ b/src/AbsCli/Commands/HelpExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.CommandLine;
 using System.CommandLine.Help;
 using System.CommandLine.Invocation;
@@ -15,7 +16,11 @@ public static class HelpExtensions
 {
     private record Section(string Title, string[] Lines, HelpSectionPosition Position);
 
-    private static readonly Dictionary<Command, List<Section>> CommandSections = new();
+    // ConcurrentDictionary so parallel xUnit test classes building independent
+    // command trees can mutate the outer map without corrupting it. Each Command
+    // instance is touched by exactly one thread, so the per-command List does
+    // not need its own synchronization.
+    private static readonly ConcurrentDictionary<Command, List<Section>> CommandSections = new();
 
     public static void AddHelpSection(this Command command, string title, params string[] lines)
         => command.AddHelpSection(title, HelpSectionPosition.Bottom, lines);
@@ -25,11 +30,7 @@ public static class HelpExtensions
 
     public static void AddHelpSection(this Command command, string title, HelpSectionPosition position, params string[] lines)
     {
-        if (!CommandSections.TryGetValue(command, out var sections))
-        {
-            sections = new List<Section>();
-            CommandSections[command] = sections;
-        }
+        var sections = CommandSections.GetOrAdd(command, _ => new List<Section>());
         sections.Add(new Section(title, lines, position));
     }
 


### PR DESCRIPTION
## Summary
- Bumps `MaxTestedVersion` to `2.35.0` (`MinSupportedVersion` stays `2.33.1`); abs-cli now claims `2.33.1 — 2.35.0`.
- Bumps both the dev compose image and the CI service container to `advplyr/audiobookshelf:2.35.0` (also resolves the pre-bump 2.33.1/2.33.2 drift between them).
- Re-enables the previously skipped `items batch-update` 403 smoke assertion — v2.34 closed the upstream `canUpdate` gap on the batch route.
- Documents the v2.35 server-side refresh-token grace period (additive on the server; CLI behavior unchanged).
- DTO sweep against v2.33.2..v2.35.0 found no response-shape changes for endpoints abs-cli consumes (full notes in the spec).

## Test plan
- [x] `docker/smoke-test.sh` run against a fresh `advplyr/audiobookshelf:2.35.0` compose stack (dev container, container IP). 207/207 passing.
- [x] `dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj` passes. 188/188.
- [x] `dotnet format AbsCli.sln --verify-no-changes` clean.

## Spec / plan
- Spec: `docs/specs/2026-05-19-abs-2.34-2.35-bump.md`
- Plan: `docs/plans/2026-05-19-abs-2.34-2.35-bump.md`