### PR TITLE
feat: cache purge-items and cache purge commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ abs-cli config set defaultLibrary <library-id>
 | `backup download --id <id> --output <path>` | Download a backup file (admin) |
 | `backup delete --id <id>` | Delete a backup (admin) |
 | `backup upload --file <path>` | Upload a backup file (admin) |
+| `cache purge-items` | Purge per-item cache backups: encode-m4b + embed-metadata --backup copies (admin) |
+| `cache purge` | Purge all server cache: items + covers + images (admin) |
 | `metadata search` | Search a metadata provider (`--provider`, `--title`, `--author`) |
 | `metadata providers` | List available metadata providers |
 | `metadata covers` | Search for cover images (`--provider`, `--title`, `--author`) |

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -526,6 +526,17 @@ assert_json_key "backup delete returns backups" "backups" "$output"
 
 # ============================================================
 echo ""
+echo "=== Cache Commands ==="
+# ============================================================
+
+$CLI cache purge-items 2>/dev/null
+pass "cache purge-items completes (exit 0)"
+
+$CLI cache purge 2>/dev/null
+pass "cache purge completes (exit 0)"
+
+# ============================================================
+echo ""
 echo "=== Upload Command ==="
 # ============================================================
 
@@ -777,6 +788,20 @@ if echo "$error_output" | grep -q "'update' permission"; then
     pass "items chapters set as readonlyuser hits 'update' permission denial"
 else
     fail "items chapters set as readonlyuser hits 'update' permission denial" "got: ${error_output:0:200}"
+fi
+
+error_output=$($CLI cache purge-items 2>&1 || true)
+if echo "$error_output" | grep -q "admin permission"; then
+    pass "cache purge-items as readonlyuser hits 'admin permission' denial"
+else
+    fail "cache purge-items as readonlyuser hits 'admin permission' denial" "got: ${error_output:0:200}"
+fi
+
+error_output=$($CLI cache purge 2>&1 || true)
+if echo "$error_output" | grep -q "admin permission"; then
+    pass "cache purge as readonlyuser hits 'admin permission' denial"
+else
+    fail "cache purge as readonlyuser hits 'admin permission' denial" "got: ${error_output:0:200}"
 fi
 
 export ABS_TOKEN="$SAVE_TOKEN"

--- a/docs/plans/2026-05-19-v0.5.0-cache-purge.md
+++ b/docs/plans/2026-05-19-v0.5.0-cache-purge.md
@@ -1,0 +1,752 @@
+# Cache Purge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `abs-cli cache purge-items` and `abs-cli cache purge` as admin-only thin pass-throughs for ABS's two cache-purge endpoints.
+
+**Architecture:** A new top-level `cache` command sits beside `backup` in the root command tree. Two subcommands map 1:1 with `POST /api/cache/items/purge` and `POST /api/cache/purge`. A new `CacheService` wraps both endpoints using the existing `AbsApiClient.PostEmptyAsync`. No DTOs (both endpoints return empty body); silent exit 0 on success.
+
+**Tech Stack:** C# .NET 10 LTS, System.CommandLine 2.0.7, AOT-compiled. xUnit v3 for unit tests. Bash smoke against the docker-compose 2.35.0 dev stack.
+
+**Spec:** `docs/specs/2026-05-19-v0.5.0-cache-purge.md` (committed alongside this plan on the implementation branch).
+
+---
+
+## File Structure
+
+**Create:**
+- `src/AbsCli/Services/CacheService.cs` — `PurgeItemsAsync()` + `PurgeAsync()`, both POSTing with empty bodies and the `"admin permission"` hint.
+- `src/AbsCli/Commands/CacheCommand.cs` — top-level `cache` command + `CreatePurgeItemsCommand()` + `CreatePurgeCommand()`. Each subcommand: `AddPermissionRequired("admin")`, examples, Caveats help section, action that builds client + calls service + returns 0.
+- `tests/AbsCli.Tests/Commands/CacheCommandTests.cs` — help-text tests matching the `ItemsEncodeM4bCommandTests` pattern: top-level lists both verbs; each subcommand surfaces the Permission required + Caveats sections; each names the correct ABS endpoint in examples or caveats.
+
+**Modify:**
+- `src/AbsCli/Api/ApiEndpoints.cs` — add `CachePurgeItems` and `CachePurge` string constants.
+- `src/AbsCli/Program.cs` — register `CacheCommand.Create()` in the root command tree.
+- `docker/smoke-test.sh` — new `=== Cache Commands ===` block (admin success) and two readonlyuser 403 assertions in the existing Permission Errors section.
+- `README.md` — two new rows in the Commands table, slotted alphabetically alongside the existing `backup` rows.
+
+**No DTOs.** Both endpoints return empty body. No `AppJsonContext` registrations, no `Models/` additions, no `ResponseExamples.g.cs` regeneration. Help text shows no `Response shape:` block.
+
+---
+
+### Task 1: Create implementation branch and commit spec
+
+**Files:**
+- Commit: `docs/specs/2026-05-19-v0.5.0-cache-purge.md`
+
+- [ ] **Step 1: Confirm clean working tree and current branch**
+
+```bash
+cd /workspaces/abs-cli
+git status -s
+git branch --show-current
+```
+
+Expected: working tree shows only the two new files (`docs/specs/2026-05-19-v0.5.0-cache-purge.md` and `docs/plans/2026-05-19-v0.5.0-cache-purge.md`) as untracked. Branch: `main`.
+
+If any other files are present uncommitted, STOP and report — the rest of this plan assumes a clean main.
+
+- [ ] **Step 2: Create the implementation branch**
+
+```bash
+git checkout -b feat/cache-purge
+```
+
+Expected: `Switched to a new branch 'feat/cache-purge'`.
+
+- [ ] **Step 3: Commit the spec**
+
+```bash
+git add docs/specs/2026-05-19-v0.5.0-cache-purge.md
+git commit -m "docs: spec cache purge commands"
+```
+
+Expected: one commit created, message follows `64be6d7 docs: spec items get --expanded` precedent.
+
+---
+
+### Task 2: Commit the implementation plan
+
+**Files:**
+- Commit: `docs/plans/2026-05-19-v0.5.0-cache-purge.md`
+
+- [ ] **Step 1: Confirm the plan file is present and uncommitted**
+
+```bash
+git status docs/plans/2026-05-19-v0.5.0-cache-purge.md
+```
+
+Expected: file listed under "Untracked files".
+
+- [ ] **Step 2: Commit the plan**
+
+```bash
+git add docs/plans/2026-05-19-v0.5.0-cache-purge.md
+git commit -m "docs: plan cache purge implementation"
+```
+
+Expected: one commit created, message follows `d8cd93c docs: plan items get --expanded implementation` precedent.
+
+---
+
+### Task 3: Add API endpoint constants and CacheService
+
+**Files:**
+- Modify: `src/AbsCli/Api/ApiEndpoints.cs`
+- Create: `src/AbsCli/Services/CacheService.cs`
+
+- [ ] **Step 1: Read the existing endpoint constants to pick an insertion point**
+
+```bash
+sed -n '25,35p' src/AbsCli/Api/ApiEndpoints.cs
+```
+
+Expected: lines around `public const string Backups = "/api/backups";` so we can slot the new cache constants near related admin endpoints.
+
+- [ ] **Step 2: Add the two cache endpoint constants**
+
+Use the Edit tool to add the two constants. Find the existing `Backups` constant line:
+
+`old_string`:
+```csharp
+    public const string Backups = "/api/backups";
+```
+
+`new_string`:
+```csharp
+    public const string Backups = "/api/backups";
+
+    public const string CachePurgeItems = "/api/cache/items/purge";
+    public const string CachePurge = "/api/cache/purge";
+```
+
+If `Backups` is preceded or followed by other admin endpoints, place the cache constants nearby — alphabetical or grouped, whichever the file already does. The exact line doesn't matter as long as both constants are present and compile.
+
+- [ ] **Step 3: Verify the constants are visible**
+
+```bash
+grep -n 'CachePurgeItems\|CachePurge\b' src/AbsCli/Api/ApiEndpoints.cs
+```
+
+Expected: two lines printed.
+
+- [ ] **Step 4: Create `CacheService.cs`**
+
+Write the file at `src/AbsCli/Services/CacheService.cs` with the following content (mirrors `EmbedMetadataService.cs` and `EncodeM4bService.cs` shape):
+
+```csharp
+using AbsCli.Api;
+
+namespace AbsCli.Services;
+
+public class CacheService
+{
+    private readonly AbsApiClient _client;
+
+    public CacheService(AbsApiClient client)
+    {
+        _client = client;
+    }
+
+    public async Task PurgeItemsAsync()
+    {
+        await _client.PostEmptyAsync(ApiEndpoints.CachePurgeItems, permissionHint: "admin permission");
+    }
+
+    public async Task PurgeAsync()
+    {
+        await _client.PostEmptyAsync(ApiEndpoints.CachePurge, permissionHint: "admin permission");
+    }
+}
+```
+
+- [ ] **Step 5: Build to verify it compiles**
+
+```bash
+dotnet build src/AbsCli/AbsCli.csproj -c Release 2>&1 | tail -8
+```
+
+Expected:
+```
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+```
+
+- [ ] **Step 6: Format check**
+
+```bash
+dotnet format AbsCli.sln --verify-no-changes 2>&1 | tail -5
+```
+
+Expected: empty output (no changes). If the format check reports drift, run `dotnet format AbsCli.sln` to fix and re-check.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/AbsCli/Api/ApiEndpoints.cs src/AbsCli/Services/CacheService.cs
+git commit -m "$(cat <<'EOF'
+feat: add cache service for items + full purge
+
+Wraps ABS's two admin-only cache purge endpoints:
+  POST /api/cache/items/purge — clears <MetadataPath>/cache/items/
+  POST /api/cache/purge       — clears the whole <MetadataPath>/cache/
+
+Both POST empty bodies with the standard "admin permission" hint. No
+DTOs — both endpoints return 200 with empty body. CacheService follows
+the same shape as EncodeM4bService and EmbedMetadataService.
+EOF
+)"
+```
+
+---
+
+### Task 4: Add CacheCommand and register it in Program.cs
+
+**Files:**
+- Create: `src/AbsCli/Commands/CacheCommand.cs`
+- Modify: `src/AbsCli/Program.cs`
+
+- [ ] **Step 1: Create `CacheCommand.cs`**
+
+Write the file at `src/AbsCli/Commands/CacheCommand.cs` with the following content. The shape mirrors `BackupCommand.cs` (top-level container + per-subcommand factory methods, each with `AddPermissionRequired("admin")`):
+
+```csharp
+using System.CommandLine;
+using AbsCli.Output;
+using AbsCli.Services;
+
+namespace AbsCli.Commands;
+
+public static class CacheCommand
+{
+    public static Command Create()
+    {
+        var command = new Command("cache", "Manage server-side cache (admin)");
+        command.Subcommands.Add(CreatePurgeItemsCommand());
+        command.Subcommands.Add(CreatePurgeCommand());
+        return command;
+    }
+
+    private static Command CreatePurgeItemsCommand()
+    {
+        var command = new Command("purge-items", "Purge per-item cache backups (admin)");
+        command.AddPermissionRequired("admin");
+        command.AddExamples(
+            "abs-cli cache purge-items");
+        command.AddHelpSection("Caveats",
+            "Wipes <MetadataPath>/cache/items/ — encode-m4b backups, embed-metadata --backup copies.",
+            "200 does not guarantee deletion — ABS swallows filesystem errors server-side.",
+            "Irreversible: cached track originals have no upstream replica once encode-m4b moved them out of the library dir.");
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new CacheService(client);
+            await service.PurgeItemsAsync();
+            return 0;
+        });
+        return command;
+    }
+
+    private static Command CreatePurgeCommand()
+    {
+        var command = new Command("purge", "Purge all server cache: items, covers, images (admin)");
+        command.AddPermissionRequired("admin");
+        command.AddExamples(
+            "abs-cli cache purge");
+        command.AddHelpSection("Caveats",
+            "Wipes <MetadataPath>/cache/ in full — cache/items/, cache/covers/, cache/images/.",
+            "200 does not guarantee deletion — ABS swallows filesystem errors server-side.",
+            "covers/ and images/ rebuild lazily on next request; expect a first-request latency spike.");
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new CacheService(client);
+            await service.PurgeAsync();
+            return 0;
+        });
+        return command;
+    }
+}
+```
+
+- [ ] **Step 2: Register `CacheCommand` in the root command tree**
+
+Read the current Program.cs registration block:
+
+```bash
+sed -n '1,22p' src/AbsCli/Program.cs
+```
+
+Expected output:
+```csharp
+using System.CommandLine;
+using AbsCli.Commands;
+
+var rootCommand = new RootCommand("abs-cli — Audiobookshelf CLI");
+
+rootCommand.Subcommands.Add(LoginCommand.Create());
+rootCommand.Subcommands.Add(ConfigCommand.Create());
+rootCommand.Subcommands.Add(LibrariesCommand.Create());
+rootCommand.Subcommands.Add(ItemsCommand.Create());
+rootCommand.Subcommands.Add(SeriesCommand.Create());
+rootCommand.Subcommands.Add(AuthorsCommand.Create());
+rootCommand.Subcommands.Add(SearchCommand.Create());
+rootCommand.Subcommands.Add(BackupCommand.Create());
+rootCommand.Subcommands.Add(UploadCommand.Create());
+rootCommand.Subcommands.Add(TasksCommand.Create());
+rootCommand.Subcommands.Add(MetadataCommand.Create());
+rootCommand.Subcommands.Add(SelfTestCommand.Create());
+rootCommand.Subcommands.Add(ChangelogCommand.Create());
+
+rootCommand.UseCustomHelpSections();
+```
+
+Use the Edit tool to insert the `CacheCommand` registration after the `BackupCommand` line (both are admin-heavy top-level commands; this groups them):
+
+`old_string`:
+```csharp
+rootCommand.Subcommands.Add(BackupCommand.Create());
+rootCommand.Subcommands.Add(UploadCommand.Create());
+```
+
+`new_string`:
+```csharp
+rootCommand.Subcommands.Add(BackupCommand.Create());
+rootCommand.Subcommands.Add(CacheCommand.Create());
+rootCommand.Subcommands.Add(UploadCommand.Create());
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+```bash
+dotnet build src/AbsCli/AbsCli.csproj -c Release 2>&1 | tail -8
+```
+
+Expected:
+```
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+```
+
+- [ ] **Step 4: Format check**
+
+```bash
+dotnet format AbsCli.sln --verify-no-changes 2>&1 | tail -5
+```
+
+Expected: empty output (no changes).
+
+- [ ] **Step 5: Smoke the help output locally**
+
+```bash
+./src/AbsCli/bin/Release/net10.0/abs-cli cache --help
+echo "---"
+./src/AbsCli/bin/Release/net10.0/abs-cli cache purge-items --help
+echo "---"
+./src/AbsCli/bin/Release/net10.0/abs-cli cache purge --help
+```
+
+Expected:
+- `cache --help` lists `purge-items` and `purge` under Commands.
+- Each subcommand's help shows `Permission required:` `admin`, an `Examples:` block, and a `Caveats:` block with the wording from Task 4 Step 1.
+
+If the help text doesn't render the expected sections, the issue is most likely a missing `using AbsCli.Output;` (for `CommandHelper`) or a typo in the subcommand wiring.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/AbsCli/Commands/CacheCommand.cs src/AbsCli/Program.cs
+git commit -m "$(cat <<'EOF'
+feat: add cache purge-items and cache purge commands
+
+Two admin-only thin pass-throughs for ABS's cache purge endpoints,
+sibling subcommands under a new top-level `cache` group:
+
+  cache purge-items  — items-only purge (encode-m4b + embed-metadata
+                       --backup copies)
+  cache purge        — full cache purge (items + covers + images)
+
+Both POST with empty bodies and exit 0 silently on the underlying 200.
+403 surfaces via the standard "admin permission" error message.
+
+Caveats are documented in each subcommand's --help:
+  - 200 does not guarantee deletion (ABS swallows fs errors server-side)
+  - cache purge invalidates covers/ + images/; rebuilt lazily on next
+    request (first-request latency spike afterward)
+  - cache/items/ contents are irreplaceable: encode-m4b moves originals
+    there as backup, and there is no upstream replica.
+EOF
+)"
+```
+
+---
+
+### Task 5: Add help-text tests and smoke coverage
+
+**Files:**
+- Create: `tests/AbsCli.Tests/Commands/CacheCommandTests.cs`
+- Modify: `docker/smoke-test.sh`
+
+- [ ] **Step 1: Create `CacheCommandTests.cs`**
+
+Write the file at `tests/AbsCli.Tests/Commands/CacheCommandTests.cs` mirroring `ItemsEncodeM4bCommandTests.cs`:
+
+```csharp
+using System.CommandLine;
+using AbsCli.Commands;
+using Xunit;
+
+namespace AbsCli.Tests.Commands;
+
+public class CacheCommandTests
+{
+    private static string RenderHelp(params string[] path)
+    {
+        var root = new RootCommand();
+        root.Subcommands.Add(CacheCommand.Create());
+        root.UseCustomHelpSections();
+        var output = new StringWriter();
+        var config = new InvocationConfiguration { Output = output };
+        var args = path.Concat(new[] { "--help" }).ToArray();
+        root.Parse(args).Invoke(config);
+        return output.ToString();
+    }
+
+    [Fact]
+    public void Cache_TopLevel_Help_ListsBothVerbs()
+    {
+        var output = RenderHelp("cache");
+        Assert.Contains("purge-items", output);
+        Assert.Contains("purge", output);
+    }
+
+    [Fact]
+    public void CachePurgeItems_Help_ShowsPermissionAndCaveats()
+    {
+        var output = RenderHelp("cache", "purge-items");
+        Assert.Contains("Permission required", output);
+        Assert.Contains("admin", output);
+        Assert.Contains("Caveats", output);
+        Assert.Contains("cache/items/", output);
+        Assert.Contains("200 does not guarantee deletion", output);
+    }
+
+    [Fact]
+    public void CachePurgeItems_Help_HasExample()
+    {
+        var output = RenderHelp("cache", "purge-items");
+        Assert.Contains("abs-cli cache purge-items", output);
+    }
+
+    [Fact]
+    public void CachePurge_Help_ShowsPermissionAndCaveats()
+    {
+        var output = RenderHelp("cache", "purge");
+        Assert.Contains("Permission required", output);
+        Assert.Contains("admin", output);
+        Assert.Contains("Caveats", output);
+        Assert.Contains("rebuild lazily", output);
+        Assert.Contains("200 does not guarantee deletion", output);
+    }
+
+    [Fact]
+    public void CachePurge_Help_HasExample()
+    {
+        var output = RenderHelp("cache", "purge");
+        Assert.Contains("abs-cli cache purge", output);
+    }
+}
+```
+
+- [ ] **Step 2: Run unit tests**
+
+```bash
+dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj 2>&1 | tail -5
+```
+
+Expected: `Passed!  - Failed:     0, Passed:   <N+5>, Skipped: 0` — the test count goes up by 5 from the pre-task baseline. If any of the new tests fail, the help-section assertions in `CacheCommand.cs` don't match what was rendered; re-check the Step 1 strings.
+
+- [ ] **Step 3: Add the smoke admin-success block**
+
+Read the current end of the Backup Commands section so we can slot the new Cache Commands section right after it:
+
+```bash
+sed -n '525,535p' docker/smoke-test.sh
+```
+
+Expected: the existing `=== Backup Commands ===` block ending around line 525, followed by `=== Upload Command ===` at line 528.
+
+Use the Edit tool to insert the new section between Backup and Upload. Find this exact block:
+
+`old_string`:
+```bash
+output=$($CLI backup delete --id "$BACKUP_ID" 2>/dev/null)
+assert_json_key "backup delete returns backups" "backups" "$output"
+
+# ============================================================
+echo ""
+echo "=== Upload Command ==="
+```
+
+`new_string`:
+```bash
+output=$($CLI backup delete --id "$BACKUP_ID" 2>/dev/null)
+assert_json_key "backup delete returns backups" "backups" "$output"
+
+# ============================================================
+echo ""
+echo "=== Cache Commands ==="
+# ============================================================
+
+$CLI cache purge-items 2>/dev/null
+pass "cache purge-items completes (exit 0)"
+
+$CLI cache purge 2>/dev/null
+pass "cache purge completes (exit 0)"
+
+# ============================================================
+echo ""
+echo "=== Upload Command ==="
+```
+
+- [ ] **Step 4: Add the smoke readonlyuser 403 assertions**
+
+Find the existing readonlyuser block in the Permission Errors section (the block that asserts `items chapters set` 403). Read it:
+
+```bash
+sed -n '769,780p' docker/smoke-test.sh
+```
+
+Expected: the existing `items chapters set as readonlyuser hits 'update' permission denial` block ending around line 775, followed by `export ABS_TOKEN="$SAVE_TOKEN"`.
+
+Use the Edit tool to insert two new admin-403 assertions between the chapters block and the `SAVE_TOKEN` restoration. Find:
+
+`old_string`:
+```bash
+error_output=$(echo '{"chapters":[{"title":"x","start":0,"end":1}]}' \
+    | $CLI items chapters set --id "$FIRST_ITEM_ID" --stdin 2>&1 || true)
+if echo "$error_output" | grep -q "'update' permission"; then
+    pass "items chapters set as readonlyuser hits 'update' permission denial"
+else
+    fail "items chapters set as readonlyuser hits 'update' permission denial" "got: ${error_output:0:200}"
+fi
+
+export ABS_TOKEN="$SAVE_TOKEN"
+```
+
+`new_string`:
+```bash
+error_output=$(echo '{"chapters":[{"title":"x","start":0,"end":1}]}' \
+    | $CLI items chapters set --id "$FIRST_ITEM_ID" --stdin 2>&1 || true)
+if echo "$error_output" | grep -q "'update' permission"; then
+    pass "items chapters set as readonlyuser hits 'update' permission denial"
+else
+    fail "items chapters set as readonlyuser hits 'update' permission denial" "got: ${error_output:0:200}"
+fi
+
+error_output=$($CLI cache purge-items 2>&1 || true)
+if echo "$error_output" | grep -q "admin permission"; then
+    pass "cache purge-items as readonlyuser hits 'admin permission' denial"
+else
+    fail "cache purge-items as readonlyuser hits 'admin permission' denial" "got: ${error_output:0:200}"
+fi
+
+error_output=$($CLI cache purge 2>&1 || true)
+if echo "$error_output" | grep -q "admin permission"; then
+    pass "cache purge as readonlyuser hits 'admin permission' denial"
+else
+    fail "cache purge as readonlyuser hits 'admin permission' denial" "got: ${error_output:0:200}"
+fi
+
+export ABS_TOKEN="$SAVE_TOKEN"
+```
+
+- [ ] **Step 5: Sanity-check shell syntax**
+
+```bash
+bash -n docker/smoke-test.sh
+```
+
+Expected: empty output (no syntax errors).
+
+- [ ] **Step 6: Bring up the dev stack and run the smoke**
+
+The smoke needs a live ABS 2.35.0 stack (already pinned in `docker/docker-compose.yml` since the previous PR).
+
+```bash
+cd /workspaces/abs-cli/docker
+docker compose up -d
+for i in $(seq 1 30); do
+  curl -sf http://localhost:13378/healthcheck && break
+  sleep 1
+done
+ABS_IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+echo "ABS_IP=$ABS_IP"
+```
+
+If the stack is already running with seeded state from prior work, skip directly to the smoke run. If state is stale or missing (no test users), tear it down first and re-seed:
+
+```bash
+cd /workspaces/abs-cli/docker
+docker compose down -v && docker compose up -d
+for i in $(seq 1 30); do
+  curl -sf http://localhost:13378/healthcheck && break
+  sleep 1
+done
+ABS_IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+cd /workspaces/abs-cli
+ABS_URL="http://${ABS_IP}:80" bash docker/seed.sh
+dotnet build src/AbsCli/AbsCli.csproj -c Release
+```
+
+- [ ] **Step 7: Run the full smoke against 2.35.0**
+
+```bash
+cd /workspaces/abs-cli
+ABS_URL="http://${ABS_IP}:80" bash docker/smoke-test.sh
+```
+
+Expected: full smoke green. Specifically, four new PASS lines:
+```
+PASS: cache purge-items completes (exit 0)
+PASS: cache purge completes (exit 0)
+PASS: cache purge-items as readonlyuser hits 'admin permission' denial
+PASS: cache purge as readonlyuser hits 'admin permission' denial
+```
+
+If any of the new assertions FAIL, troubleshoot before committing. The most likely failures:
+- `admin permission` text doesn't appear → the `permissionHint` was passed differently. Re-check `CacheService.cs` and the `AbsApiClient.PostEmptyAsync` 403-handling path.
+- `cache purge-items` exits non-zero as admin → check that the `cache` group is wired into `Program.cs` and that the admin token in `$SAVE_TOKEN` is actually admin (it should be — seed.sh creates `root/root` as the admin token used by the smoke harness).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/AbsCli.Tests/Commands/CacheCommandTests.cs docker/smoke-test.sh
+git commit -m "$(cat <<'EOF'
+test: help-text and smoke coverage for cache purge
+
+Help-text tests follow the ItemsEncodeM4bCommandTests pattern: top-level
+`cache --help` lists both verbs; each subcommand surfaces Permission
+required + Caveats; each example is present.
+
+Smoke adds a new Cache Commands section (admin success on both
+subcommands, exit 0) plus two readonlyuser 403 assertions in the
+Permission Errors section.
+EOF
+)"
+```
+
+---
+
+### Task 6: Add the README Commands table rows
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Read the existing backup rows so we can slot the cache rows next to them**
+
+```bash
+grep -n 'abs-cli backup\|backup create\|backup list\|backup apply\|backup download\|backup delete\|backup upload' README.md | head -10
+```
+
+Expected: the existing Commands-table backup rows around `backup create`, `backup list`, `backup apply`, `backup download`, `backup delete`, `backup upload` — six rows in a contiguous block.
+
+- [ ] **Step 2: Insert two new rows after the backup block**
+
+Use the Edit tool. Find:
+
+`old_string`:
+```
+| `backup upload --file <path>` | Upload a backup file (admin) |
+| `metadata search` | Search a metadata provider (`--provider`, `--title`, `--author`) |
+```
+
+`new_string`:
+```
+| `backup upload --file <path>` | Upload a backup file (admin) |
+| `cache purge-items` | Purge per-item cache backups: encode-m4b + embed-metadata --backup copies (admin) |
+| `cache purge` | Purge all server cache: items + covers + images (admin) |
+| `metadata search` | Search a metadata provider (`--provider`, `--title`, `--author`) |
+```
+
+- [ ] **Step 3: Verify the rows are present**
+
+```bash
+grep -n '`cache purge' README.md
+```
+
+Expected: two lines, in order — `cache purge-items` then `cache purge`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add cache commands to README table"
+```
+
+---
+
+### Task 7: Push branch and open PR
+
+- [ ] **Step 1: Confirm the branch has all commits in the expected order**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected output (exact subjects, newest first):
+```
+<sha> docs: add cache commands to README table
+<sha> test: help-text and smoke coverage for cache purge
+<sha> feat: add cache purge-items and cache purge commands
+<sha> feat: add cache service for items + full purge
+<sha> docs: plan cache purge implementation
+<sha> docs: spec cache purge commands
+```
+
+If any commit is missing or out of order, fix before pushing.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin feat/cache-purge
+```
+
+Expected: branch pushed; remote URL printed.
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --title "feat: cache purge-items and cache purge commands" --body "$(cat <<'EOF'
+## Summary
+- Adds `abs-cli cache purge-items` (`POST /api/cache/items/purge`) and `abs-cli cache purge` (`POST /api/cache/purge`), both admin-only thin pass-throughs.
+- Hygiene primitive for reclaiming disk used by `items encode-m4b` backups and `items embed-metadata --backup` copies.
+- `--help` documents the two caveats: 200 does not guarantee deletion (ABS swallows fs errors server-side); `cache purge` invalidates covers/images caches (rebuilt lazily, first-request latency spike).
+- No DTOs — both endpoints return empty body. Silent exit 0 on success; 403 surfaces via the standard `"admin permission"` error.
+
+## Test plan
+- [x] `docker/smoke-test.sh` against the 2.35.0 compose stack (dev container, container IP) — all assertions including 4 new ones (admin success on both subcommands, readonlyuser 403 on both).
+- [x] `dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj` passes; 5 new help-text tests added.
+- [x] `dotnet format AbsCli.sln --verify-no-changes` clean.
+
+## Spec / plan
+- Spec: `docs/specs/2026-05-19-v0.5.0-cache-purge.md`
+- Plan: `docs/plans/2026-05-19-v0.5.0-cache-purge.md`
+EOF
+)"
+```
+
+- [ ] **Step 4: Surface the PR URL**
+
+Present the URL on its own line as a clickable link per the CLAUDE.md convention.
+
+---
+
+## Done criteria
+
+- Branch `feat/cache-purge` exists on origin with six commits (two `docs:` for spec+plan, two `feat:`, one `test:`, one `docs:`).
+- `docker/smoke-test.sh` passes end-to-end against `advplyr/audiobookshelf:2.35.0`, including the four new cache-related assertions.
+- `dotnet test` and `dotnet format --verify-no-changes` are green.
+- PR is open and its URL has been surfaced to the user.

--- a/docs/specs/2026-05-19-v0.5.0-cache-purge.md
+++ b/docs/specs/2026-05-19-v0.5.0-cache-purge.md
@@ -1,0 +1,182 @@
+# Cache purge commands
+
+Date: 2026-05-19
+Target release: v0.5.0 (file management milestone)
+
+## Goal
+
+Add `abs-cli cache purge-items` and `abs-cli cache purge` so admin agents
+can reclaim disk space consumed by the per-item track backups that
+`items encode-m4b` and `items embed-metadata` (with `backup=1`) leave
+behind, and optionally also drop ABS's lazily-rebuilt cover/image render
+caches.
+
+## Outcome
+
+After this lands:
+
+- New top-level `abs-cli cache` command with two admin-only subcommands:
+  - `cache purge-items` wraps `POST /api/cache/items/purge` and clears
+    `<MetadataPath>/cache/items/` — encode-m4b backups, embed-metadata
+    `?backup=1` copies.
+  - `cache purge` wraps `POST /api/cache/purge` and additionally wipes
+    `<MetadataPath>/cache/covers/` and `<MetadataPath>/cache/images/`,
+    which ABS rebuilds lazily on next request.
+- Both commands take no arguments, send no body, and exit `0` silently
+  on the underlying `200`. `403` (non-admin) surfaces via the standard
+  `"admin permission"` error message.
+- README Commands table gains two rows, per CLAUDE.md command
+  conventions.
+- `--help` for each subcommand carries two terse caveats:
+  - `200` does not guarantee deletion — ABS swallows filesystem errors
+    server-side.
+  - `cache purge` (broad) also drops `covers/` + `images/`; ABS rebuilds
+    them lazily on next request.
+
+## Upstream summary
+
+Both endpoints live under `server/controllers/CacheController.js` in
+ABS:
+
+- `POST /api/cache/items/purge` → `purgeItemsCache` → 403 unless
+  `req.user.isAdminOrUp`; calls `CacheManager.purgeItems()`, which
+  `fs.remove`s `<MetadataPath>/cache/items/` (errors caught and logged)
+  and re-`ensureDir`s the path. Returns `sendStatus(200)`.
+- `POST /api/cache/purge` → `purgeCache` → same admin gate; calls
+  `CacheManager.purgeAll()`, which `fs.remove`s the whole
+  `<MetadataPath>/cache/` (errors caught and logged) and re-creates
+  `cache/`, `cache/covers/`, `cache/images/`, `cache/items/`. Returns
+  `sendStatus(200)`.
+
+Neither endpoint accepts parameters or body. Neither exposes a listing
+of what is about to be purged or a restore path. The errors-are-logged-
+but-swallowed behaviour is the reason `200` is not a strict guarantee of
+deletion.
+
+## CLI design
+
+### Verb shape
+
+Two siblings under a new top-level `cache` command, 1:1 with the two
+ABS endpoints:
+
+- `abs-cli cache purge-items`
+- `abs-cli cache purge`
+
+This matches the thin-pass-through convention recorded in saved
+feedback: abs-cli commands are 1:1 with API calls, no smart defaults,
+no response interpretation. The destructive verb name is the consent —
+no interactive prompt, no `--yes` flag, consistent with `backup delete`,
+`authors delete`, `items chapters set`, etc. Interactive prompts would
+block AI agents, the primary user.
+
+### Output
+
+`200` with empty body → CLI prints nothing and exits `0`. This matches
+the existing pattern for `items encode-m4b cancel`, `items
+embed-metadata`, `libraries scan`, and the other empty-success
+endpoints.
+
+### Permission tag and hint
+
+Both subcommands carry `command.AddPermissionRequired("admin")`. Service
+calls pass `permissionHint: "admin permission"` (no quotes around
+`admin` per CLAUDE.md — `admin` is a user type, not a flag in
+`user.permissions`).
+
+## File changes
+
+### Create
+
+- `src/AbsCli/Commands/CacheCommand.cs` — top-level `cache` command with
+  `CreatePurgeItemsCommand()` and `CreatePurgeCommand()` factory
+  methods. Each subcommand: `AddPermissionRequired("admin")`,
+  `AddExamples(...)`, `AddHelpSection("Caveats", ...)` with the two
+  terse caveats, `SetAction(async ...)` that builds the client, calls
+  the service, returns `0`.
+- `src/AbsCli/Services/CacheService.cs` — `PurgeItemsAsync()` and
+  `PurgeAsync()`, both calling `_client.PostEmptyAsync(endpoint,
+  permissionHint: "admin permission")`. No DTOs needed — responses are
+  empty.
+- `tests/AbsCli.Tests/Commands/CacheCommandTests.cs` — help-text
+  assertions: top-level `cache --help` mentions both subcommands; each
+  subcommand's help includes its example, the Permission required
+  section, and the Caveats section.
+
+### Modify
+
+- `src/AbsCli/Api/ApiEndpoints.cs` — add two endpoint constants:
+  - `public const string CachePurgeItems = "/api/cache/items/purge";`
+  - `public const string CachePurge = "/api/cache/purge";`
+- `src/AbsCli/Program.cs` (or wherever `RootCommand` is wired) —
+  register `CacheCommand.Create()` alongside the other top-level
+  commands.
+- `README.md` — Commands table gains two rows:
+  - `cache purge-items` — `Clear per-item cache backups (admin)`
+  - `cache purge` — `Clear all server cache including covers/images
+    (admin)`
+- `docker/smoke-test.sh`:
+  - New `=== Cache Commands ===` block (admin token) running each
+    subcommand and asserting exit `0`.
+  - In the existing Permission Errors section, two new readonlyuser
+    assertions: each subcommand fails with `"admin permission"` in the
+    error output.
+
+### Out of scope
+
+- No DTO models (responses are empty).
+- No fixture seeding for the cache directory; both endpoints succeed on
+  an empty cache, so the smoke can run without pre-populating state.
+- No interactive confirmation; no `--dry-run`; no `--what` listing.
+  These would require client-side state ABS does not expose.
+
+## Commit shape
+
+Branch `feat/cache-purge` with four work commits plus the usual
+`docs: spec …` / `docs: plan …` commits on the same branch:
+
+1. `feat: add cache service for items + full purge` — `ApiEndpoints.cs`
+   constants and `CacheService.cs`.
+2. `feat: add cache purge-items and cache purge commands` —
+   `CacheCommand.cs` + root-command registration + help-text caveats.
+3. `test: help-text and smoke coverage for cache purge` —
+   `CacheCommandTests.cs` and the new smoke blocks (admin success +
+   readonlyuser 403 for both subcommands).
+4. `docs: add cache commands to README table` — README Commands table
+   rows.
+
+Each commit is independently revertable. The release skill harvests
+these as: two feats (service + command), one test, one docs.
+
+## Verification
+
+- `dotnet format AbsCli.sln --verify-no-changes` clean.
+- `dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj` green; new
+  help-text tests pass.
+- `docker/smoke-test.sh` against the 2.35.0 compose stack passes
+  end-to-end, including the four new assertions:
+  - `PASS: cache purge-items completes (exit 0)`
+  - `PASS: cache purge completes (exit 0)`
+  - `PASS: cache purge-items as readonlyuser hits 'admin permission' denial`
+  - `PASS: cache purge as readonlyuser hits 'admin permission' denial`
+
+## Risks
+
+- **`200` is not a deletion guarantee.** Per the upstream code path,
+  filesystem errors during `fs.remove` are caught and logged on the
+  server, but the endpoint still returns `200`. Callers cannot
+  distinguish "purged successfully" from "purge attempted, some files
+  were locked or permission-denied on the server filesystem." This is
+  documented in `--help` and is an upstream limitation, not a CLI bug.
+- **Latency spike after broad purge.** First requests for previously-
+  cached covers and images will be slower while ABS regenerates them
+  via ffmpeg. Documented in `--help` for `cache purge`. Agents using
+  `cache purge` immediately before user-visible workflows should expect
+  this.
+- **No restore, and `cache/items/` is irreplaceable.** Both endpoints
+  are one-way. `cache/covers/` and `cache/images/` are regeneratable
+  derivatives ABS rebuilds lazily. `cache/items/` is different: ABS
+  moves the original tracks out of the library directory into
+  `cache/items/` as backup when `items encode-m4b` runs (and when
+  `items embed-metadata --backup` runs). Once those backups are
+  purged, the originals are gone — there is no upstream replica.

--- a/src/AbsCli/Api/ApiEndpoints.cs
+++ b/src/AbsCli/Api/ApiEndpoints.cs
@@ -32,6 +32,10 @@ public static class ApiEndpoints
     public static string BackupDownload(string id) => $"/api/backups/{id}/download";
     public const string BackupUpload = "/api/backups/upload";
 
+    // Cache
+    public const string CachePurgeItems = "/api/cache/items/purge";
+    public const string CachePurge = "/api/cache/purge";
+
     // Upload
     public const string Upload = "/api/upload";
 

--- a/src/AbsCli/Commands/CacheCommand.cs
+++ b/src/AbsCli/Commands/CacheCommand.cs
@@ -1,0 +1,56 @@
+using System.CommandLine;
+using AbsCli.Output;
+using AbsCli.Services;
+
+namespace AbsCli.Commands;
+
+public static class CacheCommand
+{
+    public static Command Create()
+    {
+        var command = new Command("cache", "Manage server-side cache (admin)");
+        command.Subcommands.Add(CreatePurgeItemsCommand());
+        command.Subcommands.Add(CreatePurgeCommand());
+        return command;
+    }
+
+    private static Command CreatePurgeItemsCommand()
+    {
+        var command = new Command("purge-items", "Purge per-item cache backups (admin)");
+        command.AddPermissionRequired("admin");
+        command.AddExamples(
+            "abs-cli cache purge-items");
+        command.AddHelpSection("Caveats",
+            "Wipes <MetadataPath>/cache/items/ — encode-m4b backups, embed-metadata --backup copies.",
+            "200 does not guarantee deletion — ABS swallows filesystem errors server-side.",
+            "Irreversible: cached track originals have no upstream replica once encode-m4b moved them out of the library dir.");
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new CacheService(client);
+            await service.PurgeItemsAsync();
+            return 0;
+        });
+        return command;
+    }
+
+    private static Command CreatePurgeCommand()
+    {
+        var command = new Command("purge", "Purge all server cache: items, covers, images (admin)");
+        command.AddPermissionRequired("admin");
+        command.AddExamples(
+            "abs-cli cache purge");
+        command.AddHelpSection("Caveats",
+            "Wipes <MetadataPath>/cache/ in full — cache/items/, cache/covers/, cache/images/.",
+            "200 does not guarantee deletion — ABS swallows filesystem errors server-side.",
+            "covers/ and images/ rebuild lazily on next request; expect a first-request latency spike.");
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new CacheService(client);
+            await service.PurgeAsync();
+            return 0;
+        });
+        return command;
+    }
+}

--- a/src/AbsCli/Program.cs
+++ b/src/AbsCli/Program.cs
@@ -11,6 +11,7 @@ rootCommand.Subcommands.Add(SeriesCommand.Create());
 rootCommand.Subcommands.Add(AuthorsCommand.Create());
 rootCommand.Subcommands.Add(SearchCommand.Create());
 rootCommand.Subcommands.Add(BackupCommand.Create());
+rootCommand.Subcommands.Add(CacheCommand.Create());
 rootCommand.Subcommands.Add(UploadCommand.Create());
 rootCommand.Subcommands.Add(TasksCommand.Create());
 rootCommand.Subcommands.Add(MetadataCommand.Create());

--- a/src/AbsCli/Services/CacheService.cs
+++ b/src/AbsCli/Services/CacheService.cs
@@ -1,0 +1,23 @@
+using AbsCli.Api;
+
+namespace AbsCli.Services;
+
+public class CacheService
+{
+    private readonly AbsApiClient _client;
+
+    public CacheService(AbsApiClient client)
+    {
+        _client = client;
+    }
+
+    public async Task PurgeItemsAsync()
+    {
+        await _client.PostEmptyAsync(ApiEndpoints.CachePurgeItems, permissionHint: "admin permission");
+    }
+
+    public async Task PurgeAsync()
+    {
+        await _client.PostEmptyAsync(ApiEndpoints.CachePurge, permissionHint: "admin permission");
+    }
+}

--- a/tests/AbsCli.Tests/Commands/CacheCommandTests.cs
+++ b/tests/AbsCli.Tests/Commands/CacheCommandTests.cs
@@ -1,0 +1,64 @@
+using System.CommandLine;
+using AbsCli.Commands;
+using Xunit;
+
+namespace AbsCli.Tests.Commands;
+
+public class CacheCommandTests
+{
+    private static string RenderHelp(params string[] path)
+    {
+        var root = new RootCommand();
+        root.Subcommands.Add(CacheCommand.Create());
+        root.UseCustomHelpSections();
+        var output = new StringWriter();
+        var config = new InvocationConfiguration { Output = output };
+        var args = path.Concat(new[] { "--help" }).ToArray();
+        root.Parse(args).Invoke(config);
+        return output.ToString();
+    }
+
+    [Fact]
+    public void Cache_TopLevel_Help_ListsBothVerbs()
+    {
+        var output = RenderHelp("cache");
+        Assert.Contains("purge-items", output);
+        Assert.Contains("purge", output);
+    }
+
+    [Fact]
+    public void CachePurgeItems_Help_ShowsPermissionAndCaveats()
+    {
+        var output = RenderHelp("cache", "purge-items");
+        Assert.Contains("Permission required", output);
+        Assert.Contains("admin", output);
+        Assert.Contains("Caveats", output);
+        Assert.Contains("cache/items/", output);
+        Assert.Contains("200 does not guarantee deletion", output);
+    }
+
+    [Fact]
+    public void CachePurgeItems_Help_HasExample()
+    {
+        var output = RenderHelp("cache", "purge-items");
+        Assert.Contains("abs-cli cache purge-items", output);
+    }
+
+    [Fact]
+    public void CachePurge_Help_ShowsPermissionAndCaveats()
+    {
+        var output = RenderHelp("cache", "purge");
+        Assert.Contains("Permission required", output);
+        Assert.Contains("admin", output);
+        Assert.Contains("Caveats", output);
+        Assert.Contains("rebuild lazily", output);
+        Assert.Contains("200 does not guarantee deletion", output);
+    }
+
+    [Fact]
+    public void CachePurge_Help_HasExample()
+    {
+        var output = RenderHelp("cache", "purge");
+        Assert.Contains("abs-cli cache purge", output);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `abs-cli cache purge-items` (`POST /api/cache/items/purge`) and `abs-cli cache purge` (`POST /api/cache/purge`), both admin-only thin pass-throughs.
- Hygiene primitive for reclaiming disk used by `items encode-m4b` backups and `items embed-metadata --backup` copies.
- `--help` documents the two caveats: `200` does not guarantee deletion (ABS swallows fs errors server-side); `cache purge` invalidates covers/images caches (rebuilt lazily, first-request latency spike).
- No DTOs — both endpoints return empty body. Silent exit 0 on success; 403 surfaces via the standard `"admin permission"` error.

## Test plan
- [x] `docker/smoke-test.sh` against the 2.35.0 compose stack (dev container, container IP) — 211/211 including 4 new assertions (admin success on both subcommands, readonlyuser 403 on both).
- [x] `dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj` passes 193/193; 5 new help-text tests added.
- [x] `dotnet format AbsCli.sln --verify-no-changes` clean.

## Spec / plan
- Spec: `docs/specs/2026-05-19-v0.5.0-cache-purge.md`
- Plan: `docs/plans/2026-05-19-v0.5.0-cache-purge.md`