### PR TITLE
feat: diagnostic logging via NLog (breaking stderr format change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,27 @@ abs-cli config set defaultLibrary <library-id>
 
 Every command supports `--help` with examples and reference sections. Commands that require a non-default ABS permission render a `Permission required:` block at the top of their `--help` (one of `admin`, `update`, `upload`, `download`, `delete`); the absence of that block means any authenticated user can run the command.
 
+## Logging
+
+Errors and warnings go to stderr by default with a timestamp + level prefix:
+
+```
+2026-05-19T14:23:45.123Z ERROR Permission denied. This operation requires 'update' permission.
+2026-05-19T14:23:45.123Z WARN  ABS server version 2.36.0 has not been tested with this version of abs-cli.
+```
+
+Add `--debug` to any command (or set `ABS_DEBUG=1` in the environment) to also emit one stderr line per HTTP call (method + full URL + status code, plus the response body on non-2xx), token-refresh decisions, and version-check decisions.
+
+Add `--log-json` to switch stderr output to single-line JSON:
+
+```
+{"timestamp":"2026-05-19T14:23:45.123Z","level":"Error","message":"Permission denied. …"}
+```
+
+The bearer token, refresh token, request bodies, and Authorization header are never logged.
+
+> **Breaking change (v0.5.0):** Error and warning prefixes changed from `Error: …` / `Warning: …` to `2026-05-19T14:23:45.123Z ERROR …` / `WARN …`. Message bodies are unchanged. Scripts that substring-match content keep working; scripts that match the old prefix verbatim need to update.
+
 ## Development
 
 ### Dev container (recommended)

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -1730,6 +1730,35 @@ fi
 
 # ============================================================
 echo ""
+echo "=== Diagnostic Logging ==="
+# ============================================================
+
+# Debug on via ABS_DEBUG=1 emits at least one DEBUG line to stderr.
+debug_output=$(ABS_DEBUG=1 $CLI libraries list 2>&1 >/dev/null)
+if echo "$debug_output" | grep -qE '^[0-9TZ:.\-]+ DEBUG '; then
+    pass "ABS_DEBUG=1 libraries list emits DEBUG lines"
+else
+    fail "ABS_DEBUG=1 libraries list emits DEBUG lines" "got: ${debug_output:0:200}"
+fi
+
+# Default level (no --debug, no ABS_DEBUG) emits no DEBUG lines.
+default_output=$($CLI libraries list 2>&1 >/dev/null)
+if echo "$default_output" | grep -qE ' DEBUG '; then
+    fail "default libraries list does not emit DEBUG lines" "got: ${default_output:0:200}"
+else
+    pass "default libraries list does not emit DEBUG lines"
+fi
+
+# --log-json combined with ABS_DEBUG=1 emits parseable JSON with the three expected fields.
+json_first_line=$(ABS_DEBUG=1 $CLI --log-json libraries list 2>&1 >/dev/null | head -1)
+if echo "$json_first_line" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); assert 'timestamp' in d and 'level' in d and 'message' in d" 2>/dev/null; then
+    pass "ABS_DEBUG=1 --log-json libraries list emits JSON with timestamp/level/message"
+else
+    fail "ABS_DEBUG=1 --log-json libraries list emits JSON with timestamp/level/message" "got: $json_first_line"
+fi
+
+# ============================================================
+echo ""
 echo "========================================"
 echo "Results: $PASS passed, $FAIL failed"
 echo "========================================"

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -65,3 +65,7 @@ Login route is in `server/Auth.js`:
   is single-process and never issues concurrent refreshes, so the grace
   period is transparent — no CLI behavior change. Request and response
   shapes are unchanged.
+
+- **Diagnostic logging.** Run any command with `--debug` (or set
+  `ABS_DEBUG=1`) to emit token-refresh decisions to stderr. See
+  README "Logging" for full details.

--- a/docs/plans/2026-05-19-v0.5.0-diagnostic-logging.md
+++ b/docs/plans/2026-05-19-v0.5.0-diagnostic-logging.md
@@ -1,0 +1,1810 @@
+# Diagnostic Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace ad-hoc `ConsoleOutput.WriteError/WriteWarning` channels with NLog 6.1.3 used directly via per-class loggers; add `--debug` / `ABS_DEBUG=1` / `--log-json` global options; add top-level exception handler; trace HTTP requests, token refresh, and version-check decisions; fix a latent URL-composition bug at `AbsApiClient.cs:25`.
+
+**Architecture:** NLog 6.x is the AOT-first release line (every project sets `<IsAotCompatible>`). Per-class `private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();` is the standard idiom; no wrapper. `LogSetup.Configure(debugEnabled, logJson)` is called once at `Program.cs` entry to set up a single `ConsoleTarget(StdErr=true)` with either a `SimpleLayout` (text) or `JsonLayout` (JSON). All log output goes to stderr; stdout (command data JSON) is unaffected.
+
+**Tech Stack:** C# .NET 10 LTS, AOT-compiled. System.CommandLine 2.0.7. NLog 6.1.3. xUnit v3 for unit tests. Bash smoke against docker-compose 2.35.0 dev stack.
+
+**Spec:** `docs/specs/2026-05-19-v0.5.0-diagnostic-logging.md` (committed alongside this plan on the implementation branch).
+
+---
+
+## File Structure
+
+**Create:**
+- `src/AbsCli/Output/LogSetup.cs` — fluent NLog configuration. Called once from `Program.cs`.
+- `src/AbsCli/Api/DebugHttpHandler.cs` — `DelegatingHandler` for HTTP request tracing.
+- `tests/AbsCli.Tests/Output/LogSetupTests.cs` — verifies `LogSetup.Configure` produces the correct `LoggingConfiguration` structure for each (debugEnabled, logJson) combination.
+- `tests/AbsCli.Tests/Api/DebugHttpHandlerTests.cs` — verifies the handler emits the right Debug lines for 2xx and non-2xx responses, body truncation, and short-circuits when debug is off.
+- `tests/AbsCli.Tests/Api/AbsApiClientUrlCompositionTests.cs` — regression coverage for the URL fix across four base-URL shapes (sub-path, sub-path-with-trailing-slash, root-domain, no-path).
+- `tests/AbsCli.Tests/Commands/RootHelpTests.cs` — locks the `--debug` / `--log-json` descriptions and the `ABS_DEBUG` help section into the root and subcommand `--help` output.
+
+**Modify:**
+- `src/AbsCli/AbsCli.csproj` — add `<PackageReference Include="NLog" Version="6.1.3" />`.
+- `src/AbsCli/Api/ApiEndpoints.cs` — strip leading `/` from every constant and helper.
+- `src/AbsCli/Api/AbsApiClient.cs` — constructor gets trailing-slash BaseAddress fix, `DebugHttpHandler` insertion, `_logger` field, decision-point logs, and `WriteError/WriteWarning` → `_logger.Error/Warn` migration.
+- `src/AbsCli/Api/TokenHelper.cs` — add `SecondsUntilExpiry(string token)` helper.
+- `src/AbsCli/Output/ConsoleOutput.cs` — remove `WriteError` and `WriteWarning`. Keep stdout JSON methods.
+- `src/AbsCli/Commands/ConfigCommand.cs` — `_logger` field + migrate one `WriteError` call site.
+- `src/AbsCli/Program.cs` — add global `--debug` and `--log-json` Options with Descriptions; add Environment-variables help section listing `ABS_DEBUG=1`; resolve effective debug state at entry; wrap `Parse().InvokeAsync()` in try/catch routed through `_logger`.
+- `docker/smoke-test.sh` — new `=== Diagnostic Logging ===` block (debug-on, debug-off, JSON layout assertions).
+- `README.md` — short "Logging" section documenting `--debug`, `ABS_DEBUG=1`, `--log-json`, and the bearer-token-never-logged guarantee.
+- `docs/authentication.md` — append one line to the Server-side notes section cross-referencing the debug logging.
+
+**No changes:**
+- `src/AbsCli/Commands/SelfTestCommand.cs` — its `Console.Error.WriteLine` calls are deliberate test-result output, not log messages. Bypass migration. (Verified during context exploration.)
+- Other commands — none use `WriteError/WriteWarning` aside from `ConfigCommand.cs:67`.
+
+---
+
+### Task 1: Create implementation branch and commit spec
+
+**Files:**
+- Commit: `docs/specs/2026-05-19-v0.5.0-diagnostic-logging.md`
+
+- [ ] **Step 1: Confirm clean working tree on main**
+
+```bash
+cd /workspaces/abs-cli
+git status -s
+git branch --show-current
+```
+
+Expected: only the two new files (`docs/specs/2026-05-19-v0.5.0-diagnostic-logging.md` and `docs/plans/2026-05-19-v0.5.0-diagnostic-logging.md`) as untracked. Branch: `main`. If anything else is present uncommitted, STOP and report — the rest of this plan assumes a clean main.
+
+- [ ] **Step 2: Create the implementation branch**
+
+```bash
+git checkout -b feat/diagnostic-logging
+```
+
+Expected: `Switched to a new branch 'feat/diagnostic-logging'`.
+
+- [ ] **Step 3: Commit the spec**
+
+```bash
+git add docs/specs/2026-05-19-v0.5.0-diagnostic-logging.md
+git commit -m "docs: spec diagnostic logging"
+```
+
+Expected: one commit created. Subject follows `docs: spec <topic>` precedent (e.g. `64be6d7 docs: spec items get --expanded`).
+
+---
+
+### Task 2: Commit the implementation plan
+
+**Files:**
+- Commit: `docs/plans/2026-05-19-v0.5.0-diagnostic-logging.md`
+
+- [ ] **Step 1: Confirm the plan file is present and uncommitted**
+
+```bash
+git status docs/plans/2026-05-19-v0.5.0-diagnostic-logging.md
+```
+
+Expected: file listed under "Untracked files".
+
+- [ ] **Step 2: Commit the plan**
+
+```bash
+git add docs/plans/2026-05-19-v0.5.0-diagnostic-logging.md
+git commit -m "docs: plan diagnostic logging implementation"
+```
+
+Expected: one commit. Subject follows the `docs: plan <topic> implementation` precedent.
+
+---
+
+### Task 3: Fix URL composition (ApiEndpoints + AbsApiClient + regression tests)
+
+**Files:**
+- Modify: `src/AbsCli/Api/ApiEndpoints.cs`
+- Modify: `src/AbsCli/Api/AbsApiClient.cs:25`
+- Create: `tests/AbsCli.Tests/Api/AbsApiClientUrlCompositionTests.cs`
+
+This task fixes a latent RFC 3986 § 5.2 bug: relative URIs starting with `/` are absolute-path references that overwrite the base URI's path component. Combined with `TrimEnd('/')` stripping the trailing slash from configured server URLs, this silently dropped sub-path components like `/audiobookshelf` from reverse-proxied installs.
+
+- [ ] **Step 1: Verify no callers outside `ApiEndpoints.cs` hardcode paths**
+
+```bash
+cd /workspaces/abs-cli
+grep -rn '"/api/\|"/login\|"/auth' src/AbsCli/ 2>/dev/null | grep -v ApiEndpoints.cs
+```
+
+Expected: no output. If any matches, STOP and report — the URL fix scope assumes all paths flow through `ApiEndpoints` constants.
+
+- [ ] **Step 2: Rewrite `src/AbsCli/Api/ApiEndpoints.cs` with leading slashes stripped**
+
+Use the Write tool to replace the entire file with this content:
+
+```csharp
+namespace AbsCli.Api;
+
+public static class ApiEndpoints
+{
+    public const string Login = "login";
+    public const string AuthRefresh = "auth/refresh";
+
+    public const string Libraries = "api/libraries";
+    public static string Library(string id) => $"api/libraries/{id}";
+    public static string LibraryItems(string libraryId) => $"api/libraries/{libraryId}/items";
+    public static string LibrarySeries(string libraryId) => $"api/libraries/{libraryId}/series";
+    public static string LibraryAuthors(string libraryId) => $"api/libraries/{libraryId}/authors";
+    public static string LibrarySearch(string libraryId) => $"api/libraries/{libraryId}/search";
+
+    public static string Item(string id) => $"api/items/{id}";
+    public static string ItemMedia(string id) => $"api/items/{id}/media";
+    public static string ItemCover(string id) => $"api/items/{id}/cover";
+    public static string ItemChapters(string id) => $"api/items/{id}/chapters";
+    public static string ItemEbookFileStatus(string id, string fileIno) => $"api/items/{id}/ebook/{fileIno}/status";
+    public const string ItemsBatchUpdate = "api/items/batch/update";
+    public const string ItemsBatchGet = "api/items/batch/get";
+
+    public static string SeriesById(string id) => $"api/series/{id}";
+    public static string AuthorById(string id) => $"api/authors/{id}";
+    public static string AuthorMatch(string id) => $"api/authors/{id}/match";
+    public static string AuthorImage(string id) => $"api/authors/{id}/image";
+
+    // Backup
+    public const string Backups = "api/backups";
+    public static string Backup(string id) => $"api/backups/{id}";
+    public static string BackupApply(string id) => $"api/backups/{id}/apply";
+    public static string BackupDownload(string id) => $"api/backups/{id}/download";
+    public const string BackupUpload = "api/backups/upload";
+
+    // Cache
+    public const string CachePurgeItems = "api/cache/items/purge";
+    public const string CachePurge = "api/cache/purge";
+
+    // Upload
+    public const string Upload = "api/upload";
+
+    // Scan
+    public static string LibraryScan(string libraryId) => $"api/libraries/{libraryId}/scan";
+    public static string ItemScan(string id) => $"api/items/{id}/scan";
+
+    // Metadata search
+    public const string SearchBooks = "api/search/books";
+    public const string SearchProviders = "api/search/providers";
+    public const string SearchCovers = "api/search/covers";
+    public const string SearchAuthors = "api/search/authors";
+    public const string SearchChapters = "api/search/chapters";
+
+    // Tools
+    public static string ToolsItemEncodeM4b(string id) => $"api/tools/item/{id}/encode-m4b";
+    public static string ToolsItemEmbedMetadata(string id) => $"api/tools/item/{id}/embed-metadata";
+    public const string ToolsBatchEmbedMetadata = "api/tools/batch/embed-metadata";
+
+    // Tasks
+    public const string Tasks = "api/tasks";
+}
+```
+
+- [ ] **Step 3: Verify the strip is complete**
+
+```bash
+grep -E '"/|=\s*"/|\$"/' src/AbsCli/Api/ApiEndpoints.cs
+```
+
+Expected: no output. No `"/...`, no `= "/...`, no `$"/...` patterns remain.
+
+- [ ] **Step 4: Update `AbsApiClient.cs` to ensure trailing slash on BaseAddress**
+
+Use the Edit tool to change `src/AbsCli/Api/AbsApiClient.cs` line 25:
+
+`old_string`:
+```csharp
+            BaseAddress = new Uri(config.Server!.TrimEnd('/')),
+```
+
+`new_string`:
+```csharp
+            BaseAddress = new Uri(config.Server!.TrimEnd('/') + "/"),
+```
+
+- [ ] **Step 5: Create the URL-composition regression test**
+
+Write `tests/AbsCli.Tests/Api/AbsApiClientUrlCompositionTests.cs`:
+
+```csharp
+using AbsCli.Api;
+using AbsCli.Configuration;
+using Xunit;
+
+namespace AbsCli.Tests.Api;
+
+public class AbsApiClientUrlCompositionTests
+{
+    private static AbsApiClient BuildClient(string server)
+    {
+        var config = new AppConfig { Server = server, AccessToken = null, RefreshToken = null };
+        var configManager = new ConfigManager(envLookup: _ => null);
+        return new AbsApiClient(config, configManager);
+    }
+
+    private static Uri Resolve(AbsApiClient client, string relativeEndpoint)
+    {
+        var baseAddr = typeof(AbsApiClient)
+            .GetField("_http", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .GetValue(client) as System.Net.Http.HttpClient;
+        return new Uri(baseAddr!.BaseAddress!, relativeEndpoint);
+    }
+
+    [Fact]
+    public void SubPathServer_NoTrailingSlash_PreservesPath()
+    {
+        var client = BuildClient("https://example.com/audiobookshelf");
+        var resolved = Resolve(client, ApiEndpoints.Login);
+        Assert.Equal("https://example.com/audiobookshelf/login", resolved.AbsoluteUri);
+    }
+
+    [Fact]
+    public void SubPathServer_WithTrailingSlash_PreservesPath_NoDoubleSlash()
+    {
+        var client = BuildClient("https://example.com/audiobookshelf/");
+        var resolved = Resolve(client, ApiEndpoints.Login);
+        Assert.Equal("https://example.com/audiobookshelf/login", resolved.AbsoluteUri);
+    }
+
+    [Fact]
+    public void RootDomainServer_NoPath_StillResolves()
+    {
+        var client = BuildClient("https://example.com");
+        var resolved = Resolve(client, ApiEndpoints.Login);
+        Assert.Equal("https://example.com/login", resolved.AbsoluteUri);
+    }
+
+    [Fact]
+    public void SubPathServer_InterpolatedHelper_PreservesPath()
+    {
+        var client = BuildClient("https://example.com/audiobookshelf");
+        var resolved = Resolve(client, ApiEndpoints.Item("li_abc"));
+        Assert.Equal("https://example.com/audiobookshelf/api/items/li_abc", resolved.AbsoluteUri);
+    }
+
+    [Fact]
+    public void SubPathServer_BatchConstant_PreservesPath()
+    {
+        var client = BuildClient("https://example.com/audiobookshelf");
+        var resolved = Resolve(client, ApiEndpoints.ItemsBatchUpdate);
+        Assert.Equal("https://example.com/audiobookshelf/api/items/batch/update", resolved.AbsoluteUri);
+    }
+}
+```
+
+- [ ] **Step 6: Build to verify it compiles**
+
+```bash
+dotnet build src/AbsCli/AbsCli.csproj -c Release 2>&1 | tail -5
+```
+
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`.
+
+- [ ] **Step 7: Run unit tests**
+
+```bash
+dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj 2>&1 | tail -5
+```
+
+Expected: `Passed!` with 5 new tests added (baseline was 193 after PR #44; expect 198).
+
+- [ ] **Step 8: Format check**
+
+```bash
+dotnet format AbsCli.sln --verify-no-changes 2>&1 | tail -5
+```
+
+Expected: empty output. If drift, run `dotnet format AbsCli.sln`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/AbsCli/Api/ApiEndpoints.cs src/AbsCli/Api/AbsApiClient.cs tests/AbsCli.Tests/Api/AbsApiClientUrlCompositionTests.cs
+git commit -m "$(cat <<'EOF'
+fix: compose request URLs against BaseAddress trailing slash
+
+ApiEndpoints constants previously started with "/", and the
+AbsApiClient constructor stripped the trailing slash from the
+configured server URL via TrimEnd('/'). Combined, those two choices
+hit RFC 3986 § 5.2's absolute-path-reference rule: a relative URI
+starting with "/" replaces the base URI's path component entirely.
+Users with reverse-proxied installs at a sub-path (e.g.
+https://my.domain.net/audiobookshelf) silently had the sub-path
+dropped on every request, causing 405 Method Not Allowed responses
+from the root domain.
+
+Solution A: strip the leading "/" from every ApiEndpoints constant
+and helper, and ensure BaseAddress always ends with "/". Per RFC 3986
+this flips resolution from absolute-path-reference to the merge rule
+(containing-directory append), preserving sub-path bases through
+resolution.
+
+New AbsApiClientUrlCompositionTests cover four base-URL shapes
+(sub-path no-slash, sub-path with-slash, root-domain, interpolated
+helper). The dev compose stack uses a root-domain URL and would not
+catch a regression here on its own.
+EOF
+)"
+```
+
+---
+
+### Task 4: Add NLog package, LogSetup, and global options (`--debug`, `ABS_DEBUG`, `--log-json`)
+
+**Files:**
+- Modify: `src/AbsCli/AbsCli.csproj`
+- Create: `src/AbsCli/Output/LogSetup.cs`
+- Modify: `src/AbsCli/Program.cs`
+- Create: `tests/AbsCli.Tests/Output/LogSetupTests.cs`
+- Create: `tests/AbsCli.Tests/Commands/RootHelpTests.cs`
+
+After this task the logging infra is in place and discoverable via `--help`, but not yet used by any caller (errors/warnings still flow through `ConsoleOutput.WriteError/WriteWarning` until Task 5).
+
+- [ ] **Step 1: Add NLog 6.1.3 package reference**
+
+Read the current csproj to find the right insertion point:
+
+```bash
+cat src/AbsCli/AbsCli.csproj
+```
+
+Use the Edit tool to add the package reference inside the existing `<ItemGroup>` that holds `<PackageReference>` entries. If there's only one such ItemGroup, append to it; if multiple, pick the one with other runtime packages (not the test-only ones).
+
+`old_string` (find a stable anchor — likely the first PackageReference line):
+```xml
+  </ItemGroup>
+```
+
+Better: locate an existing PackageReference line and add NLog adjacent to it. Example, if the file has:
+```xml
+    <PackageReference Include="System.CommandLine" Version="2.0.7" />
+  </ItemGroup>
+```
+
+Then `new_string`:
+```xml
+    <PackageReference Include="System.CommandLine" Version="2.0.7" />
+    <PackageReference Include="NLog" Version="6.1.3" />
+  </ItemGroup>
+```
+
+(The exact anchor depends on the current csproj structure; use the Read tool to inspect first, then Edit to add one new line.)
+
+- [ ] **Step 2: Verify NLog restores under AOT**
+
+```bash
+dotnet restore src/AbsCli/AbsCli.csproj 2>&1 | tail -5
+dotnet build src/AbsCli/AbsCli.csproj -c Release 2>&1 | tail -8
+```
+
+Expected: both succeed, zero warnings.
+
+- [ ] **Step 3: Create `src/AbsCli/Output/LogSetup.cs`**
+
+Write the file:
+
+```csharp
+using NLog;
+using NLog.Config;
+using NLog.Layouts;
+using NLog.Targets;
+
+namespace AbsCli.Output;
+
+public static class LogSetup
+{
+    public static void Configure(bool debugEnabled, bool logJson)
+    {
+        var config = new LoggingConfiguration();
+
+        Layout layout = logJson
+            ? new JsonLayout
+            {
+                Attributes =
+                {
+                    new JsonAttribute("timestamp", "${date:format=yyyy-MM-ddTHH\\:mm\\:ss.fffZ:universalTime=true}"),
+                    new JsonAttribute("level", "${level}"),
+                    new JsonAttribute("message", "${message}")
+                }
+            }
+            : new SimpleLayout(
+                "${date:format=yyyy-MM-ddTHH\\:mm\\:ss.fffZ:universalTime=true} ${level:uppercase=true:padding=-5} ${message}");
+
+        var target = new ConsoleTarget("stderr")
+        {
+            StdErr = true,
+            Layout = layout
+        };
+        config.AddTarget(target);
+
+        var minLevel = debugEnabled ? LogLevel.Debug : LogLevel.Warn;
+        config.AddRule(minLevel, LogLevel.Fatal, target);
+
+        LogManager.Configuration = config;
+    }
+}
+```
+
+- [ ] **Step 4: Update `src/AbsCli/Program.cs` to add the two global options and call `LogSetup.Configure`**
+
+Read the current Program.cs:
+
+```bash
+cat src/AbsCli/Program.cs
+```
+
+Expected: the existing structure registers subcommands and calls `rootCommand.UseCustomHelpSections()` and `return await rootCommand.Parse(args).InvokeAsync();`.
+
+Use the Write tool to replace the entire file with this content (preserves all existing subcommand registrations + adds the new options, the env-var help section, the LogSetup.Configure call):
+
+```csharp
+using System.CommandLine;
+using AbsCli.Commands;
+using AbsCli.Output;
+
+var rootCommand = new RootCommand("abs-cli — Audiobookshelf CLI");
+
+var debugOption = new Option<bool>("--debug")
+{
+    Description = "Enable debug-level logging (HTTP requests, token refresh, version check) to stderr."
+};
+var logJsonOption = new Option<bool>("--log-json")
+{
+    Description = "Emit stderr log lines as single-line JSON instead of text."
+};
+rootCommand.Options.Add(debugOption);
+rootCommand.Options.Add(logJsonOption);
+
+rootCommand.Subcommands.Add(LoginCommand.Create());
+rootCommand.Subcommands.Add(ConfigCommand.Create());
+rootCommand.Subcommands.Add(LibrariesCommand.Create());
+rootCommand.Subcommands.Add(ItemsCommand.Create());
+rootCommand.Subcommands.Add(SeriesCommand.Create());
+rootCommand.Subcommands.Add(AuthorsCommand.Create());
+rootCommand.Subcommands.Add(SearchCommand.Create());
+rootCommand.Subcommands.Add(BackupCommand.Create());
+rootCommand.Subcommands.Add(CacheCommand.Create());
+rootCommand.Subcommands.Add(UploadCommand.Create());
+rootCommand.Subcommands.Add(TasksCommand.Create());
+rootCommand.Subcommands.Add(MetadataCommand.Create());
+rootCommand.Subcommands.Add(SelfTestCommand.Create());
+rootCommand.Subcommands.Add(ChangelogCommand.Create());
+
+rootCommand.AddHelpSection("Environment variables",
+    "ABS_DEBUG=1   Same as --debug. Enables debug-level logging to stderr.");
+
+rootCommand.UseCustomHelpSections();
+
+var parseResult = rootCommand.Parse(args);
+var debugEnabled = parseResult.GetValue(debugOption)
+                   || Environment.GetEnvironmentVariable("ABS_DEBUG") == "1";
+var logJson = parseResult.GetValue(logJsonOption);
+LogSetup.Configure(debugEnabled, logJson);
+
+return await parseResult.InvokeAsync();
+```
+
+Note: this preserves the existing `return await rootCommand.Parse(args).InvokeAsync()` semantics but reuses the already-parsed `parseResult` so we don't double-parse. The try/catch wrapping comes in Task 6.
+
+- [ ] **Step 5: Create `tests/AbsCli.Tests/Output/LogSetupTests.cs`**
+
+```csharp
+using AbsCli.Output;
+using NLog;
+using NLog.Layouts;
+using NLog.Targets;
+using Xunit;
+
+namespace AbsCli.Tests.Output;
+
+public class LogSetupTests
+{
+    [Fact]
+    public void Configure_DefaultLevel_AllowsWarnAndError_BlocksDebug()
+    {
+        LogSetup.Configure(debugEnabled: false, logJson: false);
+        var rule = LogManager.Configuration.LoggingRules[0];
+        Assert.Equal(LogLevel.Warn, rule.Levels.Where(l => l != LogLevel.Off).Min());
+        Assert.Contains(LogLevel.Warn, rule.Levels);
+        Assert.Contains(LogLevel.Error, rule.Levels);
+        Assert.Contains(LogLevel.Fatal, rule.Levels);
+        Assert.DoesNotContain(LogLevel.Debug, rule.Levels);
+        Assert.DoesNotContain(LogLevel.Info, rule.Levels);
+    }
+
+    [Fact]
+    public void Configure_DebugLevel_AllowsAllLevels()
+    {
+        LogSetup.Configure(debugEnabled: true, logJson: false);
+        var rule = LogManager.Configuration.LoggingRules[0];
+        Assert.Contains(LogLevel.Debug, rule.Levels);
+        Assert.Contains(LogLevel.Info, rule.Levels);
+        Assert.Contains(LogLevel.Warn, rule.Levels);
+        Assert.Contains(LogLevel.Error, rule.Levels);
+        Assert.Contains(LogLevel.Fatal, rule.Levels);
+    }
+
+    [Fact]
+    public void Configure_TextLayout_UsesSimpleLayout()
+    {
+        LogSetup.Configure(debugEnabled: false, logJson: false);
+        var target = (ConsoleTarget)LogManager.Configuration.LoggingRules[0].Targets[0];
+        Assert.IsType<SimpleLayout>(target.Layout);
+        var layout = (SimpleLayout)target.Layout;
+        Assert.Contains("yyyy-MM-ddTHH", layout.Text);
+        Assert.Contains(".fffZ", layout.Text);
+        Assert.Contains("${level:uppercase=true:padding=-5}", layout.Text);
+        Assert.Contains("${message}", layout.Text);
+    }
+
+    [Fact]
+    public void Configure_JsonLayout_HasThreeAttributes()
+    {
+        LogSetup.Configure(debugEnabled: false, logJson: true);
+        var target = (ConsoleTarget)LogManager.Configuration.LoggingRules[0].Targets[0];
+        Assert.IsType<JsonLayout>(target.Layout);
+        var layout = (JsonLayout)target.Layout;
+        Assert.Equal(3, layout.Attributes.Count);
+        Assert.Contains(layout.Attributes, a => a.Name == "timestamp");
+        Assert.Contains(layout.Attributes, a => a.Name == "level");
+        Assert.Contains(layout.Attributes, a => a.Name == "message");
+    }
+
+    [Fact]
+    public void Configure_TargetIsConsoleStdErr()
+    {
+        LogSetup.Configure(debugEnabled: false, logJson: false);
+        var target = (ConsoleTarget)LogManager.Configuration.LoggingRules[0].Targets[0];
+        Assert.True(target.StdErr);
+    }
+}
+```
+
+- [ ] **Step 6: Create `tests/AbsCli.Tests/Commands/RootHelpTests.cs`**
+
+```csharp
+using System.CommandLine;
+using AbsCli.Commands;
+using AbsCli.Output;
+using Xunit;
+
+namespace AbsCli.Tests.Commands;
+
+public class RootHelpTests
+{
+    private static string RenderHelp(params string[] args)
+    {
+        // Mirror Program.cs structure (minus LogSetup.Configure, which is unrelated to help rendering).
+        var rootCommand = new RootCommand("abs-cli — Audiobookshelf CLI");
+        var debugOption = new Option<bool>("--debug")
+        {
+            Description = "Enable debug-level logging (HTTP requests, token refresh, version check) to stderr."
+        };
+        var logJsonOption = new Option<bool>("--log-json")
+        {
+            Description = "Emit stderr log lines as single-line JSON instead of text."
+        };
+        rootCommand.Options.Add(debugOption);
+        rootCommand.Options.Add(logJsonOption);
+        rootCommand.Subcommands.Add(LibrariesCommand.Create());
+        rootCommand.AddHelpSection("Environment variables",
+            "ABS_DEBUG=1   Same as --debug. Enables debug-level logging to stderr.");
+        rootCommand.UseCustomHelpSections();
+
+        var output = new StringWriter();
+        var config = new InvocationConfiguration { Output = output };
+        var actualArgs = args.Concat(new[] { "--help" }).ToArray();
+        rootCommand.Parse(actualArgs).Invoke(config);
+        return output.ToString();
+    }
+
+    [Fact]
+    public void Root_Help_Shows_DebugOption_WithDescription()
+    {
+        var output = RenderHelp();
+        Assert.Contains("--debug", output);
+        Assert.Contains("Enable debug-level logging", output);
+    }
+
+    [Fact]
+    public void Root_Help_Shows_LogJsonOption_WithDescription()
+    {
+        var output = RenderHelp();
+        Assert.Contains("--log-json", output);
+        Assert.Contains("single-line JSON", output);
+    }
+
+    [Fact]
+    public void Root_Help_Shows_EnvironmentVariablesSection_WithAbsDebug()
+    {
+        var output = RenderHelp();
+        Assert.Contains("Environment variables", output);
+        Assert.Contains("ABS_DEBUG=1", output);
+    }
+
+    [Fact]
+    public void Subcommand_Help_Shows_DebugAndLogJson_RecursivelyFromRoot()
+    {
+        var output = RenderHelp("libraries");
+        // Recursive global options should appear in subcommand --help.
+        Assert.Contains("--debug", output);
+        Assert.Contains("--log-json", output);
+    }
+}
+```
+
+- [ ] **Step 7: Build and run all tests**
+
+```bash
+dotnet build src/AbsCli/AbsCli.csproj -c Release 2>&1 | tail -5
+dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj 2>&1 | tail -5
+```
+
+Expected: build clean; tests pass with 9 new (5 LogSetup + 4 RootHelp), bringing the count to ~207.
+
+- [ ] **Step 8: Format check**
+
+```bash
+dotnet format AbsCli.sln --verify-no-changes 2>&1 | tail -5
+```
+
+Expected: empty output.
+
+- [ ] **Step 9: AOT publish gate**
+
+This is the critical NLog-AOT verification. NLog 6.x explicitly claims AOT compatibility, but our specific config shape needs empirical confirmation.
+
+```bash
+dotnet publish src/AbsCli/AbsCli.csproj -c Release -r linux-x64 --self-contained true /p:PublishAot=true -o ./publish 2>&1 | tail -15
+```
+
+Expected: build succeeds, no AOT trim warnings related to NLog. Output ends with the publish path. If trim warnings appear that name NLog types, STOP and report — we'd need to pin to an older NLog patch or fall back to 5.5.1 (see spec Risks).
+
+- [ ] **Step 10: Verify AOT binary boots and runs self-test**
+
+```bash
+./publish/abs-cli self-test 2>&1 | tail -3
+echo "exit code: $?"
+```
+
+Expected: self-test runs to completion; final line shows pass counts; exit code 0. This proves `LogSetup.Configure` runs cleanly under AOT and the binary boots end-to-end.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/AbsCli/AbsCli.csproj src/AbsCli/Output/LogSetup.cs src/AbsCli/Program.cs tests/AbsCli.Tests/Output/LogSetupTests.cs tests/AbsCli.Tests/Commands/RootHelpTests.cs
+git commit -m "$(cat <<'EOF'
+feat: add NLog logging with --debug, ABS_DEBUG, --log-json
+
+Adds NLog 6.1.3 as a package reference. NLog 6.x is the AOT-first
+release line; every NLog project sets <IsAotCompatible> and AOT
+without build warnings is a stated goal of 6.0.
+
+Output/LogSetup.cs configures NLog fluently (no nlog.config file) with
+a single ConsoleTarget(StdErr=true) and one of two layouts:
+
+  Text (default): ${date:format=yyyy-MM-ddTHH:mm:ss.fffZ} ${level:padding=-5} ${message}
+  JSON (--log-json): {"timestamp":"…","level":"…","message":"…"}
+
+Program.cs adds two global Options with explicit Descriptions
+(--debug and --log-json) and an Environment-variables help section
+listing ABS_DEBUG=1, so all three triggers are discoverable in
+abs-cli --help and every subcommand's --help (System.CommandLine
+global options are recursive).
+
+After this commit the logging infra is wired and visible in --help,
+but no caller emits log events yet (errors/warnings still flow
+through ConsoleOutput.WriteError/WriteWarning until the next commit).
+
+AOT publish + self-test verified locally before commit.
+EOF
+)"
+```
+
+---
+
+### Task 5: Route errors and warnings through NLog (breaking change)
+
+**Files:**
+- Modify: `src/AbsCli/Api/AbsApiClient.cs`
+- Modify: `src/AbsCli/Commands/ConfigCommand.cs`
+- Modify: `src/AbsCli/Output/ConsoleOutput.cs`
+
+This is the **breaking change** commit (`feat!`). After this commit, the stderr format for errors and warnings shifts from `Error: …` / `Warning: …` to `{ts} ERROR …` / `{ts} WARN  …`. Message bodies are unchanged.
+
+- [ ] **Step 1: Read the current ConsoleOutput.cs to identify what to keep**
+
+```bash
+cat src/AbsCli/Output/ConsoleOutput.cs
+```
+
+Expected: the file has `WriteJson`, `WriteRawJson`, `WriteError`, `WriteWarning`. We keep the first two (stdout data output) and remove the last two.
+
+- [ ] **Step 2: Trim `ConsoleOutput.cs`**
+
+Use the Write tool to replace the file with:
+
+```csharp
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using AbsCli.Models;
+
+namespace AbsCli.Output;
+
+public static class ConsoleOutput
+{
+    public static void WriteJson(Dictionary<string, string> data)
+    {
+        var json = JsonSerializer.Serialize(data, AppJsonContext.Default.DictionaryStringString);
+        Console.Out.WriteLine(json);
+    }
+
+    public static void WriteJson<T>(T data, JsonTypeInfo<T> typeInfo)
+    {
+        var json = JsonSerializer.Serialize(data, typeInfo);
+        Console.Out.WriteLine(json);
+    }
+
+    public static void WriteRawJson(string json)
+    {
+        Console.Out.WriteLine(json);
+    }
+}
+```
+
+- [ ] **Step 3: Migrate the six call sites in `AbsApiClient.cs`**
+
+First add the `_logger` field declaration. Use the Edit tool:
+
+`old_string` (the existing class declaration line — likely line 11 in AbsApiClient.cs):
+```csharp
+public class AbsApiClient
+{
+    private readonly HttpClient _http;
+```
+
+`new_string`:
+```csharp
+public class AbsApiClient
+{
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+    private readonly HttpClient _http;
+```
+
+Then replace each `ConsoleOutput.WriteError` / `ConsoleOutput.WriteWarning` call. Use Edit for each:
+
+For line 200 (`Session expired. Run: abs-cli login` in `RefreshTokenAsync` when `RefreshToken == null`):
+
+`old_string`:
+```csharp
+            ConsoleOutput.WriteError("Session expired. Run: abs-cli login");
+            Environment.Exit(2);
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Post, ApiEndpoints.AuthRefresh);
+```
+
+`new_string`:
+```csharp
+            _logger.Error("Session expired. Run: abs-cli login");
+            Environment.Exit(2);
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Post, ApiEndpoints.AuthRefresh);
+```
+
+For line 210 (the same message after the refresh request fails):
+
+`old_string`:
+```csharp
+        if (!response.IsSuccessStatusCode)
+        {
+            ConsoleOutput.WriteError("Session expired. Run: abs-cli login");
+            Environment.Exit(2);
+        }
+```
+
+`new_string`:
+```csharp
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.Error("Session expired. Run: abs-cli login");
+            Environment.Exit(2);
+        }
+```
+
+For lines 237 and 242 (the two `WriteWarning` calls in `CheckServerVersion`):
+
+`old_string`:
+```csharp
+        if (CompareVersions(version, MinSupportedVersion) < 0)
+        {
+            ConsoleOutput.WriteWarning(
+                $"ABS server version {version} is older than the minimum supported version ({MinSupportedVersion}). Some features may not work.");
+        }
+        else if (CompareVersions(version, MaxTestedVersion) > 0)
+        {
+            ConsoleOutput.WriteWarning(
+                $"ABS server version {version} has not been tested with this version of abs-cli. Proceed with caution.");
+        }
+```
+
+`new_string`:
+```csharp
+        if (CompareVersions(version, MinSupportedVersion) < 0)
+        {
+            _logger.Warn(
+                $"ABS server version {version} is older than the minimum supported version ({MinSupportedVersion}). Some features may not work.");
+        }
+        else if (CompareVersions(version, MaxTestedVersion) > 0)
+        {
+            _logger.Warn(
+                $"ABS server version {version} has not been tested with this version of abs-cli. Proceed with caution.");
+        }
+```
+
+For line 273 (`API request failed after token refresh`):
+
+`old_string`:
+```csharp
+                ConsoleOutput.WriteError($"API request failed after token refresh: {(int)retryResponse.StatusCode} {retryResponse.ReasonPhrase}");
+```
+
+`new_string`:
+```csharp
+                _logger.Error($"API request failed after token refresh: {(int)retryResponse.StatusCode} {retryResponse.ReasonPhrase}");
+```
+
+For line 291 (the generic API error in `EnsureSuccessOrHandleAuthAsync`):
+
+`old_string`:
+```csharp
+            ConsoleOutput.WriteError(message);
+```
+
+`new_string`:
+```csharp
+            _logger.Error(message);
+```
+
+- [ ] **Step 4: Migrate the call site in `ConfigCommand.cs`**
+
+Add the `_logger` field. Use Edit:
+
+`old_string` (the class declaration):
+```csharp
+public static class ConfigCommand
+{
+```
+
+`new_string`:
+```csharp
+public static class ConfigCommand
+{
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+```
+
+Then replace the WriteError call. Use Edit on line 67:
+
+`old_string`:
+```csharp
+                    ConsoleOutput.WriteError($"Unknown config key: '{key}'. Valid keys: server, defaultLibrary");
+```
+
+`new_string`:
+```csharp
+                    _logger.Error($"Unknown config key: '{key}'. Valid keys: server, defaultLibrary");
+```
+
+- [ ] **Step 5: Verify no `WriteError`/`WriteWarning` references remain anywhere**
+
+```bash
+grep -rn "ConsoleOutput.WriteError\|ConsoleOutput.WriteWarning" src/AbsCli/ 2>/dev/null
+```
+
+Expected: no output. All seven call sites migrated.
+
+- [ ] **Step 6: Build and run all tests**
+
+```bash
+dotnet build src/AbsCli/AbsCli.csproj -c Release 2>&1 | tail -5
+dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj 2>&1 | tail -5
+```
+
+Expected: build clean (no `ConsoleOutput.WriteError`/`WriteWarning` references resolved against the removed methods). Tests pass at the same count as Task 4 (the migration doesn't add tests).
+
+- [ ] **Step 7: Format check**
+
+```bash
+dotnet format AbsCli.sln --verify-no-changes 2>&1 | tail -5
+```
+
+Expected: empty output.
+
+- [ ] **Step 8: Commit (breaking change)**
+
+```bash
+git add src/AbsCli/Api/AbsApiClient.cs src/AbsCli/Commands/ConfigCommand.cs src/AbsCli/Output/ConsoleOutput.cs
+git commit -m "$(cat <<'EOF'
+feat!: route errors and warnings through NLog
+
+BREAKING CHANGE: stderr format for error and warning messages
+changes. Before:
+
+  Error: Permission denied. This operation requires 'update' permission.
+  Warning: ABS server version 2.36.0 has not been tested with this version of abs-cli.
+
+After (default text layout):
+
+  2026-05-19T14:23:45.123Z ERROR Permission denied. This operation requires 'update' permission.
+  2026-05-19T14:23:45.123Z WARN  ABS server version 2.36.0 has not been tested with this version of abs-cli.
+
+Or with --log-json:
+
+  {"timestamp":"…","level":"Error","message":"Permission denied. …"}
+  {"timestamp":"…","level":"Warn","message":"ABS server version …"}
+
+stdout (command data output) is unchanged. Message bodies are
+unchanged — existing scripts that substring-match on message content
+keep working. Scripts that match the "Error:" / "Warning:" prefix
+verbatim need to update.
+
+Implementation:
+  - ConsoleOutput.WriteError and WriteWarning removed.
+  - ConsoleOutput.WriteJson and WriteRawJson kept (stdout channel).
+  - Per-class _logger field added to AbsApiClient.cs and
+    ConfigCommand.cs; seven call sites migrated to
+    _logger.Error / _logger.Warn.
+EOF
+)"
+```
+
+---
+
+### Task 6: Top-level exception handler in `Program.cs`
+
+**Files:**
+- Modify: `src/AbsCli/Program.cs`
+
+Wraps `Parse().InvokeAsync()` in a try/catch so uncaught exceptions produce a `{ts} ERROR …` line instead of a raw stack trace. Full stack trace emitted via `_logger.Debug` (only visible when debug mode is on).
+
+- [ ] **Step 1: Update `Program.cs` to wrap the invocation**
+
+Use the Write tool to replace the entire file with this content (extends Task 4's version with the try/catch + a top-level `_logger`):
+
+```csharp
+using System.CommandLine;
+using AbsCli.Commands;
+using AbsCli.Output;
+
+var _logger = NLog.LogManager.GetLogger("AbsCli.Program");
+
+var rootCommand = new RootCommand("abs-cli — Audiobookshelf CLI");
+
+var debugOption = new Option<bool>("--debug")
+{
+    Description = "Enable debug-level logging (HTTP requests, token refresh, version check) to stderr."
+};
+var logJsonOption = new Option<bool>("--log-json")
+{
+    Description = "Emit stderr log lines as single-line JSON instead of text."
+};
+rootCommand.Options.Add(debugOption);
+rootCommand.Options.Add(logJsonOption);
+
+rootCommand.Subcommands.Add(LoginCommand.Create());
+rootCommand.Subcommands.Add(ConfigCommand.Create());
+rootCommand.Subcommands.Add(LibrariesCommand.Create());
+rootCommand.Subcommands.Add(ItemsCommand.Create());
+rootCommand.Subcommands.Add(SeriesCommand.Create());
+rootCommand.Subcommands.Add(AuthorsCommand.Create());
+rootCommand.Subcommands.Add(SearchCommand.Create());
+rootCommand.Subcommands.Add(BackupCommand.Create());
+rootCommand.Subcommands.Add(CacheCommand.Create());
+rootCommand.Subcommands.Add(UploadCommand.Create());
+rootCommand.Subcommands.Add(TasksCommand.Create());
+rootCommand.Subcommands.Add(MetadataCommand.Create());
+rootCommand.Subcommands.Add(SelfTestCommand.Create());
+rootCommand.Subcommands.Add(ChangelogCommand.Create());
+
+rootCommand.AddHelpSection("Environment variables",
+    "ABS_DEBUG=1   Same as --debug. Enables debug-level logging to stderr.");
+
+rootCommand.UseCustomHelpSections();
+
+var parseResult = rootCommand.Parse(args);
+var debugEnabled = parseResult.GetValue(debugOption)
+                   || Environment.GetEnvironmentVariable("ABS_DEBUG") == "1";
+var logJson = parseResult.GetValue(logJsonOption);
+LogSetup.Configure(debugEnabled, logJson);
+
+try
+{
+    return await parseResult.InvokeAsync();
+}
+catch (Exception ex)
+{
+    _logger.Error(ex.Message);
+    _logger.Debug(ex.ToString());
+    return 2;
+}
+```
+
+Note: `_logger` for Program.cs uses `GetLogger("AbsCli.Program")` explicitly since top-level statements don't have a containing class for `GetCurrentClassLogger()` to resolve to.
+
+- [ ] **Step 2: Build and run tests**
+
+```bash
+dotnet build src/AbsCli/AbsCli.csproj -c Release 2>&1 | tail -5
+dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj 2>&1 | tail -5
+```
+
+Expected: build clean; tests pass at the same count.
+
+- [ ] **Step 3: Format check**
+
+```bash
+dotnet format AbsCli.sln --verify-no-changes 2>&1 | tail -5
+```
+
+Expected: empty output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/AbsCli/Program.cs
+git commit -m "$(cat <<'EOF'
+feat: top-level exception handler routes through NLog
+
+Wraps the rootCommand.Parse(args).InvokeAsync() call in a try/catch.
+Uncaught exceptions (e.g. the InvalidOperationException throws on
+deserialization failure in AbsApiClient) previously surfaced as raw
+stack traces via System.CommandLine's default handler. They now
+emit a single _logger.Error(ex.Message) line in the configured layout
+(text or JSON), plus _logger.Debug(ex.ToString()) for the stack
+trace — visible only when --debug or ABS_DEBUG=1 is set.
+
+Exit code 2 matches the existing Environment.Exit(2) pattern used by
+the in-handler error paths in AbsApiClient.
+EOF
+)"
+```
+
+---
+
+### Task 7: Trace HTTP requests, token refresh, version check
+
+**Files:**
+- Create: `src/AbsCli/Api/DebugHttpHandler.cs`
+- Create: `tests/AbsCli.Tests/Api/DebugHttpHandlerTests.cs`
+- Modify: `src/AbsCli/Api/AbsApiClient.cs` (constructor + EnsureValidTokenAsync + RefreshTokenAsync + CheckServerVersion)
+- Modify: `src/AbsCli/Api/TokenHelper.cs` (add `SecondsUntilExpiry`)
+
+- [ ] **Step 1: Create `src/AbsCli/Api/DebugHttpHandler.cs`**
+
+```csharp
+namespace AbsCli.Api;
+
+internal sealed class DebugHttpHandler : DelegatingHandler
+{
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+
+    public DebugHttpHandler(HttpMessageHandler innerHandler) : base(innerHandler) { }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = await base.SendAsync(request, cancellationToken);
+
+        if (!_logger.IsDebugEnabled) return response;
+
+        var method = request.Method.Method;
+        // Full absolute URL — HttpClient has resolved any relative URI
+        // against BaseAddress before the handler sees the request.
+        var url = request.RequestUri?.AbsoluteUri ?? "";
+        var status = (int)response.StatusCode;
+        _logger.Debug($"{method} {url} {status}");
+
+        if (status >= 400)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            var truncated = body.Length > 500
+                ? body[..500] + "..."
+                : body;
+            _logger.Debug($"response body: {truncated}");
+        }
+        return response;
+    }
+}
+```
+
+- [ ] **Step 2: Create `tests/AbsCli.Tests/Api/DebugHttpHandlerTests.cs`**
+
+```csharp
+using System.Net;
+using System.Text;
+using AbsCli.Api;
+using AbsCli.Output;
+using NLog;
+using NLog.Layouts;
+using NLog.Targets;
+using Xunit;
+
+namespace AbsCli.Tests.Api;
+
+public class DebugHttpHandlerTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        public HttpStatusCode Status { get; init; } = HttpStatusCode.OK;
+        public string ResponseBody { get; init; } = "";
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(Status)
+            {
+                Content = new StringContent(ResponseBody, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    private static MemoryTarget ConfigureMemoryTarget(bool debugEnabled)
+    {
+        var config = new NLog.Config.LoggingConfiguration();
+        var target = new MemoryTarget("memory")
+        {
+            Layout = new SimpleLayout("${level:uppercase=true} ${message}")
+        };
+        config.AddTarget(target);
+        config.AddRule(debugEnabled ? LogLevel.Debug : LogLevel.Warn, LogLevel.Fatal, target);
+        LogManager.Configuration = config;
+        return target;
+    }
+
+    [Fact]
+    public async Task DebugOff_NoLines()
+    {
+        var target = ConfigureMemoryTarget(debugEnabled: false);
+        var handler = new DebugHttpHandler(new StubHandler { Status = HttpStatusCode.OK, ResponseBody = "{}" });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/") };
+        await client.GetAsync("foo");
+        Assert.Empty(target.Logs);
+    }
+
+    [Fact]
+    public async Task DebugOn_2xx_OneLineWithMethodUrlStatus()
+    {
+        var target = ConfigureMemoryTarget(debugEnabled: true);
+        var handler = new DebugHttpHandler(new StubHandler { Status = HttpStatusCode.OK, ResponseBody = "{}" });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/sub/") };
+        await client.GetAsync("api/items?expanded=1");
+        Assert.Single(target.Logs);
+        Assert.Equal("DEBUG GET https://example.com/sub/api/items?expanded=1 200", target.Logs[0]);
+    }
+
+    [Fact]
+    public async Task DebugOn_Non2xx_TwoLinesIncludingResponseBody()
+    {
+        var target = ConfigureMemoryTarget(debugEnabled: true);
+        var handler = new DebugHttpHandler(new StubHandler { Status = HttpStatusCode.BadRequest, ResponseBody = "{\"error\":\"nope\"}" });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/") };
+        await client.PatchAsync("api/items/foo", new StringContent(""));
+        Assert.Equal(2, target.Logs.Count);
+        Assert.Equal("DEBUG PATCH https://example.com/api/items/foo 400", target.Logs[0]);
+        Assert.Equal("DEBUG response body: {\"error\":\"nope\"}", target.Logs[1]);
+    }
+
+    [Fact]
+    public async Task DebugOn_Non2xx_LongBody_TruncatedAt500()
+    {
+        var target = ConfigureMemoryTarget(debugEnabled: true);
+        var longBody = new string('x', 600);
+        var handler = new DebugHttpHandler(new StubHandler { Status = HttpStatusCode.InternalServerError, ResponseBody = longBody });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/") };
+        await client.GetAsync("api/items");
+        Assert.Equal(2, target.Logs.Count);
+        // First line: status. Second line: truncated body (500 chars + "...").
+        Assert.Equal($"DEBUG response body: {new string('x', 500)}...", target.Logs[1]);
+    }
+}
+```
+
+- [ ] **Step 3: Add `SecondsUntilExpiry` to `TokenHelper.cs`**
+
+Use the Edit tool. Find the existing `IsExpiringSoon` method:
+
+`old_string`:
+```csharp
+    public static bool IsExpiringSoon(string token, int thresholdSeconds = 60)
+    {
+        var exp = GetExpiration(token);
+        if (exp == null) return false;
+
+        return exp.Value <= DateTimeOffset.UtcNow.AddSeconds(thresholdSeconds);
+    }
+}
+```
+
+`new_string`:
+```csharp
+    public static bool IsExpiringSoon(string token, int thresholdSeconds = 60)
+    {
+        var exp = GetExpiration(token);
+        if (exp == null) return false;
+
+        return exp.Value <= DateTimeOffset.UtcNow.AddSeconds(thresholdSeconds);
+    }
+
+    public static long? SecondsUntilExpiry(string token)
+    {
+        var exp = GetExpiration(token);
+        if (exp == null) return null;
+        return (long)(exp.Value - DateTimeOffset.UtcNow).TotalSeconds;
+    }
+}
+```
+
+- [ ] **Step 4: Update `AbsApiClient.cs` constructor to insert `DebugHttpHandler` and log the resolved base address**
+
+Use the Edit tool. Find the existing constructor body:
+
+`old_string`:
+```csharp
+    public AbsApiClient(AppConfig config, ConfigManager configManager)
+    {
+        _config = config;
+        _configManager = configManager;
+        _http = new HttpClient
+        {
+            BaseAddress = new Uri(config.Server!.TrimEnd('/') + "/"),
+            // We manage timeouts per-request via CancellationTokenSource so that
+            // long operations (backup create/apply/download/upload) can opt into
+            // longer timeouts. Setting this to Infinite disables the global cap.
+            Timeout = Timeout.InfiniteTimeSpan
+        };
+        _http.DefaultRequestHeaders.UserAgent.ParseAdd($"abs-cli/{AssemblyVersion}");
+
+        if (config.AccessToken != null)
+            _http.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", config.AccessToken);
+    }
+```
+
+`new_string`:
+```csharp
+    public AbsApiClient(AppConfig config, ConfigManager configManager)
+    {
+        _config = config;
+        _configManager = configManager;
+        var debugHandler = new DebugHttpHandler(new HttpClientHandler());
+        _http = new HttpClient(debugHandler)
+        {
+            BaseAddress = new Uri(config.Server!.TrimEnd('/') + "/"),
+            // We manage timeouts per-request via CancellationTokenSource so that
+            // long operations (backup create/apply/download/upload) can opt into
+            // longer timeouts. Setting this to Infinite disables the global cap.
+            Timeout = Timeout.InfiniteTimeSpan
+        };
+        _http.DefaultRequestHeaders.UserAgent.ParseAdd($"abs-cli/{AssemblyVersion}");
+
+        if (config.AccessToken != null)
+            _http.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", config.AccessToken);
+
+        _logger.Debug($"client base address: {_http.BaseAddress}");
+    }
+```
+
+- [ ] **Step 5: Add decision-point logging in `EnsureValidTokenAsync`**
+
+Use the Edit tool. Find the method:
+
+`old_string`:
+```csharp
+    private async Task EnsureValidTokenAsync()
+    {
+        if (_config.AccessToken == null) return;
+
+        if (TokenHelper.IsExpiringSoon(_config.AccessToken, thresholdSeconds: 60))
+        {
+            await RefreshTokenAsync();
+        }
+    }
+```
+
+`new_string`:
+```csharp
+    private async Task EnsureValidTokenAsync()
+    {
+        if (_config.AccessToken == null) return;
+
+        var secondsLeft = TokenHelper.SecondsUntilExpiry(_config.AccessToken);
+        if (TokenHelper.IsExpiringSoon(_config.AccessToken, thresholdSeconds: 60))
+        {
+            _logger.Debug($"access token expiring in {secondsLeft}s, refreshing");
+            await RefreshTokenAsync();
+        }
+        else
+        {
+            _logger.Debug($"access token valid ({secondsLeft}s remaining)");
+        }
+    }
+```
+
+- [ ] **Step 6: Add decision-point logging in `RefreshTokenAsync`**
+
+Use the Edit tool. Find the method (after Task 5's changes, the `_logger.Error` calls are already in place):
+
+`old_string`:
+```csharp
+        var response = await _http.SendAsync(request);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.Error("Session expired. Run: abs-cli login");
+            Environment.Exit(2);
+        }
+
+        var json = await response.Content.ReadAsStringAsync();
+        var loginResponse = JsonSerializer.Deserialize(json, AppJsonContext.Default.LoginResponse)!;
+
+        _config.AccessToken = loginResponse.User.AccessToken;
+        _config.RefreshToken = loginResponse.User.RefreshToken;
+        _configManager.Save(_config);
+
+        _http.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", _config.AccessToken);
+    }
+```
+
+`new_string`:
+```csharp
+        var response = await _http.SendAsync(request);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.Debug($"token refresh failed: {(int)response.StatusCode}");
+            _logger.Error("Session expired. Run: abs-cli login");
+            Environment.Exit(2);
+        }
+
+        var json = await response.Content.ReadAsStringAsync();
+        var loginResponse = JsonSerializer.Deserialize(json, AppJsonContext.Default.LoginResponse)!;
+
+        _config.AccessToken = loginResponse.User.AccessToken;
+        _config.RefreshToken = loginResponse.User.RefreshToken;
+        _configManager.Save(_config);
+
+        _http.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", _config.AccessToken);
+
+        _logger.Debug("token refresh succeeded");
+    }
+```
+
+- [ ] **Step 7: Add decision-point logging in `CheckServerVersion`**
+
+Use the Edit tool. Find the method:
+
+`old_string`:
+```csharp
+    public static void CheckServerVersion(string? version)
+    {
+        if (string.IsNullOrEmpty(version)) return;
+
+        if (CompareVersions(version, MinSupportedVersion) < 0)
+        {
+            _logger.Warn(
+                $"ABS server version {version} is older than the minimum supported version ({MinSupportedVersion}). Some features may not work.");
+        }
+        else if (CompareVersions(version, MaxTestedVersion) > 0)
+        {
+            _logger.Warn(
+                $"ABS server version {version} has not been tested with this version of abs-cli. Proceed with caution.");
+        }
+    }
+```
+
+`new_string`:
+```csharp
+    public static void CheckServerVersion(string? version)
+    {
+        if (string.IsNullOrEmpty(version)) return;
+
+        if (CompareVersions(version, MinSupportedVersion) < 0)
+        {
+            _logger.Warn(
+                $"ABS server version {version} is older than the minimum supported version ({MinSupportedVersion}). Some features may not work.");
+            _logger.Debug($"server version {version} older than min {MinSupportedVersion}");
+        }
+        else if (CompareVersions(version, MaxTestedVersion) > 0)
+        {
+            _logger.Warn(
+                $"ABS server version {version} has not been tested with this version of abs-cli. Proceed with caution.");
+            _logger.Debug($"server version {version} newer than tested {MaxTestedVersion}");
+        }
+        else
+        {
+            _logger.Debug($"server version {version} (in tested range {MinSupportedVersion}-{MaxTestedVersion})");
+        }
+    }
+```
+
+- [ ] **Step 8: Build and run tests**
+
+```bash
+dotnet build src/AbsCli/AbsCli.csproj -c Release 2>&1 | tail -5
+dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj 2>&1 | tail -5
+```
+
+Expected: build clean; tests pass with 4 new DebugHttpHandler tests added (count rises to ~211).
+
+- [ ] **Step 9: Format check**
+
+```bash
+dotnet format AbsCli.sln --verify-no-changes 2>&1 | tail -5
+```
+
+Expected: empty output.
+
+- [ ] **Step 10: AOT re-verification (optional but recommended)**
+
+The full logging emission path is now wired. Re-run the AOT publish + self-test:
+
+```bash
+dotnet publish src/AbsCli/AbsCli.csproj -c Release -r linux-x64 --self-contained true /p:PublishAot=true -o ./publish 2>&1 | tail -8
+./publish/abs-cli self-test 2>&1 | tail -3
+echo "exit code: $?"
+```
+
+Expected: publish succeeds, self-test exits 0. If trim warnings appear that name DebugHttpHandler or any NLog type, STOP and report.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/AbsCli/Api/DebugHttpHandler.cs src/AbsCli/Api/TokenHelper.cs src/AbsCli/Api/AbsApiClient.cs tests/AbsCli.Tests/Api/DebugHttpHandlerTests.cs
+git commit -m "$(cat <<'EOF'
+feat: trace HTTP requests, token refresh, version check
+
+DebugHttpHandler is a DelegatingHandler inserted into AbsApiClient's
+HttpClient pipeline. When debug-level logging is enabled, it emits
+one stderr line per request with the full absolute URL:
+
+  2026-05-19T14:23:45.123Z DEBUG GET https://server/audiobookshelf/api/items 200
+
+For non-2xx responses it emits a second line with the response body
+truncated to 500 chars. Short-circuits via _logger.IsDebugEnabled so
+the production path is a single field read.
+
+Logging the full absolute URL (not just path) makes BaseAddress
+misconfigurations visible — if the configured server URL has a
+sub-path that gets dropped through a future RFC 3986 footgun, the
+debug output shows it immediately.
+
+Decision-point logs added:
+  - EnsureValidTokenAsync: "access token valid (Ns remaining)" or
+    "access token expiring in Ns, refreshing"
+  - RefreshTokenAsync: "token refresh succeeded" or "token refresh
+    failed: {status}"
+  - CheckServerVersion: "server version X (in tested range A-B)",
+    "server version X older than min A", or "server version X newer
+    than tested B"
+
+Constructor also emits a one-time "client base address: …" line so
+users can see what HttpClient.BaseAddress is actually set to.
+
+TokenHelper.SecondsUntilExpiry helper added for the
+"Ns remaining" debug formatting.
+
+Privacy: bearer token, refresh token, request body, and
+Authorization header are never logged.
+EOF
+)"
+```
+
+---
+
+### Task 8: Smoke coverage and docs
+
+**Files:**
+- Modify: `docker/smoke-test.sh`
+- Modify: `README.md`
+- Modify: `docs/authentication.md`
+
+- [ ] **Step 1: Add the smoke block**
+
+Read the smoke file to find a good insertion point — most readable place is right before the "Permission Errors" section or at the very end as a new `=== Diagnostic Logging ===` block:
+
+```bash
+grep -n "^echo .===" docker/smoke-test.sh | tail -5
+```
+
+Pick the last section header (likely "Permission Errors" near the end). Insert the new block **after** the very last `=== … ===` section by appending before the final summary code. Use the Edit tool. Find a stable anchor — typically the smoke ends with summary lines like `if [ $FAILED -eq 0 ]; then echo "All tests passed"; else echo "$FAILED failed"; fi`. Insert before that.
+
+A safer approach: read the last 30 lines and add the new section before the summary:
+
+```bash
+tail -40 docker/smoke-test.sh
+```
+
+Use Edit to add the new block before the summary code. Choose an `old_string` that captures the last few lines of the previous section + the summary header line, and the `new_string` adds the diagnostic logging block in between.
+
+The block to insert:
+
+```bash
+# ============================================================
+echo ""
+echo "=== Diagnostic Logging ==="
+# ============================================================
+
+# Debug on via ABS_DEBUG=1 emits at least one DEBUG line to stderr.
+debug_output=$(ABS_DEBUG=1 $CLI libraries list 2>&1 >/dev/null)
+if echo "$debug_output" | grep -qE '^[0-9TZ:.\-]+ DEBUG '; then
+    pass "ABS_DEBUG=1 libraries list emits DEBUG lines"
+else
+    fail "ABS_DEBUG=1 libraries list emits DEBUG lines" "got: ${debug_output:0:200}"
+fi
+
+# Default level (no --debug, no ABS_DEBUG) emits no DEBUG lines.
+default_output=$($CLI libraries list 2>&1 >/dev/null)
+if echo "$default_output" | grep -qE ' DEBUG '; then
+    fail "default libraries list does not emit DEBUG lines" "got: ${default_output:0:200}"
+else
+    pass "default libraries list does not emit DEBUG lines"
+fi
+
+# --log-json combined with ABS_DEBUG=1 emits parseable JSON with the three expected fields.
+json_first_line=$(ABS_DEBUG=1 $CLI --log-json libraries list 2>&1 >/dev/null | head -1)
+if echo "$json_first_line" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); assert 'timestamp' in d and 'level' in d and 'message' in d" 2>/dev/null; then
+    pass "ABS_DEBUG=1 --log-json libraries list emits JSON with timestamp/level/message"
+else
+    fail "ABS_DEBUG=1 --log-json libraries list emits JSON with timestamp/level/message" "got: $json_first_line"
+fi
+```
+
+- [ ] **Step 2: Syntax-check the smoke file**
+
+```bash
+bash -n docker/smoke-test.sh
+```
+
+Expected: empty output.
+
+- [ ] **Step 3: Run the smoke against the live 2.35.0 dev stack**
+
+If the stack isn't running, bring it up:
+
+```bash
+cd /workspaces/abs-cli/docker
+docker compose ps
+# If nothing is shown, start it:
+docker compose up -d
+for i in $(seq 1 30); do
+  curl -sf http://localhost:13378/healthcheck && break
+  sleep 1
+done
+ABS_IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+echo "ABS_IP=$ABS_IP"
+cd /workspaces/abs-cli
+# Seed only if the volumes are fresh (no test users present):
+ABS_URL="http://${ABS_IP}:80" bash docker/seed.sh
+dotnet build src/AbsCli/AbsCli.csproj -c Release
+```
+
+If already running and seeded, just resolve the IP:
+
+```bash
+ABS_IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+dotnet build src/AbsCli/AbsCli.csproj -c Release
+```
+
+Run the smoke:
+
+```bash
+cd /workspaces/abs-cli
+ABS_URL="http://${ABS_IP}:80" bash docker/smoke-test.sh 2>&1 | tail -10
+```
+
+Expected: smoke completes with three new PASS lines among the others:
+```
+PASS: ABS_DEBUG=1 libraries list emits DEBUG lines
+PASS: default libraries list does not emit DEBUG lines
+PASS: ABS_DEBUG=1 --log-json libraries list emits JSON with timestamp/level/message
+```
+Final tally rises by 3 from the previous smoke baseline.
+
+If any pre-existing assertion FAILS, STOP and report — that's a regression separate from this task. The three new assertions must pass cleanly.
+
+- [ ] **Step 4: Add the README "Logging" section**
+
+Read the README to find an insertion point — typically right after the Commands table or in a "Configuration" / "Environment variables" area. Use Edit to add the section. Suggested location: after the Commands table, before the "Pre-PR verification" section or any deeper how-to subsections. Adjust the anchor based on actual file structure.
+
+Section content to add:
+
+```markdown
+## Logging
+
+Errors and warnings go to stderr by default with a timestamp + level prefix:
+
+```
+2026-05-19T14:23:45.123Z ERROR Permission denied. This operation requires 'update' permission.
+2026-05-19T14:23:45.123Z WARN  ABS server version 2.36.0 has not been tested with this version of abs-cli.
+```
+
+Add `--debug` to any command (or set `ABS_DEBUG=1` in the environment) to also emit one stderr line per HTTP call (method + full URL + status code, plus the response body on non-2xx), token-refresh decisions, and version-check decisions.
+
+Add `--log-json` to switch stderr output to single-line JSON:
+
+```
+{"timestamp":"2026-05-19T14:23:45.123Z","level":"Error","message":"Permission denied. …"}
+```
+
+The bearer token, refresh token, request bodies, and Authorization header are never logged.
+
+> **Breaking change (v0.5.0):** Error and warning prefixes changed from `Error: …` / `Warning: …` to `2026-05-19T14:23:45.123Z ERROR …` / `WARN …`. Message bodies are unchanged. Scripts that substring-match content keep working; scripts that match the old prefix verbatim need to update.
+```
+
+- [ ] **Step 5: Cross-reference in `docs/authentication.md`**
+
+Read the existing Server-side notes section in `docs/authentication.md`:
+
+```bash
+tail -20 docs/authentication.md
+```
+
+Add a one-line cross-reference at the end of that section. Use Edit:
+
+`old_string` (the last bullet of the Server-side notes section — probably the refresh-token grace-period bullet that already exists):
+
+Pick the actual final line of the section as the anchor; append after it. For example, if the file ends with:
+
+```
+  shapes are unchanged.
+```
+
+Then `new_string`:
+
+```
+  shapes are unchanged.
+
+- **Diagnostic logging.** Run any command with `--debug` (or set
+  `ABS_DEBUG=1`) to emit token-refresh decisions to stderr. See
+  README "Logging" for full details.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docker/smoke-test.sh README.md docs/authentication.md
+git commit -m "$(cat <<'EOF'
+test: smoke coverage + docs for diagnostic logging
+
+Smoke adds a new Diagnostic Logging section with three assertions:
+  - ABS_DEBUG=1 libraries list emits at least one DEBUG line
+  - default libraries list emits zero DEBUG lines
+  - ABS_DEBUG=1 --log-json libraries list emits parseable JSON with
+    timestamp/level/message fields
+
+README gains a Logging section documenting --debug, ABS_DEBUG=1,
+--log-json, the new format, and the breaking-change call-out.
+
+docs/authentication.md cross-references the debug logging from the
+existing Server-side notes section.
+EOF
+)"
+```
+
+---
+
+### Task 9: Final verification, push, and PR
+
+- [ ] **Step 1: Confirm the branch has all commits in order**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected output (newest first):
+```
+<sha> test: smoke coverage + docs for diagnostic logging
+<sha> feat: trace HTTP requests, token refresh, version check
+<sha> feat: top-level exception handler routes through NLog
+<sha> feat!: route errors and warnings through NLog
+<sha> feat: add NLog logging with --debug, ABS_DEBUG, --log-json
+<sha> fix: compose request URLs against BaseAddress trailing slash
+<sha> docs: plan diagnostic logging implementation
+<sha> docs: spec diagnostic logging
+```
+
+If any commit is missing or out of order, fix before pushing.
+
+- [ ] **Step 2: Final AOT publish + self-test**
+
+```bash
+dotnet publish src/AbsCli/AbsCli.csproj -c Release -r linux-x64 --self-contained true /p:PublishAot=true -o ./publish 2>&1 | tail -8
+./publish/abs-cli self-test 2>&1 | tail -3
+echo "exit code: $?"
+```
+
+Expected: AOT publish succeeds with zero trim warnings; self-test exits 0.
+
+- [ ] **Step 3: Final smoke against the dev stack**
+
+```bash
+ABS_IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+cd /workspaces/abs-cli
+ABS_URL="http://${ABS_IP}:80" bash docker/smoke-test.sh 2>&1 | tail -5
+```
+
+Expected: all assertions pass, including the three new diagnostic-logging ones.
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push -u origin feat/diagnostic-logging
+```
+
+Expected: branch pushed; remote URL printed.
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+gh pr create --title "feat: diagnostic logging via NLog (breaking stderr format change)" --body "$(cat <<'EOF'
+## Summary
+- Adds NLog 6.1.3 + global `--debug` / `ABS_DEBUG=1` / `--log-json` options. All three are discoverable in `abs-cli --help` (Options + Environment variables section).
+- New `DebugHttpHandler` traces method + full absolute URL + status for every HTTP call; emits response body (truncated to 500 chars) on non-2xx. Decision-point logs added in `EnsureValidTokenAsync`, `RefreshTokenAsync`, `CheckServerVersion`. Constructor logs the resolved BaseAddress once at startup.
+- Top-level exception handler in `Program.cs` routes uncaught exceptions through `_logger.Error` instead of raw stack traces; full stack trace via `_logger.Debug` when debug is on.
+- Fixes a latent URL-composition bug at `AbsApiClient.cs:25` (RFC 3986 § 5.2 absolute-path-reference rule). Users on reverse-proxied installs at a sub-path (e.g. `https://my.domain.net/audiobookshelf`) were silently losing the sub-path on every request, causing 405 Method Not Allowed responses. `ApiEndpoints` constants no longer start with `/`; `BaseAddress` now always ends with `/`.
+- Bearer token, refresh token, request bodies, and Authorization header are never logged.
+
+## ⚠ Breaking change
+
+The stderr format for errors and warnings changes:
+
+Before: `Error: Permission denied. …` / `Warning: ABS server version …`
+After: `2026-05-19T14:23:45.123Z ERROR Permission denied. …` / `WARN  ABS server version …`
+
+stdout (command JSON output) is unchanged. Message bodies are unchanged — substring matchers keep working. Scripts that match the `Error:` / `Warning:` prefix verbatim need to update.
+
+The `feat!:` marker on commit 3 surfaces this to the release skill so it lands in the v0.5.0 release notes prominently.
+
+## Test plan
+- [x] `docker/smoke-test.sh` against the 2.35.0 compose stack — all assertions pass, including 3 new ones (debug-on, debug-off, JSON layout).
+- [x] `dotnet test` passes; ~211 tests total (was 193, +18 across LogSetup, RootHelp, DebugHttpHandler, URL composition).
+- [x] `dotnet format AbsCli.sln --verify-no-changes` clean.
+- [x] `dotnet publish ... /p:PublishAot=true` succeeds with zero NLog-related trim warnings; `./publish/abs-cli self-test` exits 0 (proves NLog config loads under AOT).
+
+## Spec / plan
+- Spec: `docs/specs/2026-05-19-v0.5.0-diagnostic-logging.md`
+- Plan: `docs/plans/2026-05-19-v0.5.0-diagnostic-logging.md`
+EOF
+)"
+```
+
+- [ ] **Step 6: Surface the PR URL**
+
+Present the URL on its own line as a clickable link per CLAUDE.md convention.
+
+- [ ] **Step 7: Watch CI until terminal state**
+
+Per CLAUDE.md's Post-PR verification rule, watch CI until every check reaches a terminal state (pass / fail / skipping). Use:
+
+```bash
+gh pr checks <pr-number>
+```
+
+Or arm a Monitor task that polls until done. If any check fails, diagnose before declaring the PR ready. Flaky races warrant a rerun and a follow-up fix in the same PR.
+
+---
+
+## Done criteria
+
+- Branch `feat/diagnostic-logging` exists on origin with 8 commits (2 docs, 1 fix, 3 feat, 1 feat!, 1 test).
+- `dotnet test` and `dotnet format --verify-no-changes` are green.
+- AOT publish succeeds with no trim warnings; `./publish/abs-cli self-test` exits 0.
+- `docker/smoke-test.sh` passes end-to-end against `advplyr/audiobookshelf:2.35.0`, including the three new diagnostic-logging assertions.
+- All CI checks on the PR have reached a terminal state (pass / skipping).
+- PR URL surfaced to the user.

--- a/docs/specs/2026-05-19-v0.5.0-diagnostic-logging.md
+++ b/docs/specs/2026-05-19-v0.5.0-diagnostic-logging.md
@@ -1,0 +1,654 @@
+# Diagnostic logging
+
+Date: 2026-05-19
+Target release: v0.5.0 (file management milestone — final feature)
+
+## Goal
+
+Replace the ad-hoc `ConsoleOutput.WriteError` / `WriteWarning` channels
+with a unified logging surface (NLog used directly via per-class
+loggers) that covers error, warning, debug, and uncaught-exception
+output. Add an opt-in debug mode for HTTP / auth / version diagnostics,
+an opt-in JSON output mode for agent integrations, and a top-level
+exception handler that produces predictable error output instead of
+raw stack traces.
+
+Also fix a latent URL-composition bug (RFC 3986 § 5.2) at
+`AbsApiClient.cs:25` that silently drops the path component of any
+sub-path base URL — surfaced by a reverse-proxy user who got
+`405 Method Not Allowed` on `abs-cli login` against
+`https://my.domain.net/audiobookshelf`. The bug and the logging work
+are bundled because the new logging surface (full absolute URLs +
+BaseAddress at startup) exists primarily to make this class of
+misconfiguration self-diagnosable.
+
+## Outcome
+
+After this lands:
+
+- New global `--debug` option on the root command (recursive to every
+  subcommand) and an `ABS_DEBUG=1` env var. Either turns debug-level
+  logging on. `ABS_DEBUG` is truthy only on the literal `1` (other
+  values, empty, unset = off). Both surface in `abs-cli --help` —
+  `--debug` via its `Option<bool>` Description, `ABS_DEBUG` via an
+  explicit "Environment variables" help section on the root command.
+- New global `--log-json` option on the root command. When set,
+  switches the layout from human-readable text to single-line JSON
+  per event. Off by default. Visible in every subcommand's `--help`
+  via its `Option<bool>` Description (global options are recursive).
+- NLog is used **directly** via per-class loggers (no static
+  wrapper). Each file that emits log lines declares:
+  ```csharp
+  private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+  ```
+  and calls `_logger.Error(...)` / `_logger.Warn(...)` / `_logger.Debug(...)`.
+  Idiomatic NLog; per-class category names come for free if filtering
+  is ever needed.
+- New `src/AbsCli/Output/LogSetup.cs` static class that programs NLog
+  fluently (no `nlog.config` XML file) with one ConsoleTarget pointing
+  at `stderr` and one of two layouts (text or JSON) depending on
+  `--log-json`. Minimum level defaults to `Warn`; debug-mode flips it
+  to `Debug`. Called once from `Program.cs` at entry.
+- New top-level exception handler in `Program.cs`: wraps
+  `rootCommand.Parse(args).InvokeAsync()` in `try`/`catch`, routes
+  uncaught exceptions through `_logger.Error`, prints the full stack
+  trace via `_logger.Debug` when debug is on, returns exit code 2.
+- All existing `ConsoleOutput.WriteError` / `WriteWarning` call sites
+  (six in `AbsApiClient.cs`, one in `ConfigCommand.cs`) migrated to
+  `_logger.Error` / `_logger.Warn`. Both methods on `ConsoleOutput` are
+  removed; only the JSON-output methods remain (those write to
+  stdout, a separate channel).
+- New `src/AbsCli/Api/DebugHttpHandler.cs` (`DelegatingHandler`)
+  inserted into the `HttpClient` pipeline. Per-request, when debug
+  level is on: one line via `_logger.Debug` with `{method}
+  {absolute-uri} {status}`. For non-2xx responses, a second line
+  with `response body: {body-truncated-to-500}`. Short-circuits when
+  debug is off.
+- `AbsApiClient` constructor emits a one-time `client base address:
+  {url}` line via `_logger.Debug` after BaseAddress is set.
+- `AbsApiClient.cs:25` is fixed so that `BaseAddress` always ends with
+  a trailing `/`, and every `ApiEndpoints` constant / helper returns a
+  path **without** a leading `/`. Combined, these make RFC 3986 § 5.2
+  resolution merge correctly: relative paths now extend the base path
+  instead of replacing it. Users with reverse-proxied installs at a
+  sub-path (e.g. `https://my.domain.net/audiobookshelf`) get requests
+  that actually hit ABS instead of the root domain.
+- `AbsApiClient` decision-point `_logger.Debug` calls in:
+  - `EnsureValidTokenAsync` — `access token valid ({N}s remaining)` or
+    `access token expiring in {N}s, refreshing`.
+  - `RefreshTokenAsync` — `token refresh succeeded` or
+    `token refresh failed: {status}`.
+  - `CheckServerVersion` — `server version {X} (in tested range
+    {min}-{max})`, `server version {X} older than min {min}`, or
+    `server version {X} newer than tested {max}`.
+- Bearer token, refresh token, request bodies, and the `Authorization`
+  header are NEVER emitted.
+- README gains a one-line "Logging" mini-section covering `--debug`,
+  `ABS_DEBUG=1`, `--log-json`, and the "bearer token never logged"
+  guarantee.
+- `docs/authentication.md` cross-references the refresh-decision
+  logging.
+
+## Triggers and precedence
+
+```csharp
+// At Program.cs entry, before any subcommand action:
+var debugEnabled = parseResult.GetValue(debugOption)
+                   || Environment.GetEnvironmentVariable("ABS_DEBUG") == "1";
+var logJson = parseResult.GetValue(logJsonOption);
+LogSetup.Configure(debugEnabled, logJson);
+```
+
+The `_logger.Error` / `_logger.Warn` channels are always active regardless of
+`--debug`; the flag only controls whether `_logger.Debug` calls produce
+output. If both `ABS_DEBUG=1` env var and `--debug` are set, the result
+is unchanged — debug stays on. There is no way to force debug off via
+flag when env var is set; agents set the env once and humans add the
+flag ad-hoc.
+
+## Format
+
+Two layouts, selected by `--log-json`:
+
+### Text layout (default)
+
+```
+2026-05-19T14:23:45.123Z ERROR Permission denied. This operation requires 'update' permission.
+2026-05-19T14:23:45.123Z WARN  ABS server version 2.36.0 has not been tested with this version of abs-cli.
+2026-05-19T14:23:45.123Z DEBUG client base address: https://my.domain.net/audiobookshelf/
+2026-05-19T14:23:45.123Z DEBUG GET https://my.domain.net/audiobookshelf/api/items?expanded=1 200
+2026-05-19T14:23:45.123Z DEBUG access token valid (3422s remaining)
+2026-05-19T14:23:45.123Z DEBUG server version 2.35.0 (in tested range 2.33.1-2.35.0)
+2026-05-19T14:23:45.123Z DEBUG PATCH https://my.domain.net/audiobookshelf/api/items/li_abc 400
+2026-05-19T14:23:45.123Z DEBUG response body: {"error":"invalid title"}
+```
+
+RFC 3339 UTC timestamp with millisecond precision; level padded to 5 chars for
+column alignment; message follows.
+
+### JSON layout (`--log-json`)
+
+```json
+{"timestamp":"2026-05-19T14:23:45.123Z","level":"Error","message":"Permission denied. This operation requires 'update' permission."}
+{"timestamp":"2026-05-19T14:23:45.123Z","level":"Warn","message":"ABS server version 2.36.0 has not been tested with this version of abs-cli."}
+{"timestamp":"2026-05-19T14:23:45.123Z","level":"Debug","message":"GET https://my.domain.net/audiobookshelf/api/items?expanded=1 200"}
+```
+
+One JSON object per line (JSONL / NDJSON style). Three fields: `ts`,
+`level`, `msg`. Same fields whether the line is error/warn/debug.
+
+All output goes to `stderr` regardless of layout, so it never pollutes
+the stdout JSON pipelines that callers use for parsing command output.
+
+## Architecture
+
+### Dependency: NLog
+
+Adds a NuGet reference to `NLog` version **6.1.3** (latest stable as
+of 2026-05-19). No other NLog packages — the core `NLog` package
+contains everything we use: `ConsoleTarget`, `JsonLayout`,
+`SimpleLayout`, `LoggingConfiguration`, `LogManager.GetCurrentClassLogger`.
+
+NLog 6.x is the AOT-first release line: every project in the NLog
+solution sets `<IsAotCompatible>`, and AOT support without build
+warnings is an explicit goal stated in the 6.0 release notes
+(https://github.com/NLog/NLog/releases/tag/v6.0.0). The 6.0 breaking
+changes affected file/network/mail/trace targets (extracted into
+separate NuGet packages); none of those targets are used here.
+
+The implementation will still run the AOT publish step as part of
+verification — the claim is strong but our specific config shape
+deserves empirical confirmation.
+
+### Logger usage pattern
+
+Each file that logs declares a private static logger:
+
+```csharp
+private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+```
+
+And calls `_logger.Error/Warn/Debug` as needed. This is the standard
+NLog idiom; we use NLog directly rather than wrapping it. The logger
+name is the FQN of the declaring class, so per-class category
+filtering is available if ever needed.
+
+### NLog setup
+
+`src/AbsCli/Output/LogSetup.cs`:
+
+```csharp
+public static class LogSetup
+{
+    public static void Configure(bool debugEnabled, bool logJson)
+    {
+        var config = new NLog.Config.LoggingConfiguration();
+
+        NLog.Layouts.Layout layout = logJson
+            ? new NLog.Layouts.JsonLayout
+            {
+                Attributes =
+                {
+                    new NLog.Layouts.JsonAttribute("timestamp", "${date:format=yyyy-MM-ddTHH\\:mm\\:ss.fffZ:universalTime=true}"),
+                    new NLog.Layouts.JsonAttribute("level", "${level}"),
+                    new NLog.Layouts.JsonAttribute("message", "${message}")
+                }
+            }
+            : new NLog.Layouts.SimpleLayout(
+                "${date:format=yyyy-MM-ddTHH\\:mm\\:ss.fffZ:universalTime=true} ${level:uppercase=true:padding=-5} ${message}");
+
+        var target = new NLog.Targets.ConsoleTarget("stderr")
+        {
+            StdErr = true,
+            Layout = layout
+        };
+        config.AddTarget(target);
+
+        var minLevel = debugEnabled ? NLog.LogLevel.Debug : NLog.LogLevel.Warn;
+        config.AddRule(minLevel, NLog.LogLevel.Fatal, target);
+
+        NLog.LogManager.Configuration = config;
+    }
+}
+```
+
+Two layouts, one rule. Programmatic-only (no `nlog.config` file). AOT-
+safe per NLog's documentation.
+
+### Top-level exception handler
+
+`src/AbsCli/Program.cs` (sketch — wrap the existing entry call):
+
+```csharp
+private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+
+try
+{
+    return await rootCommand.Parse(args).InvokeAsync();
+}
+catch (Exception ex)
+{
+    _logger.Error(ex.Message);
+    _logger.Debug(ex.ToString());  // emits stack trace only when debug enabled
+    return 2;
+}
+```
+
+Catches everything that escapes a subcommand action (the
+`InvalidOperationException` throws on deserialization failure in
+`AbsApiClient.cs:71-183`, anything else unexpected). Exit code 2
+matches the existing pattern used by `Environment.Exit(2)` call sites,
+which are unchanged.
+
+### DebugHttpHandler
+
+`src/AbsCli/Api/DebugHttpHandler.cs` — a `DelegatingHandler` wrapping
+`HttpClientHandler`:
+
+```csharp
+internal sealed class DebugHttpHandler : DelegatingHandler
+{
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = await base.SendAsync(request, cancellationToken);
+
+        if (!_logger.IsDebugEnabled) return response;
+
+        var method = request.Method.Method;
+        // Full absolute URL — by the time the handler sees the request,
+        // HttpClient has resolved any relative URI against BaseAddress.
+        // request.RequestUri is the absolute URL that will actually be
+        // sent over the wire. Logging the full URL (instead of just
+        // PathAndQuery) makes BaseAddress misconfigurations visible.
+        var url = request.RequestUri?.AbsoluteUri ?? "";
+        var status = (int)response.StatusCode;
+        _logger.Debug($"{method} {url} {status}");
+
+        if (status >= 400)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            var truncated = body.Length > 500
+                ? body[..500] + "..."
+                : body;
+            _logger.Debug($"response body: {truncated}");
+        }
+        return response;
+    }
+}
+```
+
+`_logger.IsDebugEnabled` is NLog's built-in check; short-circuiting on
+it avoids needlessly reading and buffering the response body for every
+non-debug request.
+
+The handler is inserted as the outer wrapper around
+`HttpClientHandler` when `AbsApiClient` constructs its `HttpClient`.
+Every API call — login, refresh, every verb — flows through it.
+
+### Decision-point calls
+
+`AbsApiClient.EnsureValidTokenAsync`, `RefreshTokenAsync`, and
+`CheckServerVersion` each gain `_logger.Debug(...)` calls at their
+branch points (the per-class `_logger` field is declared at the top
+of `AbsApiClient.cs`). These are non-HTTP events that the handler cannot see
+(token check happens before any HTTP call; version check happens after
+deserializing the login response).
+
+A helper `TokenHelper.SecondsUntilExpiry(string accessToken)` is added
+if not already present so `EnsureValidTokenAsync` can emit the
+remaining-seconds number.
+
+## Privacy guarantees
+
+Never written by `Log`:
+
+- Bearer access token (`Authorization` header content).
+- Refresh token (`X-Refresh-Token` header content).
+- Request body (PATCH/POST bodies are not inspected).
+- Cookie headers.
+
+Written when debug level is on:
+
+- Request method.
+- Full request URI (scheme + host + path + query).
+- Response status code.
+- Response body on non-2xx, truncated to 500 chars.
+- Token-refresh decisions.
+- Version-check decisions.
+- Configured `BaseAddress` (once, at client construction).
+
+Query strings may carry non-secret IDs (item IDs, library IDs) but
+never credentials in abs-cli's endpoint surface.
+
+## File changes
+
+### Create
+
+- `src/AbsCli/Output/LogSetup.cs` — fluent NLog configuration, called
+  once from `Program.cs`.
+- `src/AbsCli/Api/DebugHttpHandler.cs` — `DelegatingHandler` for HTTP
+  request tracing.
+- `tests/AbsCli.Tests/Commands/RootHelpTests.cs` — render
+  `abs-cli --help` and one subcommand's `--help` via the existing
+  `RenderHelp` pattern (e.g. `AbsCli.Tests.Commands.HelpOutputTests`
+  for reference) and assert:
+  - The `--debug` Option appears with its Description string.
+  - The `--log-json` Option appears with its Description string.
+  - The `Environment variables` help section appears with
+    `ABS_DEBUG=1` mentioned.
+  - The same flags also surface on a subcommand's `--help` (since
+    they are recursive global options).
+- `tests/AbsCli.Tests/Output/LogSetupTests.cs` — capture
+  `Console.Error` via `TextWriter` redirect. For each test, call
+  `LogSetup.Configure(...)` with controlled flags, instantiate a
+  `NLog.LogManager.GetLogger("test")` instance, and verify:
+  - Default level (`Warn`): `_logger.Error` and `_logger.Warn` produce
+    output; `_logger.Debug` does not.
+  - Debug level: all three produce output.
+  - Text layout: lines match the expected format including ISO 8601 UTC
+    timestamp + uppercased padded level + message.
+  - JSON layout: each line parses as JSON with exactly the three
+    fields `timestamp`, `level`, `message`.
+- `tests/AbsCli.Tests/Api/DebugHttpHandlerTests.cs` — stub inner
+  handler returning controlled responses. With debug level enabled
+  on the NLog config: 2xx → one Debug line with full URL + status;
+  non-2xx → two lines (status + truncated body); body truncation
+  at 500 chars appends `...`. With debug level disabled: no output.
+- `tests/AbsCli.Tests/Api/AbsApiClientUrlCompositionTests.cs` —
+  regression coverage for the URL fix. Construct an `AbsApiClient`
+  with `Server = "https://example.com/audiobookshelf"` (no trailing
+  slash) and verify:
+  - `HttpClient.BaseAddress` is `https://example.com/audiobookshelf/`
+    (trailing slash present).
+  - Resolving `ApiEndpoints.Login` against BaseAddress yields
+    `https://example.com/audiobookshelf/login`.
+  - Same with `ApiEndpoints.Item("li_abc")` and other representative
+    shapes (constant + interpolated helper).
+  - Repeat with `Server = "https://example.com/audiobookshelf/"`
+    (trailing slash already present) — identical resolution; no
+    double slash anywhere.
+  - Repeat with `Server = "https://example.com"` (root domain, no
+    path) — resolution still yields `https://example.com/login`.
+
+### Modify
+
+- `src/AbsCli/AbsCli.csproj` — add `<PackageReference Include="NLog"
+  Version="6.1.3" />`. If a newer 6.x patch is available at
+  implementation time, use it; record the actual version chosen in
+  the PR description.
+- `src/AbsCli/Program.cs`:
+  1. Add two global `Option<bool>` instances on the `RootCommand`, each
+     with an explicit `Description` so System.CommandLine renders them
+     in every help screen's Options block:
+     ```csharp
+     var debugOption = new Option<bool>("--debug")
+     {
+         Description = "Enable debug-level logging (HTTP requests, token refresh, version check) to stderr."
+     };
+     var logJsonOption = new Option<bool>("--log-json")
+     {
+         Description = "Emit stderr log lines as single-line JSON instead of text."
+     };
+     rootCommand.Options.Add(debugOption);
+     rootCommand.Options.Add(logJsonOption);
+     ```
+     Both are recursive by default in System.CommandLine 2.0.7, so
+     they appear in `abs-cli --help` and in every subcommand's
+     `--help`.
+  2. Add a help section on the root command documenting the env var
+     equivalent (System.CommandLine's `--help` does not surface env
+     vars; we need an explicit section):
+     ```csharp
+     rootCommand.AddHelpSection("Environment variables",
+         "ABS_DEBUG=1   Same as --debug. Enables debug-level logging to stderr.");
+     ```
+  3. At entry, before invoking the parser:
+     ```csharp
+     var parseResult = rootCommand.Parse(args);
+     var debugEnabled = parseResult.GetValue(debugOption)
+                        || Environment.GetEnvironmentVariable("ABS_DEBUG") == "1";
+     var logJson = parseResult.GetValue(logJsonOption);
+     LogSetup.Configure(debugEnabled, logJson);
+     ```
+  4. Wrap the existing `return await rootCommand.Parse(args).InvokeAsync()`
+     call in `try`/`catch (Exception ex)` that routes through
+     `_logger.Error(ex.Message)`, emits `_logger.Debug(ex.ToString())` for the
+     stack trace, and returns 2.
+- `src/AbsCli/Api/AbsApiClient.cs`:
+  1. Constructor: change `BaseAddress = new Uri(config.Server!.TrimEnd('/'))`
+     to ensure a trailing `/`:
+     `BaseAddress = new Uri(config.Server!.TrimEnd('/') + "/")`.
+  2. Constructor: wrap `HttpClientHandler` in `DebugHttpHandler` and
+     pass it to `new HttpClient(handler)`. After `BaseAddress` is set,
+     emit `_logger.Debug($"client base address: {_http.BaseAddress}")`.
+  3. Declare a per-class logger at the top:
+     `private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();`
+  4. Replace `ConsoleOutput.WriteError(...)` and
+     `ConsoleOutput.WriteWarning(...)` call sites with
+     `_logger.Error(...)` and `_logger.Warn(...)`. Six occurrences
+     (lines 200, 210, 237, 242, 273, 291 in the current file).
+  5. `EnsureValidTokenAsync`: log token state via `_logger.Debug`.
+  6. `RefreshTokenAsync`: log refresh outcome via `_logger.Debug`.
+  7. `CheckServerVersion`: log version comparison via `_logger.Debug`.
+- `src/AbsCli/Api/ApiEndpoints.cs` — strip the leading `/` from every
+  `const string` value and every interpolated helper return. So
+  `"/login"` becomes `"login"`, `"/api/items"` becomes `"api/items"`,
+  `$"/api/items/{id}"` becomes `$"api/items/{id}"`, etc. No callers
+  outside this file hardcode paths (verified via grep).
+- `src/AbsCli/Auth/TokenHelper.cs` (or wherever `IsExpiringSoon`
+  lives) — add `SecondsUntilExpiry(string accessToken)` if not already
+  present.
+- `src/AbsCli/Commands/ConfigCommand.cs` — declare a per-class
+  `_logger` field and replace the one `ConsoleOutput.WriteError` call
+  site (line 67 today) with `_logger.Error`.
+- `src/AbsCli/Output/ConsoleOutput.cs` — remove `WriteError` and
+  `WriteWarning`. Keep `WriteJson`, `WriteRawJson` (those are stdout
+  data output, a different channel from stderr logging).
+- `docker/smoke-test.sh` — new `=== Diagnostic Logging ===` block:
+  - `ABS_DEBUG=1 $CLI libraries list 2>&1 >/dev/null | grep -E '^[0-9TZ:.\-]+ DEBUG '`
+    asserts at least one debug line.
+  - `$CLI libraries list 2>&1 >/dev/null | grep -E ' DEBUG '`
+    produces no lines (negative assertion against the same step).
+  - `ABS_DEBUG=1 $CLI --log-json libraries list 2>&1 >/dev/null | head -1
+    | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); assert
+    'timestamp' in d and 'level' in d and 'message' in d"` — combining `ABS_DEBUG=1`
+    and `--log-json` guarantees at least one stderr line (the HTTP
+    request trace) and verifies the JSON layout produces three-field
+    objects.
+- `README.md` — short "Logging" section (not a Commands-table row):
+  > **Logging.** Errors and warnings go to stderr by default
+  > (`{timestamp} ERROR …` / `WARN …`). Add `--debug` (or set
+  > `ABS_DEBUG=1`) to also emit one stderr line per HTTP call
+  > (method + full URL + status, plus the response body on non-2xx),
+  > token-refresh decisions, and version-check decisions. Add
+  > `--log-json` to switch stderr output to single-line JSON
+  > (`{"timestamp":"…","level":"…","message":"…"}`). The bearer token, refresh
+  > token, and request bodies are never logged.
+- `docs/authentication.md` — append one line to the existing
+  Server-side notes section noting that `--debug` / `ABS_DEBUG=1`
+  exposes token-refresh decisions to stderr.
+
+### Out of scope
+
+- `nlog.config` file support (XML config has AOT trimming concerns;
+  fluent code config is sufficient).
+- File output, log rotation, remote shippers (no `NLog.Targets.*`
+  beyond the default Console).
+- Request body logging (privacy risk; YAGNI).
+- Per-request timing measurements.
+- Per-category log filtering (single `abs-cli` logger; no class-based
+  categories yet).
+- INFO level (no current use; defer until a non-error non-debug event
+  surfaces).
+
+## Commit shape
+
+Branch `feat/diagnostic-logging` with six work commits (plus the
+`docs: spec …` / `docs: plan …` commits on the same branch):
+
+1. `fix: compose request URLs against BaseAddress trailing slash` —
+   `ApiEndpoints.cs` (strip leading `/` from every constant + helper)
+   and `AbsApiClient.cs:25` (append trailing `/` to BaseAddress). Adds
+   `AbsApiClientUrlCompositionTests.cs`. Lands first so the rest of
+   the branch can rely on correct URL composition; also so the bug fix
+   shows up in the changelog under Fixes rather than getting buried in
+   a feat commit.
+2. `feat: add NLog logging with --debug, ABS_DEBUG, --log-json` —
+   NuGet ref + `Output/LogSetup.cs` + tests + `Program.cs` adds the
+   two global options and calls `LogSetup.Configure` at entry. After
+   this commit the logging infra exists but is not yet used by anyone.
+3. `feat!: route errors and warnings through NLog` —
+   **Breaking change to stderr format.** Migrate the seven
+   `ConsoleOutput.WriteError`/`WriteWarning` call sites to per-class
+   `_logger.Error` / `_logger.Warn`; remove the two methods from
+   `ConsoleOutput`. Old prefixes `Error: …` / `Warning: …` change to
+   `{ts} ERROR …` / `{ts} WARN  …`. The `!` marker in the commit
+   subject (Conventional Commits) flags this for release tooling.
+4. `feat: top-level exception handler routes through NLog` —
+   `Program.cs` wraps the `Parse().InvokeAsync()` call in a try/catch
+   that emits `_logger.Error(ex.Message)` + `_logger.Debug(ex.ToString())`
+   and returns exit code 2. Closes the unhandled-exception gap.
+5. `feat: trace HTTP requests, token refresh, version check` —
+   `DebugHttpHandler` + tests + wire into `AbsApiClient`; decision-
+   point logs in `EnsureValidTokenAsync`, `RefreshTokenAsync`,
+   `CheckServerVersion`; `TokenHelper.SecondsUntilExpiry` helper if
+   needed.
+6. `test: smoke coverage + docs for diagnostic logging` — smoke
+   block (positive, negative, and JSON assertions), README "Logging"
+   section, `docs/authentication.md` cross-reference.
+
+Each commit independently revertable. Release skill harvests these as
+one fix, one breaking-change feat (the migration), three feats, and
+one combined test/docs.
+
+## Breaking changes
+
+This branch changes the stderr output format. **stdout (the JSON
+data output of every command) is unchanged.**
+
+Before:
+
+```
+Error: Permission denied. This operation requires 'update' permission.
+Warning: ABS server version 2.36.0 has not been tested with this version of abs-cli.
+```
+
+After (text layout, default):
+
+```
+2026-05-19T14:23:45.123Z ERROR Permission denied. This operation requires 'update' permission.
+2026-05-19T14:23:45.123Z WARN  ABS server version 2.36.0 has not been tested with this version of abs-cli.
+```
+
+Or under `--log-json`:
+
+```json
+{"timestamp":"2026-05-19T14:23:45.123Z","level":"Error","message":"Permission denied. This operation requires 'update' permission."}
+{"timestamp":"2026-05-19T14:23:45.123Z","level":"Warn","message":"ABS server version 2.36.0 has not been tested with this version of abs-cli."}
+```
+
+The **message body is unchanged** — existing scripts that
+substring-match on message content (e.g. `grep -q "'update' permission"`)
+keep working. Existing scripts that match the prefix verbatim (e.g.
+`grep -q "^Error:"`) **break**. abs-cli's own smoke test only does
+substring matches and is unaffected.
+
+The migration commit is marked `feat!` per Conventional Commits so
+the release skill surfaces it as a breaking change in the v0.5.0
+release notes. The PR description includes a "Breaking changes"
+callout. The README "Logging" section documents the new format.
+
+## Verification
+
+- `dotnet format AbsCli.sln --verify-no-changes` clean.
+- `dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj` green; new
+  tests (root help discoverability, LogSetup, DebugHttpHandler, URL
+  composition) add roughly 16–20 to the count.
+- `dotnet publish src/AbsCli/AbsCli.csproj -c Release -r linux-x64
+  --self-contained true /p:PublishAot=true` succeeds and produces a
+  runnable binary. This is the AOT gate — NLog 6.x explicitly
+  supports AOT without build warnings, but empirical confirmation
+  with our specific package version (6.1.3) and config shape is
+  still required.
+- The resulting AOT binary launches and `./publish/abs-cli self-test`
+  exits 0. This is the AOT-startup smoke: `self-test` runs ~50 JSON
+  serialization assertions and exercises the source-generated DTO
+  types, but it does NOT construct an `AbsApiClient` and makes no
+  HTTP calls, so no NLog log events fire during the run. What it
+  proves: NLog package loads cleanly under AOT, `LogSetup.Configure()`
+  runs without trim warnings, the binary boots end-to-end. What it
+  does NOT prove: actual NLog emission (no events fire) — the docker
+  smoke is what verifies emission with real log events.
+- `docker/smoke-test.sh` against the 2.35.0 compose stack passes
+  end-to-end, including the three new diagnostic-logging assertions
+  (debug-on, debug-off, JSON layout parses).
+- Manual sanity:
+  ```
+  ABS_DEBUG=1 abs-cli items get --id <id> 2>&1 >/dev/null
+  ```
+  Expected: text-layout lines covering the GET line (with full
+  absolute URL + status), the startup `client base address: …` line
+  on first run, the token state, and the version-check line on first
+  call after login. Confirm no bearer token appears anywhere.
+- URL-composition regression coverage in
+  `AbsApiClientUrlCompositionTests.cs`; the dev compose stack uses a
+  root-domain URL and would not catch a regression here on its own.
+
+## Risks
+
+- **NLog AOT compatibility.** Explicitly stated in the 6.0 release
+  notes ("Support Ahead-of-Time (AOT) builds without warnings"); all
+  NLog projects set `<IsAotCompatible>`. Our specific package
+  version + config shape (ConsoleTarget + JsonLayout/SimpleLayout +
+  fluent `LoggingConfiguration`) is squarely in the well-tested path,
+  but the AOT publish step in Verification is the empirical gate.
+  If it fails, options are: (a) pin to a different 6.x patch, (b)
+  fall back to 5.5.1 (older but ~10 months in field), (c) raise an
+  issue upstream. Failure is unlikely given the explicit AOT claims.
+- **Breaking change to stderr format.** Captured in the dedicated
+  "Breaking changes" section above; the migration commit is marked
+  `feat!` so it's surfaced in the release notes.
+- **Body-truncation cutoff (500 chars).** Heuristic. ABS error
+  bodies are short JSON in practice; the truncated suffix `...`
+  signals when more was discarded.
+- **Query strings carry non-secret IDs.** Acceptable per privacy
+  guarantees; documented.
+- **Top-level handler catches everything.** Including bugs in our
+  code that we'd previously have seen as raw stack traces (which is
+  ugly but informative for the dev). The `_logger.Debug(ex.ToString())`
+  call preserves the stack trace under debug mode; non-debug users
+  see only the friendly `_logger.Error(ex.Message)` line. This is the
+  intended trade.
+
+## URL-composition fix — context
+
+The URL-composition fix bundled into this branch addresses a latent
+bug in `AbsApiClient.cs:25`. The previous code,
+`BaseAddress = new Uri(config.Server!.TrimEnd('/'))`, stripped the
+trailing slash from the configured server URL, and every
+`ApiEndpoints` constant started with `/`. Per RFC 3986 § 5.2, a
+relative reference whose path starts with `/` is an *absolute-path
+reference* and replaces the base URI's path component entirely. The
+result: any user whose ABS install is behind a reverse proxy at a
+sub-path (e.g. `https://my.domain.net/audiobookshelf`) had the
+`/audiobookshelf` prefix silently dropped on every request, and every
+call went to the wrong URL.
+
+This was invisible against the dev container (whose server URL has no
+path component) and only surfaced in real reverse-proxied deployments.
+One such case was reported on Reddit (2026-05); the symptom was
+`405 Method Not Allowed` on `abs-cli login` against an ABS install at
+`https://my.domain.net/audiobookshelf`.
+
+The fix in this branch (Solution A): drop the leading `/` from every
+`ApiEndpoints` value, and ensure `BaseAddress` always ends with `/`.
+Combined, those two changes flip RFC 3986 resolution from the
+absolute-path-reference rule to the merge rule (containing-directory
+append), and sub-path base URLs are preserved through resolution.
+
+The new logging surface (full absolute URL + startup base-address
+line) is designed to make this class of misconfiguration
+self-diagnosable in the future even if a similar bug recurs.

--- a/src/AbsCli/AbsCli.csproj
+++ b/src/AbsCli/AbsCli.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.7" />
+    <PackageReference Include="NLog" Version="6.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -4,12 +4,12 @@ using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using AbsCli.Configuration;
 using AbsCli.Models;
-using AbsCli.Output;
 
 namespace AbsCli.Api;
 
 public class AbsApiClient
 {
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
     private readonly HttpClient _http;
     private readonly ConfigManager _configManager;
     private AppConfig _config;
@@ -197,7 +197,7 @@ public class AbsApiClient
     {
         if (_config.RefreshToken == null)
         {
-            ConsoleOutput.WriteError("Session expired. Run: abs-cli login");
+            _logger.Error("Session expired. Run: abs-cli login");
             Environment.Exit(2);
         }
 
@@ -207,7 +207,7 @@ public class AbsApiClient
         var response = await _http.SendAsync(request);
         if (!response.IsSuccessStatusCode)
         {
-            ConsoleOutput.WriteError("Session expired. Run: abs-cli login");
+            _logger.Error("Session expired. Run: abs-cli login");
             Environment.Exit(2);
         }
 
@@ -234,12 +234,12 @@ public class AbsApiClient
 
         if (CompareVersions(version, MinSupportedVersion) < 0)
         {
-            ConsoleOutput.WriteWarning(
+            _logger.Warn(
                 $"ABS server version {version} is older than the minimum supported version ({MinSupportedVersion}). Some features may not work.");
         }
         else if (CompareVersions(version, MaxTestedVersion) > 0)
         {
-            ConsoleOutput.WriteWarning(
+            _logger.Warn(
                 $"ABS server version {version} has not been tested with this version of abs-cli. Proceed with caution.");
         }
     }
@@ -270,7 +270,7 @@ public class AbsApiClient
             var retryResponse = await _http.SendAsync(retryRequest);
             if (!retryResponse.IsSuccessStatusCode)
             {
-                ConsoleOutput.WriteError($"API request failed after token refresh: {(int)retryResponse.StatusCode} {retryResponse.ReasonPhrase}");
+                _logger.Error($"API request failed after token refresh: {(int)retryResponse.StatusCode} {retryResponse.ReasonPhrase}");
                 Environment.Exit(2);
             }
         }
@@ -288,7 +288,7 @@ public class AbsApiClient
                 404 => $"Not found.{(string.IsNullOrWhiteSpace(body) ? "" : $" {body.Trim()}")}",
                 _ => $"API request failed: {status} {response.ReasonPhrase}{(string.IsNullOrWhiteSpace(body) ? "" : $"\n{body.Trim()}")}"
             };
-            ConsoleOutput.WriteError(message);
+            _logger.Error(message);
             Environment.Exit(2);
         }
     }

--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -22,7 +22,7 @@ public class AbsApiClient
         _configManager = configManager;
         _http = new HttpClient
         {
-            BaseAddress = new Uri(config.Server!.TrimEnd('/')),
+            BaseAddress = new Uri(config.Server!.TrimEnd('/') + "/"),
             // We manage timeouts per-request via CancellationTokenSource so that
             // long operations (backup create/apply/download/upload) can opt into
             // longer timeouts. Setting this to Infinite disables the global cap.

--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -246,13 +246,11 @@ public class AbsApiClient
         {
             _logger.Warn(
                 $"ABS server version {version} is older than the minimum supported version ({MinSupportedVersion}). Some features may not work.");
-            _logger.Debug($"server version {version} older than min {MinSupportedVersion}");
         }
         else if (CompareVersions(version, MaxTestedVersion) > 0)
         {
             _logger.Warn(
                 $"ABS server version {version} has not been tested with this version of abs-cli. Proceed with caution.");
-            _logger.Debug($"server version {version} newer than tested {MaxTestedVersion}");
         }
         else
         {

--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -34,7 +34,6 @@ public class AbsApiClient
         if (config.AccessToken != null)
             _http.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue("Bearer", config.AccessToken);
-
         _logger.Debug($"client base address: {_http.BaseAddress}");
     }
 
@@ -230,7 +229,6 @@ public class AbsApiClient
 
         _http.DefaultRequestHeaders.Authorization =
             new AuthenticationHeaderValue("Bearer", _config.AccessToken);
-
         _logger.Debug("token refresh succeeded");
     }
 

--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -20,7 +20,8 @@ public class AbsApiClient
     {
         _config = config;
         _configManager = configManager;
-        _http = new HttpClient
+        var debugHandler = new DebugHttpHandler(new HttpClientHandler());
+        _http = new HttpClient(debugHandler)
         {
             BaseAddress = new Uri(config.Server!.TrimEnd('/') + "/"),
             // We manage timeouts per-request via CancellationTokenSource so that
@@ -33,6 +34,8 @@ public class AbsApiClient
         if (config.AccessToken != null)
             _http.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue("Bearer", config.AccessToken);
+
+        _logger.Debug($"client base address: {_http.BaseAddress}");
     }
 
     public async Task<LoginResponse> LoginAsync(string username, string password)
@@ -187,9 +190,15 @@ public class AbsApiClient
     {
         if (_config.AccessToken == null) return;
 
+        var secondsLeft = TokenHelper.SecondsUntilExpiry(_config.AccessToken);
         if (TokenHelper.IsExpiringSoon(_config.AccessToken, thresholdSeconds: 60))
         {
+            _logger.Debug($"access token expiring in {secondsLeft}s, refreshing");
             await RefreshTokenAsync();
+        }
+        else
+        {
+            _logger.Debug($"access token valid ({secondsLeft}s remaining)");
         }
     }
 
@@ -207,6 +216,7 @@ public class AbsApiClient
         var response = await _http.SendAsync(request);
         if (!response.IsSuccessStatusCode)
         {
+            _logger.Debug($"token refresh failed: {(int)response.StatusCode}");
             _logger.Error("Session expired. Run: abs-cli login");
             Environment.Exit(2);
         }
@@ -220,6 +230,8 @@ public class AbsApiClient
 
         _http.DefaultRequestHeaders.Authorization =
             new AuthenticationHeaderValue("Bearer", _config.AccessToken);
+
+        _logger.Debug("token refresh succeeded");
     }
 
     private static readonly string MinSupportedVersion = "2.33.1";
@@ -236,11 +248,17 @@ public class AbsApiClient
         {
             _logger.Warn(
                 $"ABS server version {version} is older than the minimum supported version ({MinSupportedVersion}). Some features may not work.");
+            _logger.Debug($"server version {version} older than min {MinSupportedVersion}");
         }
         else if (CompareVersions(version, MaxTestedVersion) > 0)
         {
             _logger.Warn(
                 $"ABS server version {version} has not been tested with this version of abs-cli. Proceed with caution.");
+            _logger.Debug($"server version {version} newer than tested {MaxTestedVersion}");
+        }
+        else
+        {
+            _logger.Debug($"server version {version} (in tested range {MinSupportedVersion}-{MaxTestedVersion})");
         }
     }
 

--- a/src/AbsCli/Api/ApiEndpoints.cs
+++ b/src/AbsCli/Api/ApiEndpoints.cs
@@ -2,59 +2,59 @@ namespace AbsCli.Api;
 
 public static class ApiEndpoints
 {
-    public const string Login = "/login";
-    public const string AuthRefresh = "/auth/refresh";
+    public const string Login = "login";
+    public const string AuthRefresh = "auth/refresh";
 
-    public const string Libraries = "/api/libraries";
-    public static string Library(string id) => $"/api/libraries/{id}";
-    public static string LibraryItems(string libraryId) => $"/api/libraries/{libraryId}/items";
-    public static string LibrarySeries(string libraryId) => $"/api/libraries/{libraryId}/series";
-    public static string LibraryAuthors(string libraryId) => $"/api/libraries/{libraryId}/authors";
-    public static string LibrarySearch(string libraryId) => $"/api/libraries/{libraryId}/search";
+    public const string Libraries = "api/libraries";
+    public static string Library(string id) => $"api/libraries/{id}";
+    public static string LibraryItems(string libraryId) => $"api/libraries/{libraryId}/items";
+    public static string LibrarySeries(string libraryId) => $"api/libraries/{libraryId}/series";
+    public static string LibraryAuthors(string libraryId) => $"api/libraries/{libraryId}/authors";
+    public static string LibrarySearch(string libraryId) => $"api/libraries/{libraryId}/search";
 
-    public static string Item(string id) => $"/api/items/{id}";
-    public static string ItemMedia(string id) => $"/api/items/{id}/media";
-    public static string ItemCover(string id) => $"/api/items/{id}/cover";
-    public static string ItemChapters(string id) => $"/api/items/{id}/chapters";
-    public static string ItemEbookFileStatus(string id, string fileIno) => $"/api/items/{id}/ebook/{fileIno}/status";
-    public const string ItemsBatchUpdate = "/api/items/batch/update";
-    public const string ItemsBatchGet = "/api/items/batch/get";
+    public static string Item(string id) => $"api/items/{id}";
+    public static string ItemMedia(string id) => $"api/items/{id}/media";
+    public static string ItemCover(string id) => $"api/items/{id}/cover";
+    public static string ItemChapters(string id) => $"api/items/{id}/chapters";
+    public static string ItemEbookFileStatus(string id, string fileIno) => $"api/items/{id}/ebook/{fileIno}/status";
+    public const string ItemsBatchUpdate = "api/items/batch/update";
+    public const string ItemsBatchGet = "api/items/batch/get";
 
-    public static string SeriesById(string id) => $"/api/series/{id}";
-    public static string AuthorById(string id) => $"/api/authors/{id}";
-    public static string AuthorMatch(string id) => $"/api/authors/{id}/match";
-    public static string AuthorImage(string id) => $"/api/authors/{id}/image";
+    public static string SeriesById(string id) => $"api/series/{id}";
+    public static string AuthorById(string id) => $"api/authors/{id}";
+    public static string AuthorMatch(string id) => $"api/authors/{id}/match";
+    public static string AuthorImage(string id) => $"api/authors/{id}/image";
 
     // Backup
-    public const string Backups = "/api/backups";
-    public static string Backup(string id) => $"/api/backups/{id}";
-    public static string BackupApply(string id) => $"/api/backups/{id}/apply";
-    public static string BackupDownload(string id) => $"/api/backups/{id}/download";
-    public const string BackupUpload = "/api/backups/upload";
+    public const string Backups = "api/backups";
+    public static string Backup(string id) => $"api/backups/{id}";
+    public static string BackupApply(string id) => $"api/backups/{id}/apply";
+    public static string BackupDownload(string id) => $"api/backups/{id}/download";
+    public const string BackupUpload = "api/backups/upload";
 
     // Cache
-    public const string CachePurgeItems = "/api/cache/items/purge";
-    public const string CachePurge = "/api/cache/purge";
+    public const string CachePurgeItems = "api/cache/items/purge";
+    public const string CachePurge = "api/cache/purge";
 
     // Upload
-    public const string Upload = "/api/upload";
+    public const string Upload = "api/upload";
 
     // Scan
-    public static string LibraryScan(string libraryId) => $"/api/libraries/{libraryId}/scan";
-    public static string ItemScan(string id) => $"/api/items/{id}/scan";
+    public static string LibraryScan(string libraryId) => $"api/libraries/{libraryId}/scan";
+    public static string ItemScan(string id) => $"api/items/{id}/scan";
 
     // Metadata search
-    public const string SearchBooks = "/api/search/books";
-    public const string SearchProviders = "/api/search/providers";
-    public const string SearchCovers = "/api/search/covers";
-    public const string SearchAuthors = "/api/search/authors";
-    public const string SearchChapters = "/api/search/chapters";
+    public const string SearchBooks = "api/search/books";
+    public const string SearchProviders = "api/search/providers";
+    public const string SearchCovers = "api/search/covers";
+    public const string SearchAuthors = "api/search/authors";
+    public const string SearchChapters = "api/search/chapters";
 
     // Tools
-    public static string ToolsItemEncodeM4b(string id) => $"/api/tools/item/{id}/encode-m4b";
-    public static string ToolsItemEmbedMetadata(string id) => $"/api/tools/item/{id}/embed-metadata";
-    public const string ToolsBatchEmbedMetadata = "/api/tools/batch/embed-metadata";
+    public static string ToolsItemEncodeM4b(string id) => $"api/tools/item/{id}/encode-m4b";
+    public static string ToolsItemEmbedMetadata(string id) => $"api/tools/item/{id}/embed-metadata";
+    public const string ToolsBatchEmbedMetadata = "api/tools/batch/embed-metadata";
 
     // Tasks
-    public const string Tasks = "/api/tasks";
+    public const string Tasks = "api/tasks";
 }

--- a/src/AbsCli/Api/DebugHttpHandler.cs
+++ b/src/AbsCli/Api/DebugHttpHandler.cs
@@ -1,0 +1,33 @@
+namespace AbsCli.Api;
+
+internal sealed class DebugHttpHandler : DelegatingHandler
+{
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+
+    public DebugHttpHandler(HttpMessageHandler innerHandler) : base(innerHandler) { }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = await base.SendAsync(request, cancellationToken);
+
+        if (!_logger.IsDebugEnabled) return response;
+
+        var method = request.Method.Method;
+        // Full absolute URL — HttpClient has resolved any relative URI
+        // against BaseAddress before the handler sees the request.
+        var url = request.RequestUri?.AbsoluteUri ?? "";
+        var status = (int)response.StatusCode;
+        _logger.Debug($"{method} {url} {status}");
+
+        if (status >= 400)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            var truncated = body.Length > 500
+                ? body[..500] + "..."
+                : body;
+            _logger.Debug($"response body: {truncated}");
+        }
+        return response;
+    }
+}

--- a/src/AbsCli/Api/TokenHelper.cs
+++ b/src/AbsCli/Api/TokenHelper.cs
@@ -43,4 +43,11 @@ public static class TokenHelper
 
         return exp.Value <= DateTimeOffset.UtcNow.AddSeconds(thresholdSeconds);
     }
+
+    public static long? SecondsUntilExpiry(string token)
+    {
+        var exp = GetExpiration(token);
+        if (exp == null) return null;
+        return (long)(exp.Value - DateTimeOffset.UtcNow).TotalSeconds;
+    }
 }

--- a/src/AbsCli/Commands/AuthorsCommand.cs
+++ b/src/AbsCli/Commands/AuthorsCommand.cs
@@ -7,6 +7,7 @@ namespace AbsCli.Commands;
 
 public static class AuthorsCommand
 {
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
     public static Command Create()
     {
         var command = new Command("authors", "Manage authors");
@@ -110,7 +111,7 @@ public static class AuthorsCommand
             var sources = new[] { name, asin }.Count(s => !string.IsNullOrEmpty(s));
             if (sources != 1)
             {
-                ConsoleOutput.WriteError("Specify exactly one of --name or --asin");
+                _logger.Error("Specify exactly one of --name or --asin");
                 Environment.Exit(1);
             }
             var (client, _) = CommandHelper.BuildClient();
@@ -187,13 +188,13 @@ public static class AuthorsCommand
             var asin = parseResult.GetValue(asinOption);
             if (name is not null && string.IsNullOrEmpty(name))
             {
-                ConsoleOutput.WriteError("--name cannot be empty");
+                _logger.Error("--name cannot be empty");
                 Environment.Exit(1);
             }
             var body = BuildUpdateBodyForTesting(name, description, asin);
             if (body.Count == 0)
             {
-                ConsoleOutput.WriteError("Specify at least one of --name, --description, --asin");
+                _logger.Error("Specify at least one of --name, --description, --asin");
                 Environment.Exit(1);
             }
             var (client, _) = CommandHelper.BuildClient();

--- a/src/AbsCli/Commands/BackupCommand.cs
+++ b/src/AbsCli/Commands/BackupCommand.cs
@@ -7,6 +7,7 @@ namespace AbsCli.Commands;
 
 public static class BackupCommand
 {
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
     public static Command Create()
     {
         var command = new Command("backup", "Manage server backups");
@@ -129,7 +130,7 @@ public static class BackupCommand
             var file = parseResult.GetValue(fileOption)!;
             if (!File.Exists(file))
             {
-                ConsoleOutput.WriteError($"File not found: {file}");
+                _logger.Error($"File not found: {file}");
                 Environment.Exit(1);
                 return 1;
             }

--- a/src/AbsCli/Commands/CommandHelper.cs
+++ b/src/AbsCli/Commands/CommandHelper.cs
@@ -1,11 +1,11 @@
 using AbsCli.Api;
 using AbsCli.Configuration;
-using AbsCli.Output;
 
 namespace AbsCli.Commands;
 
 public static class CommandHelper
 {
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
     public static (AbsApiClient client, AppConfig config) BuildClient(
         string? serverOverride = null, string? tokenOverride = null,
         string? libraryOverride = null)
@@ -18,13 +18,13 @@ public static class CommandHelper
 
         if (string.IsNullOrEmpty(config.Server))
         {
-            ConsoleOutput.WriteError("No server configured. Run: abs-cli login");
+            _logger.Error("No server configured. Run: abs-cli login");
             Environment.Exit(1);
         }
 
         if (string.IsNullOrEmpty(config.AccessToken))
         {
-            ConsoleOutput.WriteError("Not authenticated. Run: abs-cli login");
+            _logger.Error("Not authenticated. Run: abs-cli login");
             Environment.Exit(1);
         }
 
@@ -35,7 +35,7 @@ public static class CommandHelper
     {
         if (string.IsNullOrEmpty(config.DefaultLibrary))
         {
-            ConsoleOutput.WriteError(
+            _logger.Error(
                 "No library specified. Use --library <id> or set a default with: abs-cli config set defaultLibrary <id>");
             Environment.Exit(1);
         }

--- a/src/AbsCli/Commands/ConfigCommand.cs
+++ b/src/AbsCli/Commands/ConfigCommand.cs
@@ -6,6 +6,7 @@ namespace AbsCli.Commands;
 
 public static class ConfigCommand
 {
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
     public static Command Create()
     {
         var command = new Command("config", "Manage abs-cli configuration");
@@ -64,7 +65,7 @@ public static class ConfigCommand
                     config.DefaultLibrary = value;
                     break;
                 default:
-                    ConsoleOutput.WriteError($"Unknown config key: '{key}'. Valid keys: server, defaultLibrary");
+                    _logger.Error($"Unknown config key: '{key}'. Valid keys: server, defaultLibrary");
                     Environment.Exit(1);
                     return 1;
             }

--- a/src/AbsCli/Commands/ItemsCommand.cs
+++ b/src/AbsCli/Commands/ItemsCommand.cs
@@ -8,6 +8,7 @@ namespace AbsCli.Commands;
 
 public static class ItemsCommand
 {
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
     public static Command Create()
     {
         var command = new Command("items", "Manage library items");
@@ -165,7 +166,7 @@ public static class ItemsCommand
             else if (input != null) jsonBody = CommandHelper.ReadJsonInput(input);
             else
             {
-                ConsoleOutput.WriteError("Provide --input <file> or --stdin");
+                _logger.Error("Provide --input <file> or --stdin");
                 Environment.Exit(1);
                 return 1;
             }
@@ -197,7 +198,7 @@ public static class ItemsCommand
             else if (input != null) jsonBody = CommandHelper.ReadJsonInput(input);
             else
             {
-                ConsoleOutput.WriteError("Provide --input <file> or --stdin");
+                _logger.Error("Provide --input <file> or --stdin");
                 Environment.Exit(1);
                 return 1;
             }
@@ -261,7 +262,7 @@ public static class ItemsCommand
             var sources = new[] { url, file, serverPath }.Count(s => !string.IsNullOrEmpty(s));
             if (sources != 1)
             {
-                ConsoleOutput.WriteError("Specify exactly one of --url, --file, --server-path");
+                _logger.Error("Specify exactly one of --url, --file, --server-path");
                 Environment.Exit(1);
             }
             var (client, _) = CommandHelper.BuildClient();
@@ -275,7 +276,7 @@ public static class ItemsCommand
             {
                 if (!File.Exists(file))
                 {
-                    ConsoleOutput.WriteError($"File not found: {file}");
+                    _logger.Error($"File not found: {file}");
                     Environment.Exit(1);
                 }
                 result = await service.UploadFromFileAsync(id, file);
@@ -387,17 +388,17 @@ public static class ItemsCommand
             var channels = parseResult.GetValue(channelsOption);
             if (codec != null && !ValidEncodeM4bCodecs.Contains(codec))
             {
-                ConsoleOutput.WriteError($"--codec must be one of: copy, aac, opus (got '{codec}')");
+                _logger.Error($"--codec must be one of: copy, aac, opus (got '{codec}')");
                 Environment.Exit(1);
             }
             if (bitrate != null && !ValidEncodeM4bBitrates.Contains(bitrate))
             {
-                ConsoleOutput.WriteError($"--bitrate must be one of: 32k, 64k, 128k, 192k (got '{bitrate}')");
+                _logger.Error($"--bitrate must be one of: 32k, 64k, 128k, 192k (got '{bitrate}')");
                 Environment.Exit(1);
             }
             if (channels.HasValue && channels.Value != 1 && channels.Value != 2)
             {
-                ConsoleOutput.WriteError($"--channels must be 1 or 2 (got {channels.Value})");
+                _logger.Error($"--channels must be 1 or 2 (got {channels.Value})");
                 Environment.Exit(1);
             }
             var (client, _) = CommandHelper.BuildClient();
@@ -470,7 +471,7 @@ public static class ItemsCommand
                 var msg = result.Error.StringKey == "MessageChaptersNotFound"
                     ? $"Not found. {result.Error.Error}"
                     : result.Error.Error ?? "Unknown lookup error";
-                ConsoleOutput.WriteError(msg);
+                _logger.Error(msg);
                 return 2;
             }
             ConsoleOutput.WriteJson(result.Success!, AppJsonContext.Default.ChaptersLookupResponse);
@@ -507,7 +508,7 @@ public static class ItemsCommand
             string jsonBody;
             if (stdin && input != null)
             {
-                ConsoleOutput.WriteError("Provide exactly one of --input or --stdin (got both)");
+                _logger.Error("Provide exactly one of --input or --stdin (got both)");
                 Environment.Exit(1);
                 return 1;
             }
@@ -521,7 +522,7 @@ public static class ItemsCommand
             }
             else
             {
-                ConsoleOutput.WriteError("Provide --input <file> or --stdin");
+                _logger.Error("Provide --input <file> or --stdin");
                 Environment.Exit(1);
                 return 1;
             }
@@ -533,7 +534,7 @@ public static class ItemsCommand
             }
             catch (JsonException ex)
             {
-                ConsoleOutput.WriteError($"Invalid chapters JSON: {ex.Message}");
+                _logger.Error($"Invalid chapters JSON: {ex.Message}");
                 Environment.Exit(1);
                 return 1;
             }
@@ -590,7 +591,7 @@ public static class ItemsCommand
                     new[] { id }, TimeSpan.FromSeconds(600), cancellationToken);
                 if (!ok)
                 {
-                    ConsoleOutput.WriteError("Timed out waiting for embed-metadata task to complete");
+                    _logger.Error("Timed out waiting for embed-metadata task to complete");
                     Environment.Exit(2);
                     return 2;
                 }
@@ -637,7 +638,7 @@ public static class ItemsCommand
             string jsonBody;
             if (stdin && input != null)
             {
-                ConsoleOutput.WriteError("Provide exactly one of --input or --stdin (got both)");
+                _logger.Error("Provide exactly one of --input or --stdin (got both)");
                 Environment.Exit(1);
                 return 1;
             }
@@ -651,7 +652,7 @@ public static class ItemsCommand
             }
             else
             {
-                ConsoleOutput.WriteError("Provide --input <file> or --stdin");
+                _logger.Error("Provide --input <file> or --stdin");
                 Environment.Exit(1);
                 return 1;
             }
@@ -663,13 +664,13 @@ public static class ItemsCommand
             }
             catch (JsonException ex)
             {
-                ConsoleOutput.WriteError($"Invalid JSON: {ex.Message}");
+                _logger.Error($"Invalid JSON: {ex.Message}");
                 Environment.Exit(1);
                 return 1;
             }
             if (request.LibraryItemIds.Count == 0)
             {
-                ConsoleOutput.WriteError("libraryItemIds must be a non-empty array");
+                _logger.Error("libraryItemIds must be a non-empty array");
                 Environment.Exit(1);
                 return 1;
             }
@@ -688,7 +689,7 @@ public static class ItemsCommand
                     request.LibraryItemIds, TimeSpan.FromSeconds(600), cancellationToken);
                 if (!ok)
                 {
-                    ConsoleOutput.WriteError("Timed out waiting for embed-metadata task(s) to complete");
+                    _logger.Error("Timed out waiting for embed-metadata task(s) to complete");
                     Environment.Exit(2);
                     return 2;
                 }

--- a/src/AbsCli/Commands/LoginCommand.cs
+++ b/src/AbsCli/Commands/LoginCommand.cs
@@ -1,12 +1,12 @@
 using System.CommandLine;
 using AbsCli.Api;
 using AbsCli.Configuration;
-using AbsCli.Output;
 
 namespace AbsCli.Commands;
 
 public static class LoginCommand
 {
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
     public static Command Create()
     {
         var serverOption = new Option<string?>("--server")
@@ -31,7 +31,7 @@ public static class LoginCommand
             }
             if (string.IsNullOrEmpty(server))
             {
-                ConsoleOutput.WriteError("Server URL is required.");
+                _logger.Error("Server URL is required.");
                 Environment.Exit(1);
             }
             Console.Error.Write("Username: ");
@@ -40,7 +40,7 @@ public static class LoginCommand
             var password = ReadPassword();
             if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
             {
-                ConsoleOutput.WriteError("Username and password are required.");
+                _logger.Error("Username and password are required.");
                 Environment.Exit(1);
             }
             var tempConfig = new AppConfig { Server = server };
@@ -70,7 +70,7 @@ public static class LoginCommand
             }
             catch (HttpRequestException ex)
             {
-                ConsoleOutput.WriteError($"Login failed: {ex.Message}");
+                _logger.Error($"Login failed: {ex.Message}");
                 Environment.Exit(2);
             }
             return 0;

--- a/src/AbsCli/Commands/UploadCommand.cs
+++ b/src/AbsCli/Commands/UploadCommand.cs
@@ -8,6 +8,7 @@ namespace AbsCli.Commands;
 
 public static class UploadCommand
 {
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
     public static Command Create()
     {
         var libraryOption = new Option<string?>("--library") { Description = "Library ID" };
@@ -84,31 +85,31 @@ public static class UploadCommand
             var manifestPath = parseResult.GetValue(manifestOption);
             if (sequence != null && series == null)
             {
-                ConsoleOutput.WriteError("--sequence requires --series.");
+                _logger.Error("--sequence requires --series.");
                 Environment.Exit(1);
                 return 1;
             }
             if (sequence != null && string.IsNullOrWhiteSpace(sequence))
             {
-                ConsoleOutput.WriteError("--sequence must be a non-empty string.");
+                _logger.Error("--sequence must be a non-empty string.");
                 Environment.Exit(1);
                 return 1;
             }
             if (manifestPath != null && files.Length > 0)
             {
-                ConsoleOutput.WriteError("--files and --files-manifest are mutually exclusive.");
+                _logger.Error("--files and --files-manifest are mutually exclusive.");
                 Environment.Exit(1);
                 return 1;
             }
             if (manifestPath != null && prefixSourceDir)
             {
-                ConsoleOutput.WriteError("--prefix-source-dir and --files-manifest are mutually exclusive.");
+                _logger.Error("--prefix-source-dir and --files-manifest are mutually exclusive.");
                 Environment.Exit(1);
                 return 1;
             }
             if (manifestPath == null && files.Length == 0)
             {
-                ConsoleOutput.WriteError("Pass --files <path>... or --files-manifest <path|->.");
+                _logger.Error("Pass --files <path>... or --files-manifest <path|->.");
                 Environment.Exit(1);
                 return 1;
             }
@@ -119,7 +120,7 @@ public static class UploadCommand
             {
                 if (!File.Exists(entry.LocalPath))
                 {
-                    ConsoleOutput.WriteError($"File not found: {entry.LocalPath}");
+                    _logger.Error($"File not found: {entry.LocalPath}");
                     Environment.Exit(1);
                     return 1;
                 }
@@ -141,7 +142,7 @@ public static class UploadCommand
                 var item = await service.WaitForItemByPathAsync(libraryId, receipt.RelPath);
                 if (item == null)
                 {
-                    ConsoleOutput.WriteError(
+                    _logger.Error(
                         $"Upload completed but the library item did not appear within the wait window. " +
                         $"Expected relPath: '{receipt.RelPath}'. " +
                         $"ABS may still be scanning — re-run: abs-cli items list --sort addedAt --desc --limit 5");
@@ -192,7 +193,7 @@ public static class UploadCommand
         {
             if (!File.Exists(manifestPath))
             {
-                ConsoleOutput.WriteError($"Manifest file not found: {manifestPath}");
+                _logger.Error($"Manifest file not found: {manifestPath}");
                 Environment.Exit(1);
             }
             json = await File.ReadAllTextAsync(manifestPath);
@@ -204,12 +205,12 @@ public static class UploadCommand
         }
         catch (JsonException ex)
         {
-            ConsoleOutput.WriteError($"Manifest is not valid JSON: {ex.Message}");
+            _logger.Error($"Manifest is not valid JSON: {ex.Message}");
             Environment.Exit(1);
         }
         if (entries == null || entries.Count == 0)
         {
-            ConsoleOutput.WriteError("Manifest is empty or null. Provide a non-empty array of {src, as} entries.");
+            _logger.Error("Manifest is empty or null. Provide a non-empty array of {src, as} entries.");
             Environment.Exit(1);
         }
         var result = new List<(string LocalPath, string UploadName)>(entries!.Count);
@@ -217,7 +218,7 @@ public static class UploadCommand
         {
             if (string.IsNullOrWhiteSpace(entry.Src) || string.IsNullOrWhiteSpace(entry.TargetName))
             {
-                ConsoleOutput.WriteError("Manifest entry missing 'src' or 'as'. Each entry must have both.");
+                _logger.Error("Manifest entry missing 'src' or 'as'. Each entry must have both.");
                 Environment.Exit(1);
             }
             result.Add((entry.Src, entry.TargetName));
@@ -244,7 +245,7 @@ public static class UploadCommand
         lines.Add("");
         lines.Add("Pass --prefix-source-dir to prefix each upload filename with its parent");
         lines.Add("directory name, or --files-manifest <path> for explicit per-file naming.");
-        ConsoleOutput.WriteError(string.Join("\n", lines));
+        _logger.Error(string.Join("\n", lines));
         Environment.Exit(1);
     }
 }

--- a/src/AbsCli/Output/ConsoleOutput.cs
+++ b/src/AbsCli/Output/ConsoleOutput.cs
@@ -22,14 +22,4 @@ public static class ConsoleOutput
     {
         Console.Out.WriteLine(json);
     }
-
-    public static void WriteError(string message)
-    {
-        Console.Error.WriteLine($"Error: {message}");
-    }
-
-    public static void WriteWarning(string message)
-    {
-        Console.Error.WriteLine($"Warning: {message}");
-    }
 }

--- a/src/AbsCli/Output/LogSetup.cs
+++ b/src/AbsCli/Output/LogSetup.cs
@@ -1,0 +1,39 @@
+using NLog;
+using NLog.Config;
+using NLog.Layouts;
+using NLog.Targets;
+
+namespace AbsCli.Output;
+
+public static class LogSetup
+{
+    public static void Configure(bool debugEnabled, bool logJson)
+    {
+        var config = new LoggingConfiguration();
+
+        Layout layout = logJson
+            ? new JsonLayout
+            {
+                Attributes =
+                {
+                    new JsonAttribute("timestamp", "${date:format=yyyy-MM-ddTHH\\:mm\\:ss.fffZ:universalTime=true}"),
+                    new JsonAttribute("level", "${level}"),
+                    new JsonAttribute("message", "${message}")
+                }
+            }
+            : new SimpleLayout(
+                "${date:format=yyyy-MM-ddTHH\\:mm\\:ss.fffZ:universalTime=true} ${level:uppercase=true:padding=-5} ${message}");
+
+        var target = new ConsoleTarget("stderr")
+        {
+            StdErr = true,
+            Layout = layout
+        };
+        config.AddTarget(target);
+
+        var minLevel = debugEnabled ? LogLevel.Debug : LogLevel.Warn;
+        config.AddRule(minLevel, LogLevel.Fatal, target);
+
+        LogManager.Configuration = config;
+    }
+}

--- a/src/AbsCli/Program.cs
+++ b/src/AbsCli/Program.cs
@@ -1,7 +1,19 @@
 using System.CommandLine;
 using AbsCli.Commands;
+using AbsCli.Output;
 
 var rootCommand = new RootCommand("abs-cli — Audiobookshelf CLI");
+
+var debugOption = new Option<bool>("--debug")
+{
+    Description = "Enable debug-level logging (HTTP requests, token refresh, version check) to stderr."
+};
+var logJsonOption = new Option<bool>("--log-json")
+{
+    Description = "Emit stderr log lines as single-line JSON instead of text."
+};
+rootCommand.Options.Add(debugOption);
+rootCommand.Options.Add(logJsonOption);
 
 rootCommand.Subcommands.Add(LoginCommand.Create());
 rootCommand.Subcommands.Add(ConfigCommand.Create());
@@ -18,6 +30,15 @@ rootCommand.Subcommands.Add(MetadataCommand.Create());
 rootCommand.Subcommands.Add(SelfTestCommand.Create());
 rootCommand.Subcommands.Add(ChangelogCommand.Create());
 
+rootCommand.AddHelpSection("Environment variables",
+    "ABS_DEBUG=1   Same as --debug. Enables debug-level logging to stderr.");
+
 rootCommand.UseCustomHelpSections();
 
-return await rootCommand.Parse(args).InvokeAsync();
+var parseResult = rootCommand.Parse(args);
+var debugEnabled = parseResult.GetValue(debugOption)
+                   || Environment.GetEnvironmentVariable("ABS_DEBUG") == "1";
+var logJson = parseResult.GetValue(logJsonOption);
+LogSetup.Configure(debugEnabled, logJson);
+
+return await parseResult.InvokeAsync();

--- a/src/AbsCli/Program.cs
+++ b/src/AbsCli/Program.cs
@@ -2,6 +2,8 @@ using System.CommandLine;
 using AbsCli.Commands;
 using AbsCli.Output;
 
+var _logger = NLog.LogManager.GetLogger("AbsCli.Program");
+
 var rootCommand = new RootCommand("abs-cli — Audiobookshelf CLI");
 
 var debugOption = new Option<bool>("--debug")
@@ -41,4 +43,13 @@ var debugEnabled = parseResult.GetValue(debugOption)
 var logJson = parseResult.GetValue(logJsonOption);
 LogSetup.Configure(debugEnabled, logJson);
 
-return await parseResult.InvokeAsync();
+try
+{
+    return await parseResult.InvokeAsync();
+}
+catch (Exception ex)
+{
+    _logger.Error(ex.Message);
+    _logger.Debug(ex.ToString());
+    return 2;
+}

--- a/src/AbsCli/Services/UploadService.cs
+++ b/src/AbsCli/Services/UploadService.cs
@@ -1,12 +1,12 @@
 using System.Web;
 using AbsCli.Api;
 using AbsCli.Models;
-using AbsCli.Output;
 
 namespace AbsCli.Services;
 
 public class UploadService
 {
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
     private readonly AbsApiClient _client;
 
     public UploadService(AbsApiClient client)
@@ -59,12 +59,12 @@ public class UploadService
             AppJsonContext.Default.Library);
         if (library.Folders.Count == 0)
         {
-            ConsoleOutput.WriteError("Library has no folders configured.");
+            _logger.Error("Library has no folders configured.");
             Environment.Exit(1);
         }
         if (library.Folders.Count > 1)
         {
-            ConsoleOutput.WriteError(
+            _logger.Error(
                 $"Library has {library.Folders.Count} folders. Specify --folder <id>.\n" +
                 "Use 'abs-cli libraries get --id <id>' to see folder IDs.");
             Environment.Exit(1);

--- a/tests/AbsCli.Tests/Api/AbsApiClientUrlCompositionTests.cs
+++ b/tests/AbsCli.Tests/Api/AbsApiClientUrlCompositionTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace AbsCli.Tests.Api;
 
+[Collection("NLog")]
 public class AbsApiClientUrlCompositionTests
 {
     private static AbsApiClient BuildClient(string server)

--- a/tests/AbsCli.Tests/Api/AbsApiClientUrlCompositionTests.cs
+++ b/tests/AbsCli.Tests/Api/AbsApiClientUrlCompositionTests.cs
@@ -1,0 +1,63 @@
+using AbsCli.Api;
+using AbsCli.Configuration;
+using Xunit;
+
+namespace AbsCli.Tests.Api;
+
+public class AbsApiClientUrlCompositionTests
+{
+    private static AbsApiClient BuildClient(string server)
+    {
+        var config = new AppConfig { Server = server, AccessToken = null, RefreshToken = null };
+        var configManager = new ConfigManager(Path.GetTempFileName());
+        return new AbsApiClient(config, configManager);
+    }
+
+    private static Uri Resolve(AbsApiClient client, string relativeEndpoint)
+    {
+        var httpField = typeof(AbsApiClient)
+            .GetField("_http", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var http = (System.Net.Http.HttpClient)httpField.GetValue(client)!;
+        return new Uri(http.BaseAddress!, relativeEndpoint);
+    }
+
+    [Fact]
+    public void SubPathServer_NoTrailingSlash_PreservesPath()
+    {
+        var client = BuildClient("https://example.com/audiobookshelf");
+        var resolved = Resolve(client, ApiEndpoints.Login);
+        Assert.Equal("https://example.com/audiobookshelf/login", resolved.AbsoluteUri);
+    }
+
+    [Fact]
+    public void SubPathServer_WithTrailingSlash_PreservesPath_NoDoubleSlash()
+    {
+        var client = BuildClient("https://example.com/audiobookshelf/");
+        var resolved = Resolve(client, ApiEndpoints.Login);
+        Assert.Equal("https://example.com/audiobookshelf/login", resolved.AbsoluteUri);
+    }
+
+    [Fact]
+    public void RootDomainServer_NoPath_StillResolves()
+    {
+        var client = BuildClient("https://example.com");
+        var resolved = Resolve(client, ApiEndpoints.Login);
+        Assert.Equal("https://example.com/login", resolved.AbsoluteUri);
+    }
+
+    [Fact]
+    public void SubPathServer_InterpolatedHelper_PreservesPath()
+    {
+        var client = BuildClient("https://example.com/audiobookshelf");
+        var resolved = Resolve(client, ApiEndpoints.Item("li_abc"));
+        Assert.Equal("https://example.com/audiobookshelf/api/items/li_abc", resolved.AbsoluteUri);
+    }
+
+    [Fact]
+    public void SubPathServer_BatchConstant_PreservesPath()
+    {
+        var client = BuildClient("https://example.com/audiobookshelf");
+        var resolved = Resolve(client, ApiEndpoints.ItemsBatchUpdate);
+        Assert.Equal("https://example.com/audiobookshelf/api/items/batch/update", resolved.AbsoluteUri);
+    }
+}

--- a/tests/AbsCli.Tests/Api/DebugHttpHandlerTests.cs
+++ b/tests/AbsCli.Tests/Api/DebugHttpHandlerTests.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using System.Text;
+using AbsCli.Api;
+using NLog;
+using NLog.Layouts;
+using NLog.Targets;
+using Xunit;
+
+namespace AbsCli.Tests.Api;
+
+[Collection("NLog")]
+public class DebugHttpHandlerTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        public HttpStatusCode Status { get; init; } = HttpStatusCode.OK;
+        public string ResponseBody { get; init; } = "";
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(Status)
+            {
+                Content = new StringContent(ResponseBody, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    private static MemoryTarget ConfigureMemoryTarget(bool debugEnabled)
+    {
+        var config = new NLog.Config.LoggingConfiguration();
+        var target = new MemoryTarget("memory")
+        {
+            Layout = new SimpleLayout("${level:uppercase=true} ${message}")
+        };
+        config.AddTarget(target);
+        config.AddRule(debugEnabled ? LogLevel.Debug : LogLevel.Warn, LogLevel.Fatal, target);
+        LogManager.Configuration = config;
+        return target;
+    }
+
+    [Fact]
+    public async Task DebugOff_NoLines()
+    {
+        var target = ConfigureMemoryTarget(debugEnabled: false);
+        var handler = new DebugHttpHandler(new StubHandler { Status = HttpStatusCode.OK, ResponseBody = "{}" });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/") };
+        await client.GetAsync("foo");
+        Assert.Empty(target.Logs);
+    }
+
+    [Fact]
+    public async Task DebugOn_2xx_OneLineWithMethodUrlStatus()
+    {
+        var target = ConfigureMemoryTarget(debugEnabled: true);
+        var handler = new DebugHttpHandler(new StubHandler { Status = HttpStatusCode.OK, ResponseBody = "{}" });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/sub/") };
+        await client.GetAsync("api/items?expanded=1");
+        Assert.Single(target.Logs);
+        Assert.Equal("DEBUG GET https://example.com/sub/api/items?expanded=1 200", target.Logs[0]);
+    }
+
+    [Fact]
+    public async Task DebugOn_Non2xx_TwoLinesIncludingResponseBody()
+    {
+        var target = ConfigureMemoryTarget(debugEnabled: true);
+        var handler = new DebugHttpHandler(new StubHandler { Status = HttpStatusCode.BadRequest, ResponseBody = "{\"error\":\"nope\"}" });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/") };
+        await client.PatchAsync("api/items/foo", new StringContent(""));
+        Assert.Equal(2, target.Logs.Count);
+        Assert.Equal("DEBUG PATCH https://example.com/api/items/foo 400", target.Logs[0]);
+        Assert.Equal("DEBUG response body: {\"error\":\"nope\"}", target.Logs[1]);
+    }
+
+    [Fact]
+    public async Task DebugOn_Non2xx_LongBody_TruncatedAt500()
+    {
+        var target = ConfigureMemoryTarget(debugEnabled: true);
+        var longBody = new string('x', 600);
+        var handler = new DebugHttpHandler(new StubHandler { Status = HttpStatusCode.InternalServerError, ResponseBody = longBody });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/") };
+        await client.GetAsync("api/items");
+        Assert.Equal(2, target.Logs.Count);
+        Assert.Equal($"DEBUG response body: {new string('x', 500)}...", target.Logs[1]);
+    }
+}

--- a/tests/AbsCli.Tests/Commands/RootHelpTests.cs
+++ b/tests/AbsCli.Tests/Commands/RootHelpTests.cs
@@ -1,0 +1,67 @@
+using System.CommandLine;
+using AbsCli.Commands;
+using AbsCli.Output;
+using Xunit;
+
+namespace AbsCli.Tests.Commands;
+
+public class RootHelpTests
+{
+    private static string RenderHelp(params string[] args)
+    {
+        var rootCommand = new RootCommand("abs-cli — Audiobookshelf CLI");
+        var debugOption = new Option<bool>("--debug")
+        {
+            Description = "Enable debug-level logging (HTTP requests, token refresh, version check) to stderr."
+        };
+        var logJsonOption = new Option<bool>("--log-json")
+        {
+            Description = "Emit stderr log lines as single-line JSON instead of text."
+        };
+        rootCommand.Options.Add(debugOption);
+        rootCommand.Options.Add(logJsonOption);
+        rootCommand.Subcommands.Add(LibrariesCommand.Create());
+        rootCommand.AddHelpSection("Environment variables",
+            "ABS_DEBUG=1   Same as --debug. Enables debug-level logging to stderr.");
+        rootCommand.UseCustomHelpSections();
+
+        var output = new StringWriter();
+        var config = new InvocationConfiguration { Output = output };
+        var actualArgs = args.Concat(new[] { "--help" }).ToArray();
+        rootCommand.Parse(actualArgs).Invoke(config);
+        return output.ToString();
+    }
+
+    [Fact]
+    public void Root_Help_Shows_DebugOption_WithDescription()
+    {
+        var output = RenderHelp();
+        Assert.Contains("--debug", output);
+        Assert.Contains("Enable debug-level logging", output);
+    }
+
+    [Fact]
+    public void Root_Help_Shows_LogJsonOption_WithDescription()
+    {
+        var output = RenderHelp();
+        Assert.Contains("--log-json", output);
+        Assert.Contains("single-line JSON", output);
+    }
+
+    [Fact]
+    public void Root_Help_Shows_EnvironmentVariablesSection_WithAbsDebug()
+    {
+        var output = RenderHelp();
+        Assert.Contains("Environment variables", output);
+        Assert.Contains("ABS_DEBUG=1", output);
+    }
+
+    [Fact]
+    public void Root_Help_Shows_Both_Options_Together()
+    {
+        var output = RenderHelp();
+        Assert.Contains("--debug", output);
+        Assert.Contains("--log-json", output);
+        Assert.Contains("ABS_DEBUG=1", output);
+    }
+}

--- a/tests/AbsCli.Tests/NLogCollection.cs
+++ b/tests/AbsCli.Tests/NLogCollection.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace AbsCli.Tests;
+
+[CollectionDefinition("NLog")]
+public class NLogCollection
+{
+    // Empty marker — disables parallel execution of tests in this collection.
+}

--- a/tests/AbsCli.Tests/Output/LogSetupTests.cs
+++ b/tests/AbsCli.Tests/Output/LogSetupTests.cs
@@ -1,0 +1,68 @@
+using AbsCli.Output;
+using NLog;
+using NLog.Layouts;
+using NLog.Targets;
+using Xunit;
+
+namespace AbsCli.Tests.Output;
+
+public class LogSetupTests
+{
+    [Fact]
+    public void Configure_DefaultLevel_AllowsWarnAndError_BlocksDebug()
+    {
+        LogSetup.Configure(debugEnabled: false, logJson: false);
+        var rule = LogManager.Configuration!.LoggingRules[0];
+        Assert.Contains(LogLevel.Warn, rule.Levels);
+        Assert.Contains(LogLevel.Error, rule.Levels);
+        Assert.Contains(LogLevel.Fatal, rule.Levels);
+        Assert.DoesNotContain(LogLevel.Debug, rule.Levels);
+        Assert.DoesNotContain(LogLevel.Info, rule.Levels);
+    }
+
+    [Fact]
+    public void Configure_DebugLevel_AllowsAllLevels()
+    {
+        LogSetup.Configure(debugEnabled: true, logJson: false);
+        var rule = LogManager.Configuration!.LoggingRules[0];
+        Assert.Contains(LogLevel.Debug, rule.Levels);
+        Assert.Contains(LogLevel.Info, rule.Levels);
+        Assert.Contains(LogLevel.Warn, rule.Levels);
+        Assert.Contains(LogLevel.Error, rule.Levels);
+        Assert.Contains(LogLevel.Fatal, rule.Levels);
+    }
+
+    [Fact]
+    public void Configure_TextLayout_UsesSimpleLayout()
+    {
+        LogSetup.Configure(debugEnabled: false, logJson: false);
+        var target = (ConsoleTarget)LogManager.Configuration!.LoggingRules[0].Targets[0];
+        Assert.IsType<SimpleLayout>(target.Layout);
+        var layout = (SimpleLayout)target.Layout;
+        Assert.Contains("yyyy-MM-ddTHH", layout.Text);
+        Assert.Contains(".fffZ", layout.Text);
+        Assert.Contains("${level:uppercase=true:padding=-5}", layout.Text);
+        Assert.Contains("${message}", layout.Text);
+    }
+
+    [Fact]
+    public void Configure_JsonLayout_HasThreeAttributes()
+    {
+        LogSetup.Configure(debugEnabled: false, logJson: true);
+        var target = (ConsoleTarget)LogManager.Configuration!.LoggingRules[0].Targets[0];
+        Assert.IsType<JsonLayout>(target.Layout);
+        var layout = (JsonLayout)target.Layout;
+        Assert.Equal(3, layout.Attributes.Count);
+        Assert.Contains(layout.Attributes, a => a.Name == "timestamp");
+        Assert.Contains(layout.Attributes, a => a.Name == "level");
+        Assert.Contains(layout.Attributes, a => a.Name == "message");
+    }
+
+    [Fact]
+    public void Configure_TargetIsConsoleStdErr()
+    {
+        LogSetup.Configure(debugEnabled: false, logJson: false);
+        var target = (ConsoleTarget)LogManager.Configuration!.LoggingRules[0].Targets[0];
+        Assert.Equal("True", target.StdErr!.ToString()!);
+    }
+}

--- a/tests/AbsCli.Tests/Output/LogSetupTests.cs
+++ b/tests/AbsCli.Tests/Output/LogSetupTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace AbsCli.Tests.Output;
 
+[Collection("NLog")]
 public class LogSetupTests
 {
     [Fact]


### PR DESCRIPTION
## Summary
- Adds NLog 6.1.3 + global `--debug` / `ABS_DEBUG=1` / `--log-json` options. All three discoverable in `abs-cli --help` (Options block + Environment-variables help section).
- New `DebugHttpHandler` traces method + full absolute URL + status code for every HTTP call; emits response body (truncated to 500 chars) on non-2xx. Decision-point logs added in `EnsureValidTokenAsync`, `RefreshTokenAsync`, `CheckServerVersion`. Constructor logs the resolved `BaseAddress` once at startup.
- Top-level exception handler in `Program.cs` routes uncaught exceptions through `_logger.Error` instead of raw stack traces; full stack trace via `_logger.Debug` when debug is on.
- Fixes a latent URL-composition bug at `AbsApiClient.cs:25` (RFC 3986 § 5.2 absolute-path-reference rule). Users on reverse-proxied installs at a sub-path (e.g. `https://my.domain.net/audiobookshelf`) were silently losing the sub-path on every request, causing 405 Method Not Allowed responses. `ApiEndpoints` constants no longer start with `/`; `BaseAddress` now always ends with `/`.
- Bearer token, refresh token, request bodies, and Authorization header are never logged.

## ⚠ Breaking change

The stderr format for errors and warnings changes:

Before: `Error: Permission denied. …` / `Warning: ABS server version …`
After: `2026-05-19T14:23:45.123Z ERROR Permission denied. …` / `WARN  ABS server version …`

stdout (command JSON output) is unchanged. Message bodies are unchanged — substring matchers keep working. Scripts that match the `Error:` / `Warning:` prefix verbatim need to update.

The `feat!` marker on commit 5 surfaces this to the release skill for the v0.5.0 release notes.

## Test plan
- [x] `docker/smoke-test.sh` against the 2.35.0 compose stack — 214/214 passing, including 3 new ones (debug-on, debug-off, JSON layout).
- [x] `dotnet test` passes 211/211 (was 193, +18 across LogSetup, RootHelp, DebugHttpHandler, URL composition).
- [x] `dotnet format AbsCli.sln --verify-no-changes` clean.
- [x] `dotnet publish ... /p:PublishAot=true` succeeds with zero NLog-related trim warnings; `./publish/abs-cli self-test` exits 0 (proves NLog config loads under AOT).

## Spec / plan
- Spec: `docs/specs/2026-05-19-v0.5.0-diagnostic-logging.md`
- Plan: `docs/plans/2026-05-19-v0.5.0-diagnostic-logging.md`