### PR TITLE
feat: items delete + non-interactive login + items update --stdin (v0.6.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,11 @@ jobs:
     services:
       audiobookshelf:
         image: advplyr/audiobookshelf:2.35.0
+        # The smoke authenticates via `abs-cli login` at every section, which
+        # exceeds ABS's default auth rate limit (40 logins / 10 min). Disable
+        # it on this disposable CI instance.
+        env:
+          RATE_LIMIT_AUTH_MAX: '0'
         ports:
           - 13378:80
     steps:

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ abs-cli upload --title "The Hobbit" --author "J.R.R. Tolkien" --files hobbit.m4b
 abs-cli metadata search --provider audible.de --title "The Hobbit" --author "Tolkien"
 
 # Update metadata
-abs-cli items update --id <item-id> --input '{"metadata":{"title":"New Title"}}'
+echo '{"metadata":{"title":"New Title"}}' | abs-cli items update --id <item-id> --stdin
 
 # Create a backup before bulk changes
 abs-cli backup create
@@ -162,7 +162,7 @@ The agent:
 1. Creates a backup (`abs-cli backup create`)
 2. Searches for affected items (`abs-cli search`, `abs-cli items list --limit 200` with pagination for broader checks)
 3. For each affected item, inspects existing metadata (author name, title, description) to infer the language — or searches a provider to confirm (`abs-cli metadata search --provider audible.de --title "..."`)
-4. Applies fixes it's confident about (`abs-cli items update --id <id> --input '{"metadata":{"language":"German"}}'`)
+4. Applies fixes it's confident about (`echo '{"metadata":{"language":"German"}}' | abs-cli items update --id <id> --stdin`)
 5. Asks you about ambiguous cases — "This book has a German author but an English title, which language should I set?"
 
 Same pattern works for any metadata issue: missing series assignments, inconsistent author naming, books without ASIN/ISBN, missing covers. You describe the problem, the agent investigates and fixes, escalating when unsure.
@@ -188,7 +188,7 @@ abs-cli config set defaultLibrary <library-id>
 
 | Command | Description |
 |---------|-------------|
-| `login` | Authenticate and store tokens |
+| `login [--server <url>] [--username <u>] [--password <pw> \| --password-stdin]` | Authenticate and store tokens (flags fall back to interactive prompt) |
 | `config get` | Show current configuration |
 | `config set <key> <value>` | Set a configuration value (`server`, `defaultLibrary`) |
 | `libraries list` | List all libraries |
@@ -196,7 +196,7 @@ abs-cli config set defaultLibrary <library-id>
 | `libraries scan [--force]` | Trigger a library scan (admin, async) |
 | `items list` | List items (`--filter`, `--sort`, `--limit`, `--page`, `--desc`) |
 | `items get --id <id> [--expanded] [--include progress,rssfeed,share,downloads]` | Get a single item (`--expanded` returns `libraryFiles[]`, `lastScan`, `scanVersion`; `--include` auto-implies `--expanded`) |
-| `items update --id <id> --input <json>` | Update item metadata |
+| `items update --id <id> {--input <file> \| --stdin}` | Update item metadata (JSON body from file or stdin; inline JSON no longer accepted) |
 | `items batch-update` | Batch update items (`--input <file>` or `--stdin`) |
 | `items batch-get` | Batch get items by ID (`--input <file>` or `--stdin`) |
 | `items scan --id <id>` | Scan a single item (admin, sync) |
@@ -214,6 +214,8 @@ abs-cli config set defaultLibrary <library-id>
 | `items progress set --library-item <lid> [flags]` | Set / mark finished / clear progress fields (typed flags; `--finished-at` requires `--is-finished true`) |
 | `items progress remove --library-item <lid>` | Clear all progress for an item (both audio + ebook) |
 | `items batch-update-progress {--input <file> \| --stdin}` | Bulk update progress from a JSON array |
+| `items delete --id <id> [--hard]` | Delete an item (soft = DB only; `--hard` also removes files) |
+| `items batch-delete {--input <file> \| --stdin} [--hard]` | Delete multiple items by ID |
 | `me` | Show the currently authenticated user |
 | `collections list [--library <id>] [--limit] [--page] [--include rssfeed]` | List collections in a library (paginated) |
 | `collections get --id <id> [--include rssfeed]` | Get a single collection (expanded) |

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,10 @@ services:
       - abs-metadata:/metadata
     environment:
       - PORT=80
+      # The smoke test authenticates via `abs-cli login` at every section
+      # (no curl token plumbing), which exceeds ABS's default auth rate
+      # limit (40 logins / 10 min). Disable it on this disposable test stack.
+      - RATE_LIMIT_AUTH_MAX=0
 
 volumes:
   abs-config:

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -286,6 +286,65 @@ $CLI items batch-update --stdin 2>/dev/null <<< "[{\"id\":\"$FIRST_ITEM_ID\",\"m
 
 # ============================================================
 echo ""
+echo "=== Item Delete ==="
+# ============================================================
+
+# Resolve FOLDER_ID locally — this section runs before the Upload
+# section (which sets the shared FOLDER_ID), so don't depend on it.
+DELETE_FOLDER_ID=$($CLI libraries get --id "$LIB_ID" 2>/dev/null \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['folders'][0]['id'])")
+DELETE_TMP=$(mktemp -d)
+python3 -c "
+header = bytes([0xFF, 0xFB, 0x90, 0x00]); frame = header + b'\x00' * 413
+with open('$DELETE_TMP/d.mp3', 'wb') as f:
+    [f.write(frame) for _ in range(38)]
+"
+DEL_ITEM_1=""; DEL_ITEM_2=""; DEL_ITEM_3=""
+delete_cleanup() {
+    abs_login root root
+    for v in "$DEL_ITEM_1" "$DEL_ITEM_2" "$DEL_ITEM_3"; do
+        [ -n "$v" ] && $CLI items delete --id "$v" --hard >/dev/null 2>&1 || true
+    done
+    rm -rf "$DELETE_TMP"
+}
+trap delete_cleanup EXIT
+
+# Single soft delete
+out=$($CLI upload --library "$LIB_ID" --folder "$DELETE_FOLDER_ID" --title "DELETE_SOFT" --author "Del Author" --wait --files "$DELETE_TMP/d.mp3" 2>/dev/null)
+DEL_ITEM_1=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+out=$($CLI items delete --id "$DEL_ITEM_1" 2>/dev/null)
+assert_json_expr "items delete returns success" "d['success']=='true'" "$out"
+out=$($CLI items get --id "$DEL_ITEM_1" 2>&1 || true)
+if echo "$out" | grep -qi "not found"; then pass "soft-deleted item is gone"; else fail "soft-deleted item is gone" "got: ${out:0:160}"; fi
+DEL_ITEM_1=""
+
+# Batch hard delete (two items)
+out=$($CLI upload --library "$LIB_ID" --folder "$DELETE_FOLDER_ID" --title "DELETE_B1" --author "Del Author" --wait --files "$DELETE_TMP/d.mp3" 2>/dev/null)
+DEL_ITEM_2=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+out=$($CLI upload --library "$LIB_ID" --folder "$DELETE_FOLDER_ID" --title "DELETE_B2" --author "Del Author" --wait --files "$DELETE_TMP/d.mp3" 2>/dev/null)
+DEL_ITEM_3=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+out=$(echo "{\"libraryItemIds\":[\"$DEL_ITEM_2\",\"$DEL_ITEM_3\"]}" | $CLI items batch-delete --stdin --hard 2>/dev/null)
+assert_json_expr "items batch-delete returns success" "d['success']=='true'" "$out"
+out=$($CLI items get --id "$DEL_ITEM_2" 2>&1 || true)
+if echo "$out" | grep -qi "not found"; then pass "batch-hard-deleted item 1 gone"; else fail "batch-hard-deleted item 1 gone" "got: ${out:0:160}"; fi
+out=$($CLI items get --id "$DEL_ITEM_3" 2>&1 || true)
+if echo "$out" | grep -qi "not found"; then pass "batch-hard-deleted item 2 gone"; else fail "batch-hard-deleted item 2 gone" "got: ${out:0:160}"; fi
+DEL_ITEM_2=""; DEL_ITEM_3=""
+
+# Permission denial: readonlyuser lacks delete (part E)
+out=$($CLI upload --library "$LIB_ID" --folder "$DELETE_FOLDER_ID" --title "DELETE_DENY" --author "Del Author" --wait --files "$DELETE_TMP/d.mp3" 2>/dev/null)
+DEL_ITEM_1=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+abs_login readonlyuser readonlypass
+out=$($CLI items delete --id "$DEL_ITEM_1" 2>&1 || true)
+if echo "$out" | grep -qi "permission denied.*delete"; then pass "items delete: readonlyuser hits 'delete' permission denial"; else fail "items delete: readonlyuser hits 'delete' permission denial" "got: ${out:0:160}"; fi
+abs_login root root
+
+delete_cleanup
+trap - EXIT
+DEL_ITEM_1=""
+
+# ============================================================
+echo ""
 echo "=== Series Commands ==="
 # ============================================================
 

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -63,24 +63,30 @@ assert $expr
     fi
 }
 
-# --- Get auth token and library ID from ABS directly ---
-echo "Setting up test context..."
-TOKEN=$(curl -sf -X POST "$ABS_URL/login" \
-    -H 'Content-Type: application/json' \
-    -H 'X-Return-Tokens: true' \
-    -d '{"username":"root","password":"root"}' \
-    | python3 -c "import sys,json; print(json.load(sys.stdin)['user']['accessToken'])")
+abs_login() {
+    # $1 username, $2 password — non-interactive CLI login (writes config).
+    $CLI login --server "$ABS_URL" --username "$1" --password-stdin <<<"$2" >/dev/null 2>&1
+}
 
-LIB_ID=$(curl -sf "$ABS_URL/api/libraries" \
-    -H "Authorization: Bearer $TOKEN" \
+# --- Authenticate via the CLI (dogfoods non-interactive login) ---
+echo "Setting up test context..."
+if abs_login root root; then
+    pass "login: root non-interactive login succeeds"
+else
+    fail "login: root non-interactive login succeeds" "abs_login root failed"
+    exit 1
+fi
+
+LIB_ID=$($CLI libraries list 2>/dev/null \
     | python3 -c "import sys,json; print(json.load(sys.stdin)['libraries'][0]['id'])")
 
 echo "ABS_URL=$ABS_URL  LIB_ID=$LIB_ID"
 echo ""
 
-# Export env so CLI picks them up
+# Server + library context for commands that take them explicitly.
+# NOTE: no auth token is exported — auth is driven by the config file
+# that `$CLI login` writes (flag → env → file precedence).
 export ABS_SERVER="$ABS_URL"
-export ABS_TOKEN="$TOKEN"
 export ABS_LIBRARY="$LIB_ID"
 
 # ============================================================
@@ -552,14 +558,7 @@ with open('$UPLOAD_TMP/test.mp3', 'wb') as f:
         f.write(frame)
 "
 
-UPLOAD_TOKEN=$(curl -sf -X POST "$ABS_URL/login" \
-    -H 'Content-Type: application/json' \
-    -H 'X-Return-Tokens: true' \
-    -d '{"username":"uploaduser","password":"uploadpass"}' \
-    | python3 -c "import sys,json; print(json.load(sys.stdin)['user']['accessToken'])")
-
-SAVE_TOKEN="$ABS_TOKEN"
-export ABS_TOKEN="$UPLOAD_TOKEN"
+abs_login uploaduser uploadpass
 
 output=$($CLI upload --title "Smoke Test Upload" --author "Test Author" \
     --folder "$FOLDER_ID" --wait --files "$UPLOAD_TMP/test.mp3" 2>/dev/null)
@@ -572,12 +571,11 @@ else
     echo "    response: ${output:0:200}"
 fi
 
-export ABS_TOKEN="$SAVE_TOKEN"
+abs_login root root
 
 # Cleanup: hard-delete the uploaded item (also removes orphan author "Test Author")
 if [ -n "$UPLOADED_ITEM_ID" ]; then
-    curl -sf -X DELETE "$ABS_URL/api/items/$UPLOADED_ITEM_ID?hard=1" \
-        -H "Authorization: Bearer $ABS_TOKEN" > /dev/null 2>&1 || true
+    $CLI items delete --id "$UPLOADED_ITEM_ID" --hard >/dev/null 2>&1 || true
 fi
 
 # --- Sanitisation drift detection ---
@@ -587,12 +585,12 @@ fi
 
 run_drift_case() {
     local label="$1" title="$2" author="$3" expected_relpath="$4" sequence_arg="$5" series_arg="$6"
-    export ABS_TOKEN="$UPLOAD_TOKEN"
+    abs_login uploaduser uploadpass
     local out
     out=$($CLI upload --title "$title" --author "$author" $series_arg $sequence_arg \
         --folder "$FOLDER_ID" --wait --files "$UPLOAD_TMP/test.mp3" 2>&1)
     local rc=$?
-    export ABS_TOKEN="$SAVE_TOKEN"
+    abs_login root root
     if [ $rc -ne 0 ]; then
         fail "sanitize drift: $label" "upload failed: ${out:0:300}"
         return
@@ -602,8 +600,7 @@ run_drift_case() {
     if [ "$actual" = "$expected_relpath" ]; then
         pass "sanitize drift: $label"
         local item_id=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null)
-        [ -n "$item_id" ] && curl -sf -X DELETE "$ABS_URL/api/items/$item_id?hard=1" \
-            -H "Authorization: Bearer $ABS_TOKEN" > /dev/null 2>&1 || true
+        [ -n "$item_id" ] && $CLI items delete --id "$item_id" --hard >/dev/null 2>&1 || true
     else
         fail "sanitize drift: $label" "expected relPath '$expected_relpath', got '$actual'"
     fi
@@ -656,7 +653,7 @@ for d in ['$COLLIDE_TMP/Part1', '$COLLIDE_TMP/Part2']:
                 f.write(frame)
 "
 
-export ABS_TOKEN="$UPLOAD_TOKEN"
+abs_login uploaduser uploadpass
 
 # Default: collision detected, error, no upload
 collide_out=$($CLI upload --title "Collision Default" --author "Collide Author" \
@@ -674,10 +671,9 @@ prefix_out=$($CLI upload --title "Collision Prefix" --author "Collide Author Pre
 PREFIX_ITEM=$(echo "$prefix_out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || echo "")
 if [ -n "$PREFIX_ITEM" ]; then
     pass "upload --prefix-source-dir created item"
-    export ABS_TOKEN="$SAVE_TOKEN"
-    curl -sf -X DELETE "$ABS_URL/api/items/$PREFIX_ITEM?hard=1" \
-        -H "Authorization: Bearer $ABS_TOKEN" > /dev/null 2>&1 || true
-    export ABS_TOKEN="$UPLOAD_TOKEN"
+    abs_login root root
+    $CLI items delete --id "$PREFIX_ITEM" --hard >/dev/null 2>&1 || true
+    abs_login uploaduser uploadpass
 else
     fail "upload --prefix-source-dir created item" "item not found in library"
 fi
@@ -696,15 +692,14 @@ manifest_out=$($CLI upload --title "Collision Manifest" --author "Collide Author
 MANIFEST_ITEM=$(echo "$manifest_out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || echo "")
 if [ -n "$MANIFEST_ITEM" ]; then
     pass "upload --files-manifest created item"
-    export ABS_TOKEN="$SAVE_TOKEN"
-    curl -sf -X DELETE "$ABS_URL/api/items/$MANIFEST_ITEM?hard=1" \
-        -H "Authorization: Bearer $ABS_TOKEN" > /dev/null 2>&1 || true
-    export ABS_TOKEN="$UPLOAD_TOKEN"
+    abs_login root root
+    $CLI items delete --id "$MANIFEST_ITEM" --hard >/dev/null 2>&1 || true
+    abs_login uploaduser uploadpass
 else
     fail "upload --files-manifest created item" "item not found in library"
 fi
 
-export ABS_TOKEN="$SAVE_TOKEN"
+abs_login root root
 rm -rf "$COLLIDE_TMP"
 
 # ============================================================
@@ -712,14 +707,7 @@ echo ""
 echo "=== Permission Errors ==="
 # ============================================================
 
-TEST_TOKEN=$(curl -sf -X POST "$ABS_URL/login" \
-    -H 'Content-Type: application/json' \
-    -H 'X-Return-Tokens: true' \
-    -d '{"username":"testuser","password":"testpass"}' \
-    | python3 -c "import sys,json; print(json.load(sys.stdin)['user']['accessToken'])")
-
-SAVE_TOKEN="$ABS_TOKEN"
-export ABS_TOKEN="$TEST_TOKEN"
+abs_login testuser testpass
 
 UPLOAD_TMP2=$(mktemp -d)
 python3 -c "
@@ -743,20 +731,14 @@ else
     fail "backup list as testuser shows permission denied" "got: ${error_output:0:200}"
 fi
 
-export ABS_TOKEN="$SAVE_TOKEN"
+abs_login root root
 
 # canUpdate denials: testuser AND uploaduser both have update=true in seed.sh,
 # so they can't exercise these paths. readonlyuser has update=false.
-READONLY_TOKEN=$(curl -sf -X POST "$ABS_URL/login" \
-    -H 'Content-Type: application/json' \
-    -H 'X-Return-Tokens: true' \
-    -d '{"username":"readonlyuser","password":"readonlypass"}' \
-    | python3 -c "import sys,json; print(json.load(sys.stdin)['user']['accessToken'])")
+abs_login readonlyuser readonlypass
 
-export ABS_TOKEN="$READONLY_TOKEN"
-
-error_output=$($CLI items update --id "$FIRST_ITEM_ID" \
-    --input '{"metadata":{"title":"Should Fail"}}' 2>&1 || true)
+error_output=$(echo '{"metadata":{"title":"Should Fail"}}' \
+    | $CLI items update --id "$FIRST_ITEM_ID" --stdin 2>&1 || true)
 if echo "$error_output" | grep -q "'update' permission"; then
     pass "items update as readonlyuser hits 'update' permission denial"
 else
@@ -804,7 +786,7 @@ else
     fail "cache purge as readonlyuser hits 'admin permission' denial" "got: ${error_output:0:200}"
 fi
 
-export ABS_TOKEN="$SAVE_TOKEN"
+abs_login root root
 
 # ============================================================
 echo ""
@@ -998,17 +980,14 @@ else
 fi
 
 # 11. permission denied as readonlyuser (no `update` perm — seeded by docker/seed.sh)
-if [ -n "${READONLY_TOKEN:-}" ]; then
-    SAVE_TOKEN_COLLECTIONS="$ABS_TOKEN"
-    export ABS_TOKEN="$READONLY_TOKEN"
-    output=$(echo "{\"books\":[\"$LID1\"]}" \
-        | $CLI collections create --name "denied" --stdin 2>&1 || true)
-    export ABS_TOKEN="$SAVE_TOKEN_COLLECTIONS"
-    if echo "$output" | grep -qi "permission denied.*update"; then
-        pass "collections create: readonlyuser hits 'update' permission denial"
-    else
-        fail "collections create: readonlyuser hits 'update' permission denial" "got: ${output:0:200}"
-    fi
+abs_login readonlyuser readonlypass
+output=$(echo "{\"books\":[\"$LID1\"]}" \
+    | $CLI collections create --name "denied" --stdin 2>&1 || true)
+abs_login root root
+if echo "$output" | grep -qi "permission denied.*update"; then
+    pass "collections create: readonlyuser hits 'update' permission denial"
+else
+    fail "collections create: readonlyuser hits 'update' permission denial" "got: ${output:0:200}"
 fi
 
 trap - EXIT
@@ -1405,17 +1384,14 @@ else
 fi
 
 # Permission denial: non-admin user attempting start should 403.
-if [ -n "${UPLOAD_TOKEN:-}" ]; then
-    SAVE_TOKEN_ENCODE="$ABS_TOKEN"
-    export ABS_TOKEN="$UPLOAD_TOKEN"
-    output=$($CLI items encode-m4b start --id "$ENCODE_ITEM_ID" --codec copy 2>&1 || true)
-    export ABS_TOKEN="$SAVE_TOKEN_ENCODE"
-    if echo "$output" | grep -qi "permission denied.*admin"; then
-        pass "encode-m4b start: non-admin user gets 403 admin-permission message"
-    else
-        fail "encode-m4b start: non-admin user gets 403 admin-permission message" "wrong / missing 403"
-        echo "    response: ${output:0:200}"
-    fi
+abs_login uploaduser uploadpass
+output=$($CLI items encode-m4b start --id "$ENCODE_ITEM_ID" --codec copy 2>&1 || true)
+abs_login root root
+if echo "$output" | grep -qi "permission denied.*admin"; then
+    pass "encode-m4b start: non-admin user gets 403 admin-permission message"
+else
+    fail "encode-m4b start: non-admin user gets 403 admin-permission message" "wrong / missing 403"
+    echo "    response: ${output:0:200}"
 fi
 
 # Cleanup runs via the trap above; call it explicitly so re-runs in the same shell are clean.
@@ -1443,12 +1419,11 @@ trap chapters_cleanup EXIT
 ffmpeg -y -f lavfi -i "sine=frequency=440:duration=5" -ac 2 -c:a libmp3lame -b:a 128k \
     "$CHAPTERS_TMP/test.mp3" > /dev/null 2>&1
 
-SAVE_TOKEN="$ABS_TOKEN"
-export ABS_TOKEN="$UPLOAD_TOKEN"
+abs_login uploaduser uploadpass
 output=$($CLI upload --folder "$FOLDER_ID" \
     --title "CHAPTERS_TEST" --author "Smoke Author" \
     --wait --files "$CHAPTERS_TMP/test.mp3" 2>/dev/null)
-export ABS_TOKEN="$SAVE_TOKEN"
+abs_login root root
 CHAPTERS_ITEM_ID=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id', ''))" 2>/dev/null)
 if [ -n "$CHAPTERS_ITEM_ID" ]; then
     pass "chapters: upload created test item (id=$CHAPTERS_ITEM_ID)"
@@ -1637,8 +1612,7 @@ ffmpeg -y -f lavfi -i "sine=frequency=440:duration=5" -ac 2 -c:a libmp3lame -b:a
 ffmpeg -y -f lavfi -i "sine=frequency=523:duration=5" -ac 2 -c:a libmp3lame -b:a 128k \
     "$EMBED_TMP/track2.mp3" > /dev/null 2>&1
 
-SAVE_TOKEN="$ABS_TOKEN"
-export ABS_TOKEN="$UPLOAD_TOKEN"
+abs_login uploaduser uploadpass
 
 output=$($CLI upload --folder "$FOLDER_ID" \
     --title "EMBED_METADATA_TEST_1" --author "Smoke Author" \
@@ -1650,7 +1624,7 @@ output=$($CLI upload --folder "$FOLDER_ID" \
     --wait --files "$EMBED_TMP/track2.mp3" 2>/dev/null)
 EMBED_ITEM_ID_2=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id', ''))" 2>/dev/null)
 
-export ABS_TOKEN="$SAVE_TOKEN"
+abs_login root root
 
 if [ -n "$EMBED_ITEM_ID" ] && [ -n "$EMBED_ITEM_ID_2" ]; then
     pass "embed-metadata: uploaded two test items ($EMBED_ITEM_ID, $EMBED_ITEM_ID_2)"
@@ -1751,9 +1725,9 @@ else
 fi
 
 # Permission denial: uploaduser is non-admin.
-export ABS_TOKEN="$UPLOAD_TOKEN"
+abs_login uploaduser uploadpass
 output=$($CLI items embed-metadata --id "$EMBED_ITEM_ID" 2>&1 || true)
-export ABS_TOKEN="$SAVE_TOKEN"
+abs_login root root
 if echo "$output" | grep -q "admin permission"; then
     pass "embed-metadata: uploaduser hits admin permission denial"
 else
@@ -1926,10 +1900,9 @@ else
 fi
 
 # Permission denial: readonlyuser (no canUpdate) → 403.
-SAVE_TOKEN="$ABS_TOKEN"
-export ABS_TOKEN="$READONLY_TOKEN"
+abs_login readonlyuser readonlypass
 output=$($CLI items toggle-ebook-status --id "$EBOOK_ITEM_ID" --ino "$PRIMARY_INO" 2>&1 || true)
-export ABS_TOKEN="$SAVE_TOKEN"
+abs_login root root
 if echo "$output" | grep -q "'update' permission"; then
     pass "toggle-ebook-status: readonlyuser hits 'update' permission denial"
 else

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -210,7 +210,7 @@ assert_json_key "items get has media" "media" "$output"
 # Update metadata — change title, verify it sticks
 ORIGINAL_TITLE=$(echo "$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null)" \
     | python3 -c "import sys,json; print(json.load(sys.stdin)['media']['metadata']['title'])")
-output=$($CLI items update --id "$FIRST_ITEM_ID" --input '{"metadata":{"title":"Smoke Test Updated Title"}}' 2>/dev/null)
+output=$(echo '{"metadata":{"title":"Smoke Test Updated Title"}}' | $CLI items update --id "$FIRST_ITEM_ID" --stdin 2>/dev/null)
 assert_json_key "items update returns updated item" "libraryItem" "$output"
 
 output=$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null)
@@ -218,14 +218,14 @@ assert_json_expr "items update persisted new title" \
     "d['media']['metadata']['title']=='Smoke Test Updated Title'" "$output"
 
 # Restore original title
-$CLI items update --id "$FIRST_ITEM_ID" --input "{\"metadata\":{\"title\":\"$ORIGINAL_TITLE\"}}" 2>/dev/null > /dev/null
+echo "{\"metadata\":{\"title\":\"$ORIGINAL_TITLE\"}}" | $CLI items update --id "$FIRST_ITEM_ID" --stdin 2>/dev/null > /dev/null
 output=$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null)
 assert_json_expr "items update restored original title" \
     "d['media']['metadata']['title']=='$ORIGINAL_TITLE'" "$output"
 
 # Update multiple fields at once
-output=$($CLI items update --id "$FIRST_ITEM_ID" \
-    --input '{"metadata":{"description":"Smoke test description","genres":["Fantasy","Epic"]}}' 2>/dev/null)
+output=$(echo '{"metadata":{"description":"Smoke test description","genres":["Fantasy","Epic"]}}' \
+    | $CLI items update --id "$FIRST_ITEM_ID" --stdin 2>/dev/null)
 assert_json_key "items multi-field update returns item" "libraryItem" "$output"
 
 output=$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null)
@@ -235,8 +235,8 @@ assert_json_expr "items multi-field update: genres set" \
     "'Fantasy' in d['media']['metadata'].get('genres',[])" "$output"
 
 # Restore: clear description and genres
-$CLI items update --id "$FIRST_ITEM_ID" \
-    --input '{"metadata":{"description":null,"genres":[]}}' 2>/dev/null > /dev/null
+echo '{"metadata":{"description":null,"genres":[]}}' \
+    | $CLI items update --id "$FIRST_ITEM_ID" --stdin 2>/dev/null > /dev/null
 
 # Update from file
 TMPFILE=$(mktemp)
@@ -250,8 +250,8 @@ assert_json_expr "items update from file: publisher set" \
 rm -f "$TMPFILE"
 
 # Restore publisher
-$CLI items update --id "$FIRST_ITEM_ID" \
-    --input '{"metadata":{"publisher":null}}' 2>/dev/null > /dev/null
+echo '{"metadata":{"publisher":null}}' \
+    | $CLI items update --id "$FIRST_ITEM_ID" --stdin 2>/dev/null > /dev/null
 
 # Batch get — fetch two items by ID
 SECOND_ITEM_ID=$($CLI items list --limit 5 --page 0 2>/dev/null \
@@ -389,7 +389,7 @@ authors = json.load(sys.stdin)
 authors.append({'name': 'Smoke Test Throwaway'})
 print(json.dumps({'metadata': {'authors': authors}}))
 ")
-$CLI items update --id "$FIRST_ITEM_ID" --input "$THROWAWAY_PAYLOAD" 2>/dev/null > /dev/null
+echo "$THROWAWAY_PAYLOAD" | $CLI items update --id "$FIRST_ITEM_ID" --stdin 2>/dev/null > /dev/null
 
 output=$($CLI authors list 2>/dev/null)
 assert_json_expr "authors update added throwaway author" \
@@ -412,7 +412,7 @@ RESTORE_PAYLOAD=$(python3 -c "
 import json
 print(json.dumps({'metadata': {'authors': json.loads('$ORIGINAL_AUTHORS')}}))
 ")
-$CLI items update --id "$FIRST_ITEM_ID" --input "$RESTORE_PAYLOAD" 2>/dev/null > /dev/null
+echo "$RESTORE_PAYLOAD" | $CLI items update --id "$FIRST_ITEM_ID" --stdin 2>/dev/null > /dev/null
 
 # --- update merge-on-rename (rename throwaway into an existing author) ---
 MERGEE_PAYLOAD=$(echo "$ORIGINAL_AUTHORS" | python3 -c "
@@ -421,7 +421,7 @@ authors = json.load(sys.stdin)
 authors.append({'name': 'Smoke Test Mergee'})
 print(json.dumps({'metadata': {'authors': authors}}))
 ")
-$CLI items update --id "$FIRST_ITEM_ID" --input "$MERGEE_PAYLOAD" 2>/dev/null > /dev/null
+echo "$MERGEE_PAYLOAD" | $CLI items update --id "$FIRST_ITEM_ID" --stdin 2>/dev/null > /dev/null
 
 MERGEE_ID=$($CLI authors list 2>/dev/null | python3 -c "
 import sys,json
@@ -440,7 +440,7 @@ assert_json_expr "authors update merge removed throwaway" \
 assert_json_expr "authors list still 7 after merge" "len(d['results'])==7" "$output"
 
 # Restore book to original authors (merge added Jim Butcher to FIRST_ITEM_ID)
-$CLI items update --id "$FIRST_ITEM_ID" --input "$RESTORE_PAYLOAD" 2>/dev/null > /dev/null
+echo "$RESTORE_PAYLOAD" | $CLI items update --id "$FIRST_ITEM_ID" --stdin 2>/dev/null > /dev/null
 
 # --- image set/get/remove ---
 output=$($CLI authors image set --id "$AUTHOR_ID" --url "https://placehold.co/64x64.png" 2>/dev/null)
@@ -1184,14 +1184,9 @@ ENCODE_TMP=$(mktemp -d)
 ENCODE_ITEM_ID=""
 CANCEL_TEST_ITEM_ID=""
 encode_cleanup() {
-    if [ -n "$ENCODE_ITEM_ID" ]; then
-        curl -sf -X DELETE "$ABS_URL/api/items/$ENCODE_ITEM_ID?hard=1" \
-            -H "Authorization: Bearer $ABS_TOKEN" > /dev/null 2>&1 || true
-    fi
-    if [ -n "$CANCEL_TEST_ITEM_ID" ]; then
-        curl -sf -X DELETE "$ABS_URL/api/items/$CANCEL_TEST_ITEM_ID?hard=1" \
-            -H "Authorization: Bearer $ABS_TOKEN" > /dev/null 2>&1 || true
-    fi
+    abs_login root root
+    [ -n "${ENCODE_ITEM_ID:-}" ] && $CLI items delete --id "$ENCODE_ITEM_ID" --hard >/dev/null 2>&1 || true
+    [ -n "${CANCEL_TEST_ITEM_ID:-}" ] && $CLI items delete --id "$CANCEL_TEST_ITEM_ID" --hard >/dev/null 2>&1 || true
     rm -rf "$ENCODE_TMP"
 }
 trap encode_cleanup EXIT
@@ -1406,10 +1401,8 @@ echo "=== Chapter Commands ==="
 CHAPTERS_TMP=$(mktemp -d)
 CHAPTERS_ITEM_ID=""
 chapters_cleanup() {
-    if [ -n "$CHAPTERS_ITEM_ID" ]; then
-        curl -sf -X DELETE "$ABS_URL/api/items/$CHAPTERS_ITEM_ID?hard=1" \
-            -H "Authorization: Bearer $ABS_TOKEN" > /dev/null 2>&1 || true
-    fi
+    abs_login root root
+    [ -n "${CHAPTERS_ITEM_ID:-}" ] && $CLI items delete --id "$CHAPTERS_ITEM_ID" --hard >/dev/null 2>&1 || true
     rm -rf "$CHAPTERS_TMP"
 }
 trap chapters_cleanup EXIT
@@ -1594,14 +1587,9 @@ EMBED_TMP=$(mktemp -d)
 EMBED_ITEM_ID=""
 EMBED_ITEM_ID_2=""
 embed_cleanup() {
-    if [ -n "$EMBED_ITEM_ID" ]; then
-        curl -sf -X DELETE "$ABS_URL/api/items/$EMBED_ITEM_ID?hard=1" \
-            -H "Authorization: Bearer $ABS_TOKEN" > /dev/null 2>&1 || true
-    fi
-    if [ -n "$EMBED_ITEM_ID_2" ]; then
-        curl -sf -X DELETE "$ABS_URL/api/items/$EMBED_ITEM_ID_2?hard=1" \
-            -H "Authorization: Bearer $ABS_TOKEN" > /dev/null 2>&1 || true
-    fi
+    abs_login root root
+    [ -n "${EMBED_ITEM_ID:-}" ] && $CLI items delete --id "$EMBED_ITEM_ID" --hard >/dev/null 2>&1 || true
+    [ -n "${EMBED_ITEM_ID_2:-}" ] && $CLI items delete --id "$EMBED_ITEM_ID_2" --hard >/dev/null 2>&1 || true
     rm -rf "$EMBED_TMP"
 }
 trap embed_cleanup EXIT

--- a/docs/input-output.md
+++ b/docs/input-output.md
@@ -16,11 +16,11 @@
 ## Input for Updates
 
 ```bash
-# Single item from JSON string
-abs-cli items update --id abc123 --input '{"metadata":{"language":"English"}}'
-
-# Single item from file
+# Single item from file (--input is file-path only)
 abs-cli items update --id abc123 --input update.json
+
+# Single item from stdin (pipe inline JSON)
+echo '{"metadata":{"language":"English"}}' | abs-cli items update --id abc123 --stdin
 
 # Batch from file
 abs-cli items batch-update --input updates.json

--- a/docs/plans/2026-05-30-v0.6.0-delete-login-update-stdin.md
+++ b/docs/plans/2026-05-30-v0.6.0-delete-login-update-stdin.md
@@ -1,0 +1,1047 @@
+# `items delete` + `login` non-interactive + `items update --stdin` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `items delete` / `items batch-delete`, non-interactive `login` (`--username` / `--password` / `--password-stdin`), and convert `items update` to the `--input <file>` / `--stdin` shape (breaking) — then de-curl the smoke test so it authenticates and deletes fixtures entirely through the CLI.
+
+**Architecture:** Two new `ItemsService` methods wrap the single + batch delete endpoints (raw passthrough, `delete` permission). Two new factories in `ItemsCommand.cs` (`CreateDeleteCommand`, `CreateBatchDeleteCommand`) and a reworked `CreateUpdateCommand` adopt the existing batch-* input idiom. `LoginCommand` gains flag/stdin credential resolution with prompt fallback. The smoke test replaces all curl logins with `abs-cli login` and all curl item-deletes with `abs-cli items delete`, making config-file auth the baseline.
+
+**Tech Stack:** C# / .NET 10 / `System.CommandLine` 2.0.7 / `System.Text.Json` source-gen (AOT-safe). No new packages, no new DTOs.
+
+**Spec:** [docs/specs/2026-05-30-v0.6.0-delete-login-update-stdin.md](../specs/2026-05-30-v0.6.0-delete-login-update-stdin.md)
+
+**Research:** [docs/specs/research/2026-05-30-delete-login-update-stdin.md](../specs/research/2026-05-30-delete-login-update-stdin.md)
+
+---
+
+## File Structure
+
+**New files:**
+
+- `tests/AbsCli.Tests/Commands/ItemsDeleteCommandTests.cs` — help-shape + subcommand-presence tests for `items delete` / `items batch-delete`, and `items update` shape.
+- `tests/AbsCli.Tests/Commands/LoginCommandTests.cs` — help-shape + `ReadPasswordFromStdin` line-handling tests.
+
+**Modified files:**
+
+- `src/AbsCli/Api/ApiEndpoints.cs` — add `ItemsBatchDelete` constant.
+- `src/AbsCli/Services/ItemsService.cs` — add `DeleteAsync(id, hard)` + `BatchDeleteAsync(jsonBody, hard)`.
+- `src/AbsCli/Commands/ItemsCommand.cs` — add `CreateDeleteCommand()` + `CreateBatchDeleteCommand()` factories (register both); rework `CreateUpdateCommand()` to `--input <file>` + `--stdin`.
+- `src/AbsCli/Commands/LoginCommand.cs` — add `--username` / `--password` / `--password-stdin`, resolution + prompt fallback, `ReadPasswordFromStdin` helper.
+- `README.md` — Commands table: add delete/batch-delete rows, update the `items update` and `login` rows.
+- `docker/smoke-test.sh` — de-curl auth (A,B) + inline-update rewrite (C) + new delete section (D) + delete-denial (E) + curl-delete→CLI conversion (F).
+
+**Files explicitly NOT modified:**
+
+- `CHANGELOG.md` — owned by release workflow (`feedback_changelog_owned_by_release`).
+- `docs/roadmap.md` — bullets already link the research doc on main.
+- `src/AbsCli/Api/AbsApiClient.cs` — all needed overloads exist.
+- `CommandHelper.ReadJsonInput` — left as-is.
+- No new models / `JsonContext` entries.
+
+---
+
+## Task 0: Commit this plan doc
+
+The branch (`feat/delete-login-stdin`) already has the research (linked from main) and the spec committed. This task only commits the plan.
+
+**Files:**
+- Add: `docs/plans/2026-05-30-v0.6.0-delete-login-update-stdin.md`
+
+- [ ] **Step 1: Verify branch state**
+
+```bash
+git status
+git log --oneline -3
+```
+
+Expected: on `feat/delete-login-stdin`, clean tree, top commit `64f05f6 docs: note uploads already use cli; defer further smoke tidying`.
+
+- [ ] **Step 2: Commit the plan**
+
+```bash
+git add docs/plans/2026-05-30-v0.6.0-delete-login-update-stdin.md
+git commit -m "docs: plan delete + login + update-stdin"
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+git log --oneline -1
+```
+
+Expected: top commit `docs: plan delete + login + update-stdin`.
+
+---
+
+## Task 1: Add `ItemsBatchDelete` endpoint constant
+
+**Files:**
+- Modify: `src/AbsCli/Api/ApiEndpoints.cs`
+
+- [ ] **Step 1: Add the constant**
+
+In `src/AbsCli/Api/ApiEndpoints.cs`, next to the existing
+`ItemsBatchUpdate` / `ItemsBatchGet` constants (around line 20-21), add:
+
+```csharp
+    public const string ItemsBatchDelete = "api/items/batch/delete";
+```
+
+(The single-delete URL reuses the existing `Item(string id)` helper.)
+
+- [ ] **Step 2: Build**
+
+```bash
+dotnet build src/AbsCli/AbsCli.csproj
+```
+
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/AbsCli/Api/ApiEndpoints.cs
+git commit -m "feat: add items batch-delete endpoint constant"
+```
+
+---
+
+## Task 2: Add delete methods to `ItemsService`
+
+**Files:**
+- Modify: `src/AbsCli/Services/ItemsService.cs`
+
+- [ ] **Step 1: Add the two methods**
+
+In `src/AbsCli/Services/ItemsService.cs`, add after the existing
+`BatchGetAsync` method (the methods use the existing string-returning
+`DeleteAsync` / `PostAsync` overloads and discard the empty-200 body):
+
+```csharp
+public async Task DeleteAsync(string id, bool hard)
+{
+    var url = ApiEndpoints.Item(id);
+    if (hard) url += "?hard=1";
+    await _client.DeleteAsync(url, "'delete' permission");
+}
+
+public async Task BatchDeleteAsync(string jsonBody, bool hard)
+{
+    var url = ApiEndpoints.ItemsBatchDelete;
+    if (hard) url += "?hard=1";
+    await _client.PostAsync(url, jsonBody, "'delete' permission");
+}
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+dotnet build src/AbsCli/AbsCli.csproj
+```
+
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/AbsCli/Services/ItemsService.cs
+git commit -m "feat: add ItemsService delete and batch-delete"
+```
+
+---
+
+## Task 3: Command-layer tests (write first, go red)
+
+These tests cover `items delete`, `items batch-delete`, the reworked
+`items update`, and the `login` changes. They will fail to compile until
+Tasks 4-6 land — commit them anyway (TDD red).
+
+**Files:**
+- Create: `tests/AbsCli.Tests/Commands/ItemsDeleteCommandTests.cs`
+- Create: `tests/AbsCli.Tests/Commands/LoginCommandTests.cs`
+
+- [ ] **Step 1: Create `ItemsDeleteCommandTests.cs`**
+
+```csharp
+using System.CommandLine;
+using AbsCli.Commands;
+using Xunit;
+
+namespace AbsCli.Tests.Commands;
+
+public class ItemsDeleteCommandTests
+{
+    private static string RenderHelp(params string[] path)
+    {
+        var root = new RootCommand();
+        root.Subcommands.Add(ItemsCommand.Create());
+        root.UseCustomHelpSections();
+        var output = new StringWriter();
+        var config = new InvocationConfiguration { Output = output };
+        var args = path.Concat(new[] { "--help" }).ToArray();
+        root.Parse(args).Invoke(config);
+        return output.ToString();
+    }
+
+    [Fact]
+    public void Items_HasDeleteAndBatchDelete()
+    {
+        var verbs = ItemsCommand.Create().Subcommands.Select(c => c.Name).ToList();
+        Assert.Contains("delete", verbs);
+        Assert.Contains("batch-delete", verbs);
+    }
+
+    [Fact]
+    public void ItemsDelete_Help_DocumentsIdHardAndSoftDefault()
+    {
+        var output = RenderHelp("items", "delete");
+        Assert.Contains("--id", output);
+        Assert.Contains("--hard", output);
+        Assert.Contains("database only", output);
+        Assert.Contains("irreversible", output);
+    }
+
+    [Fact]
+    public void ItemsBatchDelete_Help_DocumentsInputStdinHardAndCaveats()
+    {
+        var output = RenderHelp("items", "batch-delete");
+        Assert.Contains("--input", output);
+        Assert.Contains("--stdin", output);
+        Assert.Contains("--hard", output);
+        Assert.Contains("every id in the batch", output);
+        Assert.Contains("all-or-nothing", output);
+    }
+
+    [Fact]
+    public void ItemsUpdate_Help_DocumentsStdinAndDropsInlineJson()
+    {
+        var output = RenderHelp("items", "update");
+        Assert.Contains("--input", output);
+        Assert.Contains("--stdin", output);
+        Assert.Contains("Inline JSON", output);
+    }
+}
+```
+
+- [ ] **Step 2: Create `LoginCommandTests.cs`**
+
+```csharp
+using AbsCli.Commands;
+using Xunit;
+
+namespace AbsCli.Tests.Commands;
+
+public class LoginCommandTests
+{
+    [Fact]
+    public void ReadPasswordFromStdin_TakesFirstLine_StripsTrailingNewline()
+    {
+        using var reader = new StringReader("hunter2\n");
+        Assert.Equal("hunter2", LoginCommand.ReadPasswordFromStdin(reader));
+    }
+
+    [Fact]
+    public void ReadPasswordFromStdin_HandlesCrLf()
+    {
+        using var reader = new StringReader("hunter2\r\n");
+        Assert.Equal("hunter2", LoginCommand.ReadPasswordFromStdin(reader));
+    }
+
+    [Fact]
+    public void ReadPasswordFromStdin_NoTrailingNewline()
+    {
+        using var reader = new StringReader("hunter2");
+        Assert.Equal("hunter2", LoginCommand.ReadPasswordFromStdin(reader));
+    }
+
+    [Fact]
+    public void ReadPasswordFromStdin_TakesOnlyFirstLine()
+    {
+        using var reader = new StringReader("hunter2\nignored\n");
+        Assert.Equal("hunter2", LoginCommand.ReadPasswordFromStdin(reader));
+    }
+
+    [Fact]
+    public void ReadPasswordFromStdin_EmptyReturnsEmpty()
+    {
+        using var reader = new StringReader("");
+        Assert.Equal("", LoginCommand.ReadPasswordFromStdin(reader));
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to confirm they fail to compile**
+
+```bash
+dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj --filter "FullyQualifiedName~ItemsDeleteCommandTests|FullyQualifiedName~LoginCommandTests"
+```
+
+Expected: build failure — `LoginCommand.ReadPasswordFromStdin` does not exist; `items delete`/`batch-delete` subcommands don't exist; `items update` help lacks the inline-JSON note.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/AbsCli.Tests/Commands/ItemsDeleteCommandTests.cs tests/AbsCli.Tests/Commands/LoginCommandTests.cs
+git commit -m "test: add delete + login command tests"
+```
+
+---
+
+## Task 4: `items delete` + `items batch-delete` commands
+
+**Files:**
+- Modify: `src/AbsCli/Commands/ItemsCommand.cs`
+
+- [ ] **Step 1: Add the two factories**
+
+In `src/AbsCli/Commands/ItemsCommand.cs`, add two private static factory
+methods (place them after `CreateBatchGetCommand` for grouping). Both
+print `{"success":"true"}` on 200, matching `authors delete`
+(`AuthorsCommand.cs:245`).
+
+```csharp
+private static Command CreateDeleteCommand()
+{
+    var idOption = new Option<string>("--id") { Description = "Item ID", Required = true };
+    var hardOption = new Option<bool>("--hard") { Description = "Also delete files from disk (default: DB-only soft delete)" };
+    var command = new Command("delete", "Delete a library item") { idOption, hardOption };
+    command.AddPermissionRequired("delete");
+    command.AddHelpSection("Notes", HelpSectionPosition.Top,
+        "Soft delete (default) removes the item from ABS's database only —",
+        "files stay on disk and a rescan re-imports it. --hard also deletes",
+        "the files from disk (irreversible). Either way, authors and series",
+        "left empty by the deletion are pruned.");
+    command.AddExamples(
+        "abs-cli items delete --id \"li_abc123\"",
+        "abs-cli items delete --id \"li_abc123\" --hard");
+    command.AddHelpSection("Response shape", HelpSectionPosition.Bottom,
+        "{ \"success\": \"true\" }");
+    command.SetAction(async (parseResult, cancellationToken) =>
+    {
+        var id = parseResult.GetValue(idOption)!;
+        var hard = parseResult.GetValue(hardOption);
+        var (client, _) = CommandHelper.BuildClient();
+        var service = new ItemsService(client);
+        await service.DeleteAsync(id, hard);
+        ConsoleOutput.WriteJson(new Dictionary<string, string> { ["success"] = "true" });
+        return 0;
+    });
+    return command;
+}
+
+private static Command CreateBatchDeleteCommand()
+{
+    var inputOption = new Option<string?>("--input") { Description = "JSON file with {\"libraryItemIds\":[...]}" };
+    var stdinOption = new Option<bool>("--stdin") { Description = "Read JSON from stdin" };
+    var hardOption = new Option<bool>("--hard") { Description = "Also delete files from disk (applies to every id in the batch)" };
+    var command = new Command("batch-delete", "Delete multiple library items")
+        { inputOption, stdinOption, hardOption };
+    command.AddPermissionRequired("delete");
+    command.AddHelpSection("Notes", HelpSectionPosition.Top,
+        "--hard applies to every id in the batch (server has no per-item",
+        "granularity). All-or-nothing on access: if you lack access to any",
+        "item in the batch, the whole request is refused. Soft vs hard",
+        "semantics identical to `items delete`.");
+    command.AddExamples(
+        "abs-cli items batch-delete --input ids.json",
+        "echo '{\"libraryItemIds\":[\"li_a\",\"li_b\"]}' | abs-cli items batch-delete --stdin --hard");
+    command.AddHelpSection("Response shape", HelpSectionPosition.Bottom,
+        "{ \"success\": \"true\" }");
+    command.SetAction(async (parseResult, cancellationToken) =>
+    {
+        var input = parseResult.GetValue(inputOption);
+        var stdin = parseResult.GetValue(stdinOption);
+        var hard = parseResult.GetValue(hardOption);
+        string jsonBody;
+        if (stdin) jsonBody = await Console.In.ReadToEndAsync(cancellationToken);
+        else if (input != null) jsonBody = CommandHelper.ReadJsonInput(input);
+        else
+        {
+            _logger.Error("Provide --input <file> or --stdin");
+            Environment.Exit(1);
+            return 1;
+        }
+        var (client, _) = CommandHelper.BuildClient();
+        var service = new ItemsService(client);
+        await service.BatchDeleteAsync(jsonBody, hard);
+        ConsoleOutput.WriteJson(new Dictionary<string, string> { ["success"] = "true" });
+        return 0;
+    });
+    return command;
+}
+```
+
+Register both in `ItemsCommand.Create()` (after the existing
+`CreateBatchGetCommand()` registration, line 21):
+
+```csharp
+command.Subcommands.Add(CreateDeleteCommand());
+command.Subcommands.Add(CreateBatchDeleteCommand());
+```
+
+- [ ] **Step 2: Build + run delete tests**
+
+```bash
+dotnet build src/AbsCli/AbsCli.csproj
+dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj --filter "FullyQualifiedName~ItemsDeleteCommandTests.Items_HasDeleteAndBatchDelete|FullyQualifiedName~ItemsDeleteCommandTests.ItemsDelete_Help|FullyQualifiedName~ItemsDeleteCommandTests.ItemsBatchDelete_Help"
+```
+
+Expected: 3 tests pass (`Items_HasDeleteAndBatchDelete`,
+`ItemsDelete_Help_DocumentsIdHardAndSoftDefault`,
+`ItemsBatchDelete_Help_DocumentsInputStdinHardAndCaveats`). The
+`ItemsUpdate_Help` test still fails until Task 5.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/AbsCli/Commands/ItemsCommand.cs
+git commit -m "feat: add items delete and batch-delete subcommands"
+```
+
+---
+
+## Task 5: Rework `items update` to `--input <file>` + `--stdin` (breaking)
+
+**Files:**
+- Modify: `src/AbsCli/Commands/ItemsCommand.cs`
+
+- [ ] **Step 1: Replace `CreateUpdateCommand()`**
+
+In `src/AbsCli/Commands/ItemsCommand.cs`, replace the existing
+`CreateUpdateCommand()` (currently at ~line 138-162) with:
+
+```csharp
+private static Command CreateUpdateCommand()
+{
+    var idOption = new Option<string>("--id") { Description = "Item ID", Required = true };
+    var inputOption = new Option<string?>("--input") { Description = "JSON file with the update body" };
+    var stdinOption = new Option<bool>("--stdin") { Description = "Read the update body from stdin" };
+    var command = new Command("update", "Update a single item's metadata") { idOption, inputOption, stdinOption };
+    command.AddPermissionRequired("update");
+    command.AddHelpSection("Notes", HelpSectionPosition.Top,
+        "Reads the update body from a JSON file (--input <file>) or stdin",
+        "(--stdin). Inline JSON strings are no longer accepted — pipe via",
+        "--stdin instead.");
+    command.AddExamples(
+        "abs-cli items update --id \"li_abc123\" --input payload.json",
+        "echo '{\"metadata\":{\"title\":\"New Title\"}}' | abs-cli items update --id \"li_abc123\" --stdin");
+    command.AddResponseExample<UpdateMediaResponse>();
+    command.AddMediaUnionShapes();
+    command.SetAction(async (parseResult, cancellationToken) =>
+    {
+        var id = parseResult.GetValue(idOption)!;
+        var input = parseResult.GetValue(inputOption);
+        var stdin = parseResult.GetValue(stdinOption);
+        string jsonBody;
+        if (stdin) jsonBody = await Console.In.ReadToEndAsync(cancellationToken);
+        else if (input != null) jsonBody = CommandHelper.ReadJsonInput(input);
+        else
+        {
+            _logger.Error("Provide --input <file> or --stdin");
+            Environment.Exit(1);
+            return 1;
+        }
+        var (client, _) = CommandHelper.BuildClient();
+        var service = new ItemsService(client);
+        var result = await service.UpdateMediaAsync(id, jsonBody);
+        ConsoleOutput.WriteJson(result, AppJsonContext.Default.UpdateMediaResponse);
+        return 0;
+    });
+    return command;
+}
+```
+
+(`--input` is no longer `Required = true`; the action requires exactly
+one of `--input` / `--stdin`, matching `CreateBatchUpdateCommand`.)
+
+- [ ] **Step 2: Build + run the update test**
+
+```bash
+dotnet build src/AbsCli/AbsCli.csproj
+dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj --filter "FullyQualifiedName~ItemsDeleteCommandTests.ItemsUpdate_Help"
+```
+
+Expected: `ItemsUpdate_Help_DocumentsStdinAndDropsInlineJson` passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/AbsCli/Commands/ItemsCommand.cs
+git commit -m "feat: items update uses --input <file> / --stdin (breaking)"
+```
+
+---
+
+## Task 6: `login` non-interactive credentials
+
+**Files:**
+- Modify: `src/AbsCli/Commands/LoginCommand.cs`
+
+- [ ] **Step 1: Add the `ReadPasswordFromStdin` helper**
+
+In `src/AbsCli/Commands/LoginCommand.cs`, add this internal static
+method (testable; takes a `TextReader`):
+
+```csharp
+/// <summary>
+/// Read a password from stdin: the first line, stripped of a single
+/// trailing CRLF/LF. Returns "" if stdin is empty. A password with an
+/// embedded newline is not supportable via this path.
+/// </summary>
+internal static string ReadPasswordFromStdin(TextReader reader)
+{
+    var line = reader.ReadLine();
+    return line ?? "";
+}
+```
+
+(`TextReader.ReadLine` already strips the line terminator and returns
+`null` at EOF — the helper normalizes EOF to `""` and takes only the
+first line.)
+
+- [ ] **Step 2: Add the three options + resolution logic**
+
+In `LoginCommand.Create()`, add the options alongside the existing
+`serverOption`:
+
+```csharp
+var usernameOption = new Option<string?>("--username") { Description = "Username (prompts if omitted)" };
+var passwordOption = new Option<string?>("--password") { Description = "Password — visible in process list / shell history; prefer --password-stdin" };
+var passwordStdinOption = new Option<bool>("--password-stdin") { Description = "Read the password from the first line of stdin" };
+```
+
+Add them to the command's option list:
+
+```csharp
+var command = new Command("login", "Authenticate with an Audiobookshelf server")
+{
+    serverOption, usernameOption, passwordOption, passwordStdinOption
+};
+```
+
+Add a Notes help section:
+
+```csharp
+command.AddHelpSection("Notes", HelpSectionPosition.Top,
+    "--password is visible in the process list and shell history. Prefer",
+    "--password-stdin (reads the first line of stdin) for scripted use.",
+    "Any credential not supplied via flag is prompted for interactively",
+    "(username plain, password hidden).");
+```
+
+Update the examples:
+
+```csharp
+command.AddExamples(
+    "abs-cli login --server https://abs.example.com",
+    "abs-cli login --server https://abs.example.com --username agent --password-stdin <<<\"$ABS_PW\"",
+    "abs-cli login --server https://abs.example.com --username agent --password \"$ABS_PW\"");
+```
+
+- [ ] **Step 3: Wire credential resolution into the action**
+
+Inside the `SetAction` lambda, replace the current
+username/password-gathering block (the part that does
+`Console.Error.Write("Username: ")` … `ReadPassword()`) with:
+
+```csharp
+var usernameFlag = parseResult.GetValue(usernameOption);
+var passwordFlag = parseResult.GetValue(passwordOption);
+var passwordStdin = parseResult.GetValue(passwordStdinOption);
+
+if (passwordFlag != null && passwordStdin)
+{
+    _logger.Error("Provide --password or --password-stdin, not both.");
+    Environment.Exit(1);
+}
+
+// Server resolution stays as-is (flag-or-prompt), above this block.
+
+var username = usernameFlag;
+if (string.IsNullOrEmpty(username))
+{
+    Console.Error.Write("Username: ");
+    username = Console.ReadLine()?.Trim();
+}
+
+string? password;
+if (passwordFlag != null)
+{
+    password = passwordFlag;
+}
+else if (passwordStdin)
+{
+    password = ReadPasswordFromStdin(Console.In);
+    if (string.IsNullOrEmpty(password))
+    {
+        _logger.Error("No password on stdin.");
+        Environment.Exit(1);
+    }
+}
+else
+{
+    Console.Error.Write("Password: ");
+    password = ReadPassword();
+}
+
+if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
+{
+    _logger.Error("Username and password are required.");
+    Environment.Exit(1);
+}
+```
+
+Keep the rest of the action (the `LoginAsync` call, config save, status
+output) unchanged. Keep the `ReadPassword()` keystroke helper for the
+interactive path.
+
+- [ ] **Step 4: Build + run login tests**
+
+```bash
+dotnet build src/AbsCli/AbsCli.csproj
+dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj --filter "FullyQualifiedName~LoginCommandTests"
+```
+
+Expected: all 5 `LoginCommandTests` pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/AbsCli/Commands/LoginCommand.cs
+git commit -m "feat: login accepts --username / --password / --password-stdin"
+```
+
+---
+
+## Task 7: README Commands table
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update rows**
+
+In `README.md`'s Commands table:
+
+Update the existing `items update` row to:
+```markdown
+| `items update --id <id> {--input <file> \| --stdin}` | Update item metadata (JSON body from file or stdin; inline JSON no longer accepted) |
+```
+
+Update the existing `login` row to:
+```markdown
+| `login [--server <url>] [--username <u>] [--password <pw> \| --password-stdin]` | Authenticate and store tokens (flags fall back to interactive prompt) |
+```
+
+Add two new rows after the last `items` row (before the `me` /
+`collections` block):
+```markdown
+| `items delete --id <id> [--hard]` | Delete an item (soft = DB only; `--hard` also removes files) |
+| `items batch-delete {--input <file> \| --stdin} [--hard]` | Delete multiple items by ID |
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -n "items delete\|items batch-delete\|items update --id\|login \[--server" README.md
+```
+
+Expected: the new/updated rows are present.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: update README for delete + login + update-stdin"
+```
+
+---
+
+## Task 8: Smoke test — de-curl auth + setup (parts A, B)
+
+**Files:**
+- Modify: `docker/smoke-test.sh`
+
+- [ ] **Step 1: Add the `abs_login` helper + rewrite setup (part A)**
+
+In `docker/smoke-test.sh`, near the helper definitions (before the
+"Setting up test context" block at ~line 66), add:
+
+```bash
+abs_login() {
+    # $1 username, $2 password — non-interactive CLI login (writes config).
+    abs-cli login --server "$ABS_URL" --username "$1" --password-stdin <<<"$2" >/dev/null 2>&1
+}
+```
+
+Replace the setup block (currently `smoke-test.sh:66-84`, the root curl
++ `LIB_ID` curl + `ABS_TOKEN` export) with:
+
+```bash
+# --- Authenticate via the CLI (dogfoods non-interactive login) ---
+echo "Setting up test context..."
+if abs_login root root; then
+    pass "login: root non-interactive login succeeds"
+else
+    fail "login: root non-interactive login succeeds" "abs_login root failed"
+    exit 1
+fi
+
+LIB_ID=$($CLI libraries list 2>/dev/null \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['libraries'][0]['id'])")
+
+echo "ABS_URL=$ABS_URL  LIB_ID=$LIB_ID"
+echo ""
+
+# Server + library context for commands that take them explicitly.
+# NOTE: ABS_TOKEN is deliberately NOT exported — auth is driven by the
+# config file that `abs-cli login` writes (flag → env → file precedence).
+export ABS_SERVER="$ABS_URL"
+export ABS_LIBRARY="$LIB_ID"
+```
+
+- [ ] **Step 2: Convert the per-user token sections (part B)**
+
+Remove the three `UPLOAD_TOKEN` / `TEST_TOKEN` / `READONLY_TOKEN` curl
+fetches (`smoke-test.sh:555, 715, 750`). Convert every env-token swap to
+a login swap. The transformation, applied at each site
+(`smoke-test.sh:561, 590, 659, 677, 680, 699, 702, 707, 721, 722, 746,
+756, 807, 1002-1006, 1409-1412, 1446-1451, 1640-1653, 1754-1756,
+1929-1932`):
+
+Before (representative):
+```bash
+SAVE_TOKEN="$ABS_TOKEN"
+export ABS_TOKEN="$UPLOAD_TOKEN"
+# … denial check …
+export ABS_TOKEN="$SAVE_TOKEN"
+```
+After:
+```bash
+abs_login uploaduser uploadpass
+# … denial check …
+abs_login root root
+```
+
+Mapping of the old token variables to login creds:
+- `UPLOAD_TOKEN` → `abs_login uploaduser uploadpass`
+- `READONLY_TOKEN` → `abs_login readonlyuser readonlypass`
+- `TEST_TOKEN` → `abs_login testuser testpass`
+- restore (`$SAVE_TOKEN` / `$SAVE_TOKEN_*`) → `abs_login root root`
+
+Drop the `if [ -n "${UPLOAD_TOKEN:-}" ]` / `${READONLY_TOKEN:-}` guards
+(the seeded users always exist) — make those blocks unconditional. Seed
+creds confirmed at `seed.sh:268`: `testuser/testpass`,
+`uploaduser/uploadpass`, `readonlyuser/readonlypass`.
+
+- [ ] **Step 3: Syntax check**
+
+```bash
+bash -n docker/smoke-test.sh
+```
+
+Expected: silent success.
+
+- [ ] **Step 4: Grep to confirm no auth curls remain**
+
+```bash
+grep -n "X-Return-Tokens\|ABS_TOKEN" docker/smoke-test.sh || echo "CLEAN: no token curls / ABS_TOKEN left"
+```
+
+Expected: `CLEAN` (no `X-Return-Tokens`, no `ABS_TOKEN` references).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/smoke-test.sh
+git commit -m "test: de-curl smoke auth via abs-cli login"
+```
+
+---
+
+## Task 9: Smoke test — convert curl deletes to CLI (part F) + inline update rewrite (part C)
+
+**Files:**
+- Modify: `docker/smoke-test.sh`
+
+- [ ] **Step 1: Convert inline `items update` calls to `--stdin` (part C)**
+
+Rewrite the inline-JSON `items update --input '{...}'` calls. At each of
+`smoke-test.sh:207, 215, 221-222, 232-233, 247-248`, convert:
+```bash
+$CLI items update --id "$FIRST_ITEM_ID" --input '{"metadata":{"title":"Smoke Test Updated Title"}}'
+```
+to:
+```bash
+echo '{"metadata":{"title":"Smoke Test Updated Title"}}' | $CLI items update --id "$FIRST_ITEM_ID" --stdin
+```
+Keep the `$TMPFILE` file-based call (line 238, `--input "$TMPFILE"`) as
+its is — it validates the `--input <file>` path.
+
+- [ ] **Step 2: Convert inline curl deletes to CLI (part F, inline sites)**
+
+Replace the inline curl deletes in the upload section. At
+`smoke-test.sh:579` and `:605`:
+```bash
+curl -sf -X DELETE "$ABS_URL/api/items/$UPLOADED_ITEM_ID?hard=1" -H "Authorization: Bearer $TOKEN" >/dev/null 2>&1
+```
+becomes:
+```bash
+abs-cli items delete --id "$UPLOADED_ITEM_ID" --hard >/dev/null 2>&1 || true
+```
+Same for `:678` (`$PREFIX_ITEM`) and `:700` (`$MANIFEST_ITEM`). These run
+while root is the active login, so no extra guard is needed inline.
+
+- [ ] **Step 3: Convert the cleanup-trap deletes (part F, traps)**
+
+In `encode_cleanup` (`:1207-1216`), `chapters_cleanup` (`:1432-1437`),
+and `embed_cleanup` (`:1621-1630`), prepend `abs_login root root` so the
+trap always has delete permission regardless of which user a denial
+section left logged in, and convert each curl delete. Example for
+`encode_cleanup`:
+
+```bash
+encode_cleanup() {
+    abs_login root root
+    [ -n "${ENCODE_ITEM_ID:-}" ] && abs-cli items delete --id "$ENCODE_ITEM_ID" --hard >/dev/null 2>&1 || true
+    [ -n "${CANCEL_TEST_ITEM_ID:-}" ] && abs-cli items delete --id "$CANCEL_TEST_ITEM_ID" --hard >/dev/null 2>&1 || true
+    rm -rf "$ENCODE_TMP"
+}
+```
+
+Apply the same shape to `chapters_cleanup` (`$CHAPTERS_ITEM_ID`) and
+`embed_cleanup` (`$EMBED_ITEM_ID`, `$EMBED_ITEM_ID_2`).
+
+- [ ] **Step 4: Syntax check + confirm zero curl**
+
+```bash
+bash -n docker/smoke-test.sh
+grep -n "curl" docker/smoke-test.sh || echo "CLEAN: no curl left in smoke"
+```
+
+Expected: `bash -n` silent; grep prints `CLEAN: no curl left in smoke`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/smoke-test.sh
+git commit -m "test: convert smoke curl deletes + inline update to cli"
+```
+
+---
+
+## Task 10: Smoke test — new delete coverage (parts D, E)
+
+**Files:**
+- Modify: `docker/smoke-test.sh`
+
+- [ ] **Step 1: Add the `=== Item Delete ===` section**
+
+Insert after the items block (a clean seam is right before
+`=== Series Commands ===` at `smoke-test.sh:283`). Uses `$CLI upload
+--wait` for fixtures and `abs-cli items delete` for the operations under
+test, with a cleanup trap that re-establishes root.
+
+```bash
+# ============================================================
+echo ""
+echo "=== Item Delete ==="
+# ============================================================
+
+# Resolve FOLDER_ID locally — this section runs before the Upload
+# section (which sets the shared FOLDER_ID), so don't depend on it.
+DELETE_FOLDER_ID=$($CLI libraries get --id "$LIB_ID" 2>/dev/null \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['folders'][0]['id'])")
+DELETE_TMP=$(mktemp -d)
+python3 -c "
+header = bytes([0xFF, 0xFB, 0x90, 0x00]); frame = header + b'\x00' * 413
+with open('$DELETE_TMP/d.mp3', 'wb') as f:
+    [f.write(frame) for _ in range(38)]
+"
+DEL_ITEM_1=""; DEL_ITEM_2=""; DEL_ITEM_3=""
+delete_cleanup() {
+    abs_login root root
+    for v in "$DEL_ITEM_1" "$DEL_ITEM_2" "$DEL_ITEM_3"; do
+        [ -n "$v" ] && abs-cli items delete --id "$v" --hard >/dev/null 2>&1 || true
+    done
+    rm -rf "$DELETE_TMP"
+}
+trap delete_cleanup EXIT
+
+# Single soft delete
+out=$($CLI upload --library "$LIB_ID" --folder "$DELETE_FOLDER_ID" --title "DELETE_SOFT" --author "Del Author" --wait --files "$DELETE_TMP/d.mp3" 2>/dev/null)
+DEL_ITEM_1=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+out=$($CLI items delete --id "$DEL_ITEM_1" 2>/dev/null)
+assert_json_expr "items delete returns success" "d['success']=='true'" "$out"
+out=$($CLI items get --id "$DEL_ITEM_1" 2>&1 || true)
+if echo "$out" | grep -qi "not found"; then pass "soft-deleted item is gone"; else fail "soft-deleted item is gone" "got: ${out:0:160}"; fi
+DEL_ITEM_1=""
+
+# Batch hard delete (two items)
+out=$($CLI upload --library "$LIB_ID" --folder "$DELETE_FOLDER_ID" --title "DELETE_B1" --author "Del Author" --wait --files "$DELETE_TMP/d.mp3" 2>/dev/null)
+DEL_ITEM_2=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+out=$($CLI upload --library "$LIB_ID" --folder "$DELETE_FOLDER_ID" --title "DELETE_B2" --author "Del Author" --wait --files "$DELETE_TMP/d.mp3" 2>/dev/null)
+DEL_ITEM_3=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+out=$(echo "{\"libraryItemIds\":[\"$DEL_ITEM_2\",\"$DEL_ITEM_3\"]}" | $CLI items batch-delete --stdin --hard 2>/dev/null)
+assert_json_expr "items batch-delete returns success" "d['success']=='true'" "$out"
+out=$($CLI items get --id "$DEL_ITEM_2" 2>&1 || true)
+if echo "$out" | grep -qi "not found"; then pass "batch-hard-deleted item 1 gone"; else fail "batch-hard-deleted item 1 gone" "got: ${out:0:160}"; fi
+out=$($CLI items get --id "$DEL_ITEM_3" 2>&1 || true)
+if echo "$out" | grep -qi "not found"; then pass "batch-hard-deleted item 2 gone"; else fail "batch-hard-deleted item 2 gone" "got: ${out:0:160}"; fi
+DEL_ITEM_2=""; DEL_ITEM_3=""
+
+# Permission denial: readonlyuser lacks delete (part E)
+out=$($CLI upload --library "$LIB_ID" --folder "$DELETE_FOLDER_ID" --title "DELETE_DENY" --author "Del Author" --wait --files "$DELETE_TMP/d.mp3" 2>/dev/null)
+DEL_ITEM_1=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+abs_login readonlyuser readonlypass
+out=$($CLI items delete --id "$DEL_ITEM_1" 2>&1 || true)
+if echo "$out" | grep -qi "permission denied.*delete"; then pass "items delete: readonlyuser hits 'delete' permission denial"; else fail "items delete: readonlyuser hits 'delete' permission denial" "got: ${out:0:160}"; fi
+abs_login root root
+
+delete_cleanup
+trap - EXIT
+DEL_ITEM_1=""
+```
+
+(`$FOLDER_ID` is already resolved earlier in the smoke via `abs-cli
+libraries get`; confirm it is in scope at this insertion point — it is
+set in the Upload section setup. If the Upload section runs AFTER this
+insertion point, resolve `FOLDER_ID` locally here with the same
+`abs-cli libraries get` one-liner the upload section uses.)
+
+- [ ] **Step 2: Syntax check**
+
+```bash
+bash -n docker/smoke-test.sh
+```
+
+Expected: silent success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker/smoke-test.sh
+git commit -m "test: add items delete + batch-delete smoke coverage"
+```
+
+---
+
+## Task 11: Final verification (build, format, unit, self-test, live smoke)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Format check**
+
+```bash
+dotnet format AbsCli.sln --verify-no-changes
+```
+
+Expected: clean. If not, `dotnet format AbsCli.sln` and commit
+`chore: dotnet format`.
+
+- [ ] **Step 2: Full unit tests**
+
+```bash
+dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Self-test**
+
+```bash
+dotnet run --project src/AbsCli -- self-test
+```
+
+Expected: all pass (no new models, count unchanged).
+
+- [ ] **Step 4: Help renders**
+
+```bash
+dotnet run --project src/AbsCli -- items delete --help >/dev/null
+dotnet run --project src/AbsCli -- items batch-delete --help >/dev/null
+dotnet run --project src/AbsCli -- items update --help >/dev/null
+dotnet run --project src/AbsCli -- login --help >/dev/null
+echo "help OK"
+```
+
+Expected: all render without error.
+
+- [ ] **Step 5: Live smoke against the docker stack**
+
+Per `CLAUDE.md` "Pre-PR verification" — bring up the stack, resolve the
+container IP, seed, run smoke:
+
+```bash
+cd docker && docker compose up -d && cd ..
+CONTAINER_IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+# Wait for healthcheck, then seed (root/root exists only after seed):
+until curl -sf "http://$CONTAINER_IP:80/healthcheck" >/dev/null 2>&1; do sleep 5; done
+ABS_URL=http://$CONTAINER_IP:80 bash docker/seed.sh
+ABS_URL=http://$CONTAINER_IP:80 bash docker/smoke-test.sh
+```
+
+Expected: all checks green, including the new `=== Item Delete ===`
+section and the converted permission-denial sections. If the stack
+carries stale state (smoke asserts exactly 1 library), reset first:
+`cd docker && docker compose down -v && docker compose up -d`.
+
+- [ ] **Step 6: Commit any format fixup**
+
+```bash
+git status
+# if dirty from the format step:
+git add -u && git commit -m "chore: dotnet format"
+```
+
+---
+
+## Task 12: Open the PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin feat/delete-login-stdin
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "feat: items delete + non-interactive login + items update --stdin (v0.6.0)" --body "$(cat <<'EOF'
+## Summary
+- Adds `items delete --id <id> [--hard]` and `items batch-delete {--input|--stdin} [--hard]` (soft = DB-only, `--hard` = also removes files; `delete` permission; author/series cascade-prune).
+- `login` gains `--username` / `--password` / `--password-stdin`, each falling back to the interactive prompt. `--password-stdin` avoids process-list/history exposure.
+- `items update` switched to `--input <file>` / `--stdin` (breaking — inline JSON strings no longer accepted), matching the batch-* shape.
+- De-curls the smoke test: all auth now goes through `abs-cli login` and all fixture cleanup through `abs-cli items delete`. The smoke contains zero curl afterward.
+
+## Test plan
+- [x] unit tests pass (`dotnet test`)
+- [x] self-test passes (`abs-cli self-test`)
+- [x] `dotnet format AbsCli.sln --verify-no-changes` clean
+- [x] smoke test green against local dev stack (`docker/smoke-test.sh`), including new `=== Item Delete ===` section + de-curled auth/cleanup
+- [x] delete permission-denial verified as `readonlyuser`
+
+## Spec
+- Research: `docs/specs/research/2026-05-30-delete-login-update-stdin.md`
+- Spec: `docs/specs/2026-05-30-v0.6.0-delete-login-update-stdin.md`
+- Plan: `docs/plans/2026-05-30-v0.6.0-delete-login-update-stdin.md`
+EOF
+)"
+```
+
+- [ ] **Step 3: Watch CI**
+
+Poll `gh pr checks <num>` (or a Monitor) until every required check is
+terminal. Diagnose any failure before declaring done.
+
+---
+
+## Out-of-plan notes
+
+- **Roadmap** already links the research doc on main; the smoke-tidying
+  follow-up is tracked as its own v0.6.0 bullet. No plan-time roadmap
+  edits.
+- **CHANGELOG** not touched (release workflow owns it).
+- The `items update` breaking change + the smoke de-curl are the
+  highest-risk parts — Task 8/9's per-section conversions are mechanical
+  but numerous; the `grep` gates in those tasks (no `ABS_TOKEN`, no
+  `curl`) are the guardrails.

--- a/docs/specs/2026-05-30-v0.6.0-delete-login-update-stdin.md
+++ b/docs/specs/2026-05-30-v0.6.0-delete-login-update-stdin.md
@@ -424,9 +424,11 @@ upload section (`smoke-test.sh:579, 605, 678, 700`) and in the
 ```bash
 abs-cli items delete --id "$ID" --hard >/dev/null 2>&1 || true
 ```
-This completes the de-curl — after A–F the smoke uses no curl for item
-operations (only `/api/upload` fixture *creation* remains curl, which is
-out of scope; there's no throwaway-upload CLI path the smoke uses).
+This completes the de-curl. Fixture *creation* already uses `$CLI
+upload --wait` (not curl), and `FOLDER_ID` already uses `$CLI libraries
+get`, so after A–F **the smoke contains zero curl calls** — the four
+logins, one `LIB_ID` lookup, and nine deletes were the entire curl
+inventory.
 
 **Root-context wrinkle (important):** the curl deletes carry their own
 root token, so they always have `delete` permission. The CLI deletes
@@ -465,6 +467,13 @@ main). At release, the whole v0.6.0 milestone moves to "Completed".
 - Token-paste login (`config set` already writes tokens directly).
 - Narrowing `ReadJsonInput` to file-only (left as-is; other callers are
   unaffected).
+- **Further smoke tidying** — the repeated `python3 -c "import
+  sys,json…"` JSON-extraction one-liners could collapse into a
+  `json_get` helper, and the near-identical per-section `*_cleanup()`
+  traps could be parameterized. Both are large, mechanical, and
+  orthogonal to this feature; deferred to a dedicated "smoke tidy" PR to
+  keep this diff focused on delete/login/update + the de-curl they
+  enable.
 
 ## Open questions
 

--- a/docs/specs/2026-05-30-v0.6.0-delete-login-update-stdin.md
+++ b/docs/specs/2026-05-30-v0.6.0-delete-login-update-stdin.md
@@ -1,0 +1,401 @@
+# `items delete` + `login` non-interactive + `items update --stdin` — design
+
+Status: drafted 2026-05-30. Targets v0.6.0.
+
+## Summary
+
+Three independent primitives bundled into one PR (small, cohesive
+"round out existing command ergonomics" theme):
+
+```
+items delete       --id <id> [--hard]
+items batch-delete (--input <file>|--stdin) [--hard]
+
+login [--server <url>] [--username <name>] [--password <pw> | --password-stdin]
+
+items update --id <id> (--input <file>|--stdin)     # --input now file-only (breaking)
+```
+
+See research:
+[docs/specs/research/2026-05-30-delete-login-update-stdin.md](research/2026-05-30-delete-login-update-stdin.md).
+
+## Motivation
+
+- **Delete**: the CLI can list, get, and update items but cannot remove
+  them. `items delete` / `items batch-delete` close the gap for the
+  agent cleanup loop (e.g. drop a mis-imported book).
+- **Login non-interactive**: `login` is TTY-only today (prompts for
+  username + hidden password). Agents and CI need a flag/stdin path.
+- **`items update --stdin`**: `items update --input` is dual-mode
+  (inline-JSON-or-file) while `batch-update` / `batch-get` are
+  `--input <file>` + `--stdin`. This unifies the input shape across all
+  JSON-body verbs.
+
+---
+
+## 1. `items delete` + `items batch-delete`
+
+### ABS endpoints touched
+
+| CLI verb | Method | Path | Body | Query | Permission |
+|---|---|---|---|---|---|
+| `items delete` | DELETE | `/api/items/:id` | – | `?hard=1` | `canDelete` |
+| `items batch-delete` | POST | `/api/items/batch/delete` | `{libraryItemIds:[...]}` | `?hard=1` | `canDelete` |
+
+Source: `LibraryItemController.delete` (`LibraryItemController.js:114-150`),
+`batchDelete` (`:554`); routing `ApiRouter.js:109` and `:102`.
+
+### Behavior
+
+- **Soft delete (default):** removes the item + media records from ABS's
+  DB. Files stay on disk; a rescan re-imports the item.
+- **`--hard`:** sends `?hard=1` — ABS additionally `fs.remove`s the
+  item directory. Irreversible.
+- **Cascade:** authors/series left empty by the deletion are pruned
+  (`:141-146`).
+- **Batch access model:** `batchDelete` does NOT go through the `:id`
+  middleware; it checks `canDelete` inline and validates access to every
+  item via `ensureUserCanAccessLibraryItemsForBatch`. If the caller lacks
+  access to ANY item in the batch, the whole request is refused (403).
+  `404` if none of the ids resolve; `400` on a malformed body.
+- Both return empty `200`.
+
+### Command surface
+
+```
+items delete --id <id> [--hard]
+items batch-delete (--input <file>|--stdin) [--hard]
+```
+
+| Flag | Verb | Required | Notes |
+|---|---|---|---|
+| `--id` | delete | yes | Library item ID |
+| `--hard` | both | no | Also delete files from disk (default: DB-only soft delete) |
+| `--input` | batch-delete | yes\* | JSON file: `{"libraryItemIds":["li_a",...]}` |
+| `--stdin` | batch-delete | yes\* | Same JSON from stdin |
+
+\* Exactly one of `--input` / `--stdin` on `batch-delete`.
+
+Permission tag `delete` on both; service permission-hint string
+`'delete' permission`.
+
+### Output
+
+- `items delete`: `{"success":"true"}` synthesized on 200 (matches
+  `authors delete` / `collections delete`).
+- `items batch-delete`: `{"success":"true"}` on 200.
+
+### `--help` text constraint
+
+- `items delete`: "Soft delete (default) removes the item from ABS's
+  database only — files stay on disk and a rescan re-imports it.
+  `--hard` also deletes the files from disk (irreversible). Authors and
+  series left empty by the deletion are pruned."
+- `items batch-delete`: "`--hard` applies to every id in the batch
+  (server has no per-item granularity). All-or-nothing on access: if you
+  lack access to any item in the batch, the whole request is refused.
+  Soft vs hard semantics identical to `items delete`."
+
+---
+
+## 2. `login` non-interactive credentials
+
+### Current state
+
+`LoginCommand` (`src/AbsCli/Commands/LoginCommand.cs`): `--server` flag
+or stderr prompt, then stderr prompts for username and a hidden password
+(`ReadPassword`). Calls `AbsApiClient.LoginAsync(username, password)` →
+`POST /login`. No server-side or client change needed — only the
+credential-gathering changes.
+
+### Command surface
+
+```
+login [--server <url>] [--username <name>] [--password <pw> | --password-stdin]
+```
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--server` | no | Server URL (existing; flag-or-prompt) |
+| `--username` | no | Username (flag-or-prompt) |
+| `--password` | no | Password as a flag — visible in `ps`/history |
+| `--password-stdin` | no | Read password from stdin (first line) |
+
+**Resolution rules:**
+- `--server` absent → prompt (existing behavior).
+- `--username` absent → prompt (plain stdin line, as today).
+- `--password` set → use it. Else `--password-stdin` set → read first
+  line of stdin. Else → prompt (hidden, as today).
+- `--password` and `--password-stdin` both set → exit 1.
+
+Fully non-interactive examples:
+```
+abs-cli login --server https://abs.example.com --username agent --password-stdin <<<"$ABS_PW"
+abs-cli login --server https://abs.example.com --username agent --password "$ABS_PW"
+```
+
+### `--password-stdin` line handling
+
+Read all of stdin, take the first line, strip a single trailing
+`\r\n` or `\n`. So both `<<<"$PW"` (here-string, adds a newline) and
+`printf '%s' "$PW" |` work. A password containing a literal newline is
+not supportable via this path — documented in `--help`. Empty result
+after stripping → exit 1 `No password on stdin.`
+
+### Validation / errors
+
+| Failure | Exit | stderr |
+|---|---|---|
+| `--password` + `--password-stdin` both | 1 | `Provide --password or --password-stdin, not both.` |
+| `--password-stdin` empty | 1 | `No password on stdin.` |
+| server missing after prompt | 1 | `Server URL is required.` (existing) |
+| username/password empty after resolution | 1 | `Username and password are required.` (existing) |
+| login HTTP failure | 2 | `Login failed: <message>` (existing) |
+
+### `--help` text constraint
+
+- "`--password` is visible in the process list and shell history. Prefer
+  `--password-stdin` (reads the first line of stdin) for scripted use."
+- "Any credential not supplied via flag is prompted for interactively
+  (username plain, password hidden)."
+
+---
+
+## 3. `items update --stdin` (breaking)
+
+### Current state
+
+`items update --input` is dual-mode via `CommandHelper.ReadJsonInput`
+(`CommandHelper.cs:45-50`): existing file path → read file; otherwise
+treat the literal string as JSON. `batch-update` / `batch-get` instead
+use `--input <file>` (file only) + `--stdin`.
+
+### Decision: match the batch-* shape, drop inline JSON
+
+- `--input <file>` becomes **file-path-only** (read via
+  `CommandHelper.ReadJsonInput`, which reads the file when it exists).
+- Add `--stdin` to read the body from stdin.
+- Exactly one of `--input` / `--stdin` required.
+- Inline `--input '{json}'` **stops working** — the breaking change the
+  roadmap calls for.
+
+New surface:
+```
+items update --id <id> (--input <file>|--stdin)
+```
+
+The action body adopts the exact `batch-update` input block:
+```csharp
+string jsonBody;
+if (stdin) jsonBody = await Console.In.ReadToEndAsync(cancellationToken);
+else if (input != null) jsonBody = CommandHelper.ReadJsonInput(input);
+else { _logger.Error("Provide --input <file> or --stdin"); Environment.Exit(1); return 1; }
+```
+
+`--input` stays `Option<string?>` (no longer `Required = true`), and
+`--stdin` is `Option<bool>` — mirroring `batch-update`.
+
+### `ReadJsonInput` fate
+
+Leave `CommandHelper.ReadJsonInput` unchanged. Its file-existence check
+is harmless for the batch verbs (they pass file paths), and `items
+update` simply stops being routed through an inline-JSON expectation by
+requiring `--input` to name a file or using `--stdin`. No behavior change
+to the helper; only `items update`'s option wiring + the requirement
+that `--input` point at a file.
+
+### Impact: smoke test rewrite
+
+`docker/smoke-test.sh` uses inline `items update --input '{...}'` at
+lines 207, 215, 221-222, 232-233, 247-248. These convert to `--stdin`
+(echo-piped). The file-based call at line 238 (`--input "$TMPFILE"`)
+stays valid. The plan must include this rewrite or the smoke breaks.
+
+### `--help` text constraint
+
+- `items update`: "Reads the update body from a JSON file (`--input
+  <file>`) or stdin (`--stdin`). Inline JSON strings are no longer
+  accepted — pipe via `--stdin` instead."
+
+---
+
+## Components
+
+### Modified: `src/AbsCli/Api/ApiEndpoints.cs`
+
+```csharp
+public const string ItemsBatchDelete = "api/items/batch/delete";
+```
+
+(`Item(id)` already exists for the single-delete URL.)
+
+### Modified: `src/AbsCli/Services/ItemsService.cs`
+
+```csharp
+public async Task DeleteAsync(string id, bool hard)
+{
+    var url = ApiEndpoints.Item(id);
+    if (hard) url += "?hard=1";
+    await _client.DeleteAsync(url, "'delete' permission");
+}
+
+public async Task BatchDeleteAsync(string jsonBody, bool hard)
+{
+    var url = ApiEndpoints.ItemsBatchDelete;
+    if (hard) url += "?hard=1";
+    await _client.PostAsync(url, jsonBody, "'delete' permission");
+}
+```
+
+Both use the existing string-returning `DeleteAsync` / `PostAsync`
+overloads (`AbsApiClient.cs:110`, `:93`) and discard the empty-200 body.
+
+### Modified: `src/AbsCli/Commands/ItemsCommand.cs`
+
+- Add `CreateDeleteCommand()` (factory, `--id` + `--hard`), register
+  under `items`.
+- Add `CreateBatchDeleteCommand()` (factory, `--input`/`--stdin` +
+  `--hard`), register under `items`.
+- Modify `CreateUpdateCommand()`: `--input` becomes `Option<string?>`
+  (drop `Required = true`), add `--stdin` `Option<bool>`, adopt the
+  batch-update input block, update examples + add the breaking-change
+  `--help` note.
+
+### Modified: `src/AbsCli/Commands/LoginCommand.cs`
+
+- Add `--username` (`Option<string?>`), `--password` (`Option<string?>`),
+  `--password-stdin` (`Option<bool>`).
+- Resolution: flag → stdin (password only) → prompt, per the rules
+  above. Extract the prompt fallbacks but keep `ReadPassword` for the
+  interactive case.
+- Add validation (both-password-modes, empty-stdin) and the `--help`
+  notes.
+
+### Not modified
+
+- `AbsApiClient` — all needed overloads exist (`DeleteAsync`,
+  `PostAsync`, `LoginAsync`). No new HTTP plumbing.
+- No new models — delete/batch-delete return synthesized
+  `{"success":"true"}`; login reuses `LoginResponse`.
+- `CommandHelper.ReadJsonInput` — unchanged.
+
+## AOT considerations
+
+No new DTOs, no new `[JsonSerializable]` registrations. `batch-delete`
+forwards a raw JSON string (caller-supplied `{"libraryItemIds":[...]}`)
+verbatim — same passthrough pattern as `batch-update`. `items delete` /
+`login` carry no JSON body the CLI constructs.
+
+## Output formats
+
+| Verb | Output |
+|---|---|
+| `items delete` | `{"success":"true"}` on 200 |
+| `items batch-delete` | `{"success":"true"}` on 200 |
+| `login` | unchanged — stderr status lines (`Logged in as …`) |
+| `items update` | unchanged — `UpdateMediaResponse` JSON |
+
+## Error handling
+
+Standard model. New/notable:
+
+| Failure | Exit | stderr |
+|---|---|---|
+| delete/batch-delete 403 (no `delete` perm) | 2 | `Permission denied. This operation requires 'delete' permission.` |
+| delete 404 (item not found) | 2 | `Not found. <server message>` |
+| batch-delete 403 (no access to some item) | 2 | `Permission denied. …` |
+| batch-delete 404 (no ids resolve) | 2 | `Not found. <server message>` |
+| batch-delete 400 (bad body) | 2 | `Bad request. <server message>` |
+| malformed `--input`/`--stdin` JSON (batch-delete, update) | depends | server-side 400 surfaced (raw passthrough; no client parse) |
+| both `--input` + `--stdin` | 1 | `Provide --input <file> or --stdin` (batch verbs follow existing batch-update wording) |
+| login both password modes | 1 | `Provide --password or --password-stdin, not both.` |
+| login empty `--password-stdin` | 1 | `No password on stdin.` |
+
+Note: `batch-update`'s existing handling silently prefers stdin if both
+`--input` and `--stdin` are passed (it checks `if (stdin)` first). For
+the new `batch-delete` and `items update`, follow that SAME existing
+idiom for consistency (stdin wins; no explicit both-error) — do NOT
+introduce the stricter both-error here, to stay uniform with the
+sibling batch verbs. (The login both-password check is separate and
+warranted since those are two ways to supply one secret.)
+
+## Testing
+
+### Unit tests (`tests/AbsCli.Tests`)
+
+- `ItemsCommandTests` (extend or new `ItemsDeleteCommandTests.cs`):
+  - `items delete` help-shape (`--id`, `--hard`, soft/hard caveat).
+  - `items batch-delete` help-shape (`--input`/`--stdin`, `--hard`,
+    batch-wide + all-or-nothing caveat).
+  - `items update` help-shape: `--stdin` present, inline-JSON note,
+    `--input` no longer required.
+- `LoginCommandTests.cs`:
+  - help-shape (`--username`, `--password`, `--password-stdin`, the
+    `--password` exposure caveat).
+  - The `--password-stdin` line-handling helper, if extracted to a
+    testable internal method (e.g. `LoginCommand.ReadPasswordFromStdin`
+    that takes a `TextReader` and returns the trimmed first line) —
+    test `<<<` newline, `\r\n`, empty, multi-line-takes-first.
+- `ItemsServiceTests` (if a service test file exists): URL composition
+  for `DeleteAsync(id, hard)` (`?hard=1` appended only when hard) and
+  `BatchDeleteAsync`.
+
+### Smoke test additions (`docker/smoke-test.sh`)
+
+1. **Rewrite** the existing inline `items update --input '{...}'` calls
+   (lines 207, 215, 221-222, 232-233, 247-248) to `--stdin` (echo-piped).
+   Keep the `$TMPFILE` file-based call (line 238) as-is — it validates
+   the `--input <file>` path.
+2. **New `=== Item Delete ===` section** (place after the existing items
+   block, before series): upload a throwaway item, `items delete --id
+   <id>` (soft), confirm it's gone via `items get` → 404. Then upload
+   two more, `items batch-delete --stdin` with their ids, confirm both
+   gone. Use `--hard` on at least one to exercise the query param (the
+   uploaded fixtures are disposable). Mirror the `encode_cleanup` trap
+   pattern so a mid-flow abort doesn't leak fixtures.
+3. **`login` non-interactive**: add a check that `abs-cli login --server
+   <url> --username readonlyuser --password-stdin <<<"readonlypass"`
+   exits 0 and prints `Logged in as readonlyuser`. No config isolation
+   needed — the smoke's exported `ABS_TOKEN` takes precedence over the
+   config file `login` writes (see precedence note below), so the rest
+   of the smoke is unaffected.
+
+Permission-denial: `items delete` as `readonlyuser` (no `delete`) →
+expect 403 `'delete' permission`. All non-root seeded users
+(`testuser` / `uploaduser` / `readonlyuser`) have `delete: false`
+(`seed.sh:66,87,110`); `readonlyuser` is the clean choice and already
+has a `READONLY_TOKEN` in scope from the existing permission-errors
+section.
+
+The `login` smoke needs no config isolation: `BuildClient` precedence
+is flag → env → file (`ConfigManager.cs:53-62`), and the smoke exports
+`ABS_TOKEN`, which wins over whatever `login` writes to the config file.
+So running `abs-cli login --username … --password-stdin` exercises the
+non-interactive path and writes config, while the rest of the smoke
+keeps using the env-var token untouched. Just assert the login command
+exits 0 and prints the `Logged in as …` line.
+
+### Self-test additions
+
+None required — no new models. (Optional: none.)
+
+## Roadmap update
+
+The three v0.6.0 bullets already link this research doc (committed to
+main). At release, the whole v0.6.0 milestone moves to "Completed".
+
+## Out of scope
+
+- Dry-run / preview for delete (no ABS endpoint; use `items get` first).
+- Undo / trash recovery (ABS has none; soft delete relies on rescan).
+- Token-paste login (`config set` already writes tokens directly).
+- Narrowing `ReadJsonInput` to file-only (left as-is; other callers are
+  unaffected).
+
+## Open questions
+
+None outstanding. Resolved during review:
+- Delete-denial smoke uses `readonlyuser` (all non-root seeded users
+  lack `delete`; readonlyuser already has a token in scope).
+- `login` smoke needs no config isolation — env-var `ABS_TOKEN` beats
+  the config file `login` writes (flag → env → file precedence).

--- a/docs/specs/2026-05-30-v0.6.0-delete-login-update-stdin.md
+++ b/docs/specs/2026-05-30-v0.6.0-delete-login-update-stdin.md
@@ -342,38 +342,78 @@ warranted since those are two ways to supply one secret.)
 
 ### Smoke test additions (`docker/smoke-test.sh`)
 
-1. **Rewrite** the existing inline `items update --input '{...}'` calls
-   (lines 207, 215, 221-222, 232-233, 247-248) to `--stdin` (echo-piped).
-   Keep the `$TMPFILE` file-based call (line 238) as-is — it validates
-   the `--input <file>` path.
-2. **New `=== Item Delete ===` section** (place after the existing items
-   block, before series): upload a throwaway item, `items delete --id
-   <id>` (soft), confirm it's gone via `items get` → 404. Then upload
-   two more, `items batch-delete --stdin` with their ids, confirm both
-   gone. Use `--hard` on at least one to exercise the query param (the
-   uploaded fixtures are disposable). Mirror the `encode_cleanup` trap
-   pattern so a mid-flow abort doesn't leak fixtures.
-3. **`login` non-interactive**: add a check that `abs-cli login --server
-   <url> --username readonlyuser --password-stdin <<<"readonlypass"`
-   exits 0 and prints `Logged in as readonlyuser`. No config isolation
-   needed — the smoke's exported `ABS_TOKEN` takes precedence over the
-   config file `login` writes (see precedence note below), so the rest
-   of the smoke is unaffected.
+This feature also **de-curls the smoke's authentication** — all four
+`X-Return-Tokens` curl logins (`smoke-test.sh:68, 557, 717, 752`) and
+the `ABS_TOKEN` env export are removed, and every auth point becomes a
+real `abs-cli login`. This dogfoods the new non-interactive login and
+leaves the smoke with zero curl token plumbing. It is the largest part
+of this PR's smoke work — it touches ~10 permission-denial sections — so
+it is called out explicitly here.
 
-Permission-denial: `items delete` as `readonlyuser` (no `delete`) →
-expect 403 `'delete' permission`. All non-root seeded users
-(`testuser` / `uploaduser` / `readonlyuser`) have `delete: false`
-(`seed.sh:66,87,110`); `readonlyuser` is the clean choice and already
-has a `READONLY_TOKEN` in scope from the existing permission-errors
-section.
+**Auth model after the change:** with `ABS_TOKEN` unset, `BuildClient`
+precedence (flag → env → file, `ConfigManager.cs:53-62`) makes the
+**config file** the auth baseline. "Act as user X" = log in as X (writes
+config); "restore" = log in as root again.
 
-The `login` smoke needs no config isolation: `BuildClient` precedence
-is flag → env → file (`ConfigManager.cs:53-62`), and the smoke exports
-`ABS_TOKEN`, which wins over whatever `login` writes to the config file.
-So running `abs-cli login --username … --password-stdin` exercises the
-non-interactive path and writes config, while the rest of the smoke
-keeps using the env-var token untouched. Just assert the login command
-exits 0 and prints the `Logged in as …` line.
+**A. Login helper + setup rewrite.** Add near the top of the smoke:
+
+```bash
+abs_login() {
+    # $1 username, $2 password — non-interactive login, writes config.
+    abs-cli login --server "$ABS_URL" --username "$1" --password-stdin <<<"$2" >/dev/null 2>&1
+}
+```
+
+Replace the setup block (`smoke-test.sh:66-84`):
+- `abs_login root root` instead of the root curl + `ABS_TOKEN` export.
+  Assert it exits 0 (this IS the login-feature coverage — no separate
+  bolted-on check needed).
+- `LIB_ID` from `abs-cli libraries list` (parse first id) instead of the
+  `/api/libraries` curl.
+- Keep `export ABS_SERVER` / `ABS_LIBRARY` (not secrets, not under test;
+  used by commands that take an explicit library). Drop
+  `export ABS_TOKEN`.
+
+**B. Permission-denial sections.** Convert each of the ~10 env-swap sites
+(`smoke-test.sh:561, 590, 659, 702, 722, 756, 1003, 1410, 1447, 1641,
+1754, 1930` and their `SAVE_TOKEN`/restore partners) from:
+```bash
+SAVE_TOKEN="$ABS_TOKEN"; export ABS_TOKEN="$UPLOAD_TOKEN"
+# … denial check …
+export ABS_TOKEN="$SAVE_TOKEN"
+```
+to:
+```bash
+abs_login uploaduser uploadpass
+# … denial check …
+abs_login root root
+```
+The `if [ -n "${UPLOAD_TOKEN:-}" ]` guards become unconditional (the
+seeded users always exist). Seeded creds: `uploaduser/uploadpass`,
+`readonlyuser/readonlypass`, `testuser/testpass` (`seed.sh:268`).
+
+**C. Inline `items update` rewrite.** Convert the inline
+`items update --input '{...}'` calls (`smoke-test.sh:207, 215,
+221-222, 232-233, 247-248`) to `--stdin` (echo-piped). Keep the
+`$TMPFILE` file-based call (line 238) — it validates `--input <file>`.
+
+**D. New `=== Item Delete ===` section** (after the items block, before
+series): upload a throwaway item, `items delete --id <id>` (soft),
+confirm gone via `items get` → 404. Upload two more, `items batch-delete
+--stdin` with their ids (one run with `--hard`), confirm both gone.
+Mirror the `encode_cleanup` trap pattern so a mid-flow abort doesn't
+leak fixtures.
+
+**E. Delete permission-denial.** `items delete` as `readonlyuser` (no
+`delete`) → expect 403 `'delete' permission`, using the helper:
+`abs_login readonlyuser readonlypass; <delete attempt>; abs_login root
+root`. All non-root seeded users have `delete: false`
+(`seed.sh:66,87,110`).
+
+Sequencing note: the re-login-as-root after each denial adds an HTTP
+round trip per section — negligible for a smoke, and the determinism is
+worth it. Confirm the smoke runs under `bash` (here-strings `<<<`
+require it; CLAUDE.md invokes it as `bash docker/smoke-test.sh`).
 
 ### Self-test additions
 
@@ -396,6 +436,8 @@ main). At release, the whole v0.6.0 milestone moves to "Completed".
 
 None outstanding. Resolved during review:
 - Delete-denial smoke uses `readonlyuser` (all non-root seeded users
-  lack `delete`; readonlyuser already has a token in scope).
-- `login` smoke needs no config isolation — env-var `ABS_TOKEN` beats
-  the config file `login` writes (flag → env → file precedence).
+  lack `delete`).
+- Smoke auth is fully de-curled: the new `login` command replaces all
+  four `X-Return-Tokens` curls, and config-file auth (env `ABS_TOKEN`
+  removed) drives the baseline while per-user logins handle
+  impersonation. See Testing → Smoke (A–E).

--- a/docs/specs/2026-05-30-v0.6.0-delete-login-update-stdin.md
+++ b/docs/specs/2026-05-30-v0.6.0-delete-login-update-stdin.md
@@ -415,6 +415,40 @@ round trip per section — negligible for a smoke, and the determinism is
 worth it. Confirm the smoke runs under `bash` (here-strings `<<<`
 require it; CLAUDE.md invokes it as `bash docker/smoke-test.sh`).
 
+**F. Convert curl fixture-deletes to `abs-cli items delete`.** The smoke
+currently cleans up throwaway upload fixtures with ~9 raw
+`curl -X DELETE "$ABS_URL/api/items/$ID?hard=1"` calls — inline in the
+upload section (`smoke-test.sh:579, 605, 678, 700`) and in the
+`encode_cleanup` / `chapters_cleanup` / `embed_cleanup` traps (`:1209,
+1213, 1434, 1623, 1627`). Replace each with:
+```bash
+abs-cli items delete --id "$ID" --hard >/dev/null 2>&1 || true
+```
+This completes the de-curl — after A–F the smoke uses no curl for item
+operations (only `/api/upload` fixture *creation* remains curl, which is
+out of scope; there's no throwaway-upload CLI path the smoke uses).
+
+**Root-context wrinkle (important):** the curl deletes carry their own
+root token, so they always have `delete` permission. The CLI deletes
+inherit *ambient* auth (the config file's current user). A cleanup trap
+fires on EXIT — if a permission-denial section left `readonlyuser`
+logged in when the script exits, a CLI cleanup-delete would 403 and
+silently fail (`|| true`), leaking the fixture. Mitigation: each cleanup
+helper re-establishes root first:
+```bash
+encode_cleanup() {
+    abs_login root root            # ensure delete permission regardless of ambient login
+    [ -n "${ENCODE_ITEM_ID:-}" ] && abs-cli items delete --id "$ENCODE_ITEM_ID" --hard >/dev/null 2>&1 || true
+    ...
+}
+```
+Inline deletes within a section (e.g. the upload block at 579/605) run
+while root is still the active login, so they don't need the guard —
+but adding `abs_login root root` to the trap-based cleanups is
+mandatory. The denial sections already restore root via `abs_login root
+root` (part B), so in the normal path root is active at exit anyway;
+the guard covers the abort-mid-denial case.
+
 ### Self-test additions
 
 None required — no new models. (Optional: none.)
@@ -437,7 +471,9 @@ main). At release, the whole v0.6.0 milestone moves to "Completed".
 None outstanding. Resolved during review:
 - Delete-denial smoke uses `readonlyuser` (all non-root seeded users
   lack `delete`).
-- Smoke auth is fully de-curled: the new `login` command replaces all
-  four `X-Return-Tokens` curls, and config-file auth (env `ABS_TOKEN`
-  removed) drives the baseline while per-user logins handle
-  impersonation. See Testing → Smoke (A–E).
+- Smoke is fully de-curled for both auth and item-deletes: the new
+  `login` command replaces all four `X-Return-Tokens` curls (config-file
+  auth drives the baseline, per-user logins handle impersonation), and
+  `items delete --hard` replaces all ~9 curl fixture-cleanup deletes.
+  Cleanup traps `abs_login root root` first so they always have delete
+  permission. See Testing → Smoke (A–F).

--- a/src/AbsCli/Api/ApiEndpoints.cs
+++ b/src/AbsCli/Api/ApiEndpoints.cs
@@ -19,6 +19,7 @@ public static class ApiEndpoints
     public static string ItemEbookFileStatus(string id, string fileIno) => $"api/items/{id}/ebook/{fileIno}/status";
     public const string ItemsBatchUpdate = "api/items/batch/update";
     public const string ItemsBatchGet = "api/items/batch/get";
+    public const string ItemsBatchDelete = "api/items/batch/delete";
 
     public static string SeriesById(string id) => $"api/series/{id}";
     public static string AuthorById(string id) => $"api/authors/{id}";

--- a/src/AbsCli/Commands/ItemsCommand.cs
+++ b/src/AbsCli/Commands/ItemsCommand.cs
@@ -140,20 +140,33 @@ public static class ItemsCommand
     private static Command CreateUpdateCommand()
     {
         var idOption = new Option<string>("--id") { Description = "Item ID", Required = true };
-        var inputOption = new Option<string>("--input") { Description = "JSON input (string or file path)", Required = true };
-        var command = new Command("update", "Update a single item's metadata") { idOption, inputOption };
+        var inputOption = new Option<string?>("--input") { Description = "JSON file with the update body" };
+        var stdinOption = new Option<bool>("--stdin") { Description = "Read the update body from stdin" };
+        var command = new Command("update", "Update a single item's metadata") { idOption, inputOption, stdinOption };
         command.AddPermissionRequired("update");
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "Reads the update body from a JSON file (--input <file>) or stdin",
+            "(--stdin). Inline JSON strings are no longer accepted — pipe via",
+            "--stdin instead.");
         command.AddExamples(
-            "abs-cli items update --id \"li_abc123\" --input '{\"metadata\":{\"title\":\"New Title\"}}'",
             "abs-cli items update --id \"li_abc123\" --input payload.json",
-            "abs-cli items update --id \"li_abc123\" --input '{\"metadata\":{\"genres\":[\"Fantasy\",\"Epic\"]}}'");
+            "echo '{\"metadata\":{\"title\":\"New Title\"}}' | abs-cli items update --id \"li_abc123\" --stdin");
         command.AddResponseExample<UpdateMediaResponse>();
         command.AddMediaUnionShapes();
         command.SetAction(async (parseResult, cancellationToken) =>
         {
             var id = parseResult.GetValue(idOption)!;
-            var input = parseResult.GetValue(inputOption)!;
-            var jsonBody = CommandHelper.ReadJsonInput(input);
+            var input = parseResult.GetValue(inputOption);
+            var stdin = parseResult.GetValue(stdinOption);
+            string jsonBody;
+            if (stdin) jsonBody = await Console.In.ReadToEndAsync(cancellationToken);
+            else if (input != null) jsonBody = CommandHelper.ReadJsonInput(input);
+            else
+            {
+                _logger.Error("Provide --input <file> or --stdin");
+                Environment.Exit(1);
+                return 1;
+            }
             var (client, _) = CommandHelper.BuildClient();
             var service = new ItemsService(client);
             var result = await service.UpdateMediaAsync(id, jsonBody);

--- a/src/AbsCli/Commands/ItemsCommand.cs
+++ b/src/AbsCli/Commands/ItemsCommand.cs
@@ -19,6 +19,8 @@ public static class ItemsCommand
         command.Subcommands.Add(CreateBatchUpdateCommand());
         command.Subcommands.Add(CreateBatchUpdateProgressCommand());
         command.Subcommands.Add(CreateBatchGetCommand());
+        command.Subcommands.Add(CreateDeleteCommand());
+        command.Subcommands.Add(CreateBatchDeleteCommand());
         command.Subcommands.Add(CreateScanCommand());
         command.Subcommands.Add(CreateCoverCommand());
         command.Subcommands.Add(CreateEncodeM4bCommand());
@@ -220,6 +222,76 @@ public static class ItemsCommand
             var service = new ItemsService(client);
             var result = await service.BatchGetAsync(jsonBody);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.BatchGetResponse);
+            return 0;
+        });
+        return command;
+    }
+
+    private static Command CreateDeleteCommand()
+    {
+        var idOption = new Option<string>("--id") { Description = "Item ID", Required = true };
+        var hardOption = new Option<bool>("--hard") { Description = "Also delete files from disk (default: DB-only soft delete)" };
+        var command = new Command("delete", "Delete a library item") { idOption, hardOption };
+        command.AddPermissionRequired("delete");
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "Soft delete (default) removes the item from ABS's database only —",
+            "files stay on disk and a rescan re-imports it. --hard also deletes",
+            "the files from disk (irreversible). Either way, authors and series",
+            "left empty by the deletion are pruned.");
+        command.AddExamples(
+            "abs-cli items delete --id \"li_abc123\"",
+            "abs-cli items delete --id \"li_abc123\" --hard");
+        command.AddHelpSection("Response shape", HelpSectionPosition.Bottom,
+            "{ \"success\": \"true\" }");
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var id = parseResult.GetValue(idOption)!;
+            var hard = parseResult.GetValue(hardOption);
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new ItemsService(client);
+            await service.DeleteAsync(id, hard);
+            ConsoleOutput.WriteJson(new Dictionary<string, string> { ["success"] = "true" });
+            return 0;
+        });
+        return command;
+    }
+
+    private static Command CreateBatchDeleteCommand()
+    {
+        var inputOption = new Option<string?>("--input") { Description = "JSON file with {\"libraryItemIds\":[...]}" };
+        var stdinOption = new Option<bool>("--stdin") { Description = "Read JSON from stdin" };
+        var hardOption = new Option<bool>("--hard") { Description = "Also delete files from disk (applies to every id in the batch)" };
+        var command = new Command("batch-delete", "Delete multiple library items")
+            { inputOption, stdinOption, hardOption };
+        command.AddPermissionRequired("delete");
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "--hard applies to every id in the batch (server has no per-item",
+            "granularity). All-or-nothing on access: if you lack access to any",
+            "item in the batch, the whole request is refused. Soft vs hard",
+            "semantics identical to `items delete`.");
+        command.AddExamples(
+            "abs-cli items batch-delete --input ids.json",
+            "echo '{\"libraryItemIds\":[\"li_a\",\"li_b\"]}' | abs-cli items batch-delete --stdin --hard");
+        command.AddHelpSection("Response shape", HelpSectionPosition.Bottom,
+            "{ \"success\": \"true\" }");
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var input = parseResult.GetValue(inputOption);
+            var stdin = parseResult.GetValue(stdinOption);
+            var hard = parseResult.GetValue(hardOption);
+            string jsonBody;
+            if (stdin) jsonBody = await Console.In.ReadToEndAsync(cancellationToken);
+            else if (input != null) jsonBody = CommandHelper.ReadJsonInput(input);
+            else
+            {
+                _logger.Error("Provide --input <file> or --stdin");
+                Environment.Exit(1);
+                return 1;
+            }
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new ItemsService(client);
+            await service.BatchDeleteAsync(jsonBody, hard);
+            ConsoleOutput.WriteJson(new Dictionary<string, string> { ["success"] = "true" });
             return 0;
         });
         return command;

--- a/src/AbsCli/Commands/ItemsCommand.cs
+++ b/src/AbsCli/Commands/ItemsCommand.cs
@@ -159,8 +159,20 @@ public static class ItemsCommand
             var input = parseResult.GetValue(inputOption);
             var stdin = parseResult.GetValue(stdinOption);
             string jsonBody;
-            if (stdin) jsonBody = await Console.In.ReadToEndAsync(cancellationToken);
-            else if (input != null) jsonBody = CommandHelper.ReadJsonInput(input);
+            if (stdin)
+            {
+                jsonBody = await Console.In.ReadToEndAsync(cancellationToken);
+            }
+            else if (input != null)
+            {
+                if (!File.Exists(input))
+                {
+                    _logger.Error($"--input must be a file path (got '{input}'). For inline JSON, pipe via --stdin.");
+                    Environment.Exit(1);
+                    return 1;
+                }
+                jsonBody = CommandHelper.ReadJsonInput(input);
+            }
             else
             {
                 _logger.Error("Provide --input <file> or --stdin");

--- a/src/AbsCli/Commands/ItemsCommand.cs
+++ b/src/AbsCli/Commands/ItemsCommand.cs
@@ -279,7 +279,7 @@ public static class ItemsCommand
         command.AddPermissionRequired("delete");
         command.AddHelpSection("Notes", HelpSectionPosition.Top,
             "--hard applies to every id in the batch (server has no per-item",
-            "granularity). All-or-nothing on access: if you lack access to any",
+            "granularity). Access is all-or-nothing: if you lack access to any",
             "item in the batch, the whole request is refused. Soft vs hard",
             "semantics identical to `items delete`.");
         command.AddExamples(

--- a/src/AbsCli/Commands/LoginCommand.cs
+++ b/src/AbsCli/Commands/LoginCommand.cs
@@ -13,13 +13,22 @@ public static class LoginCommand
         {
             Description = "Audiobookshelf server URL"
         };
+        var usernameOption = new Option<string?>("--username") { Description = "Username (prompts if omitted)" };
+        var passwordOption = new Option<string?>("--password") { Description = "Password — visible in process list / shell history; prefer --password-stdin" };
+        var passwordStdinOption = new Option<bool>("--password-stdin") { Description = "Read the password from the first line of stdin" };
         var command = new Command("login", "Authenticate with an Audiobookshelf server")
         {
-            serverOption
+            serverOption, usernameOption, passwordOption, passwordStdinOption
         };
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "--password is visible in the process list and shell history. Prefer",
+            "--password-stdin (reads the first line of stdin) for scripted use.",
+            "Any credential not supplied via flag is prompted for interactively",
+            "(username plain, password hidden).");
         command.AddExamples(
             "abs-cli login --server https://abs.example.com",
-            "abs-cli login");
+            "abs-cli login --server https://abs.example.com --username agent --password-stdin <<<\"$ABS_PW\"",
+            "abs-cli login --server https://abs.example.com --username agent --password \"$ABS_PW\"");
         command.SetAction(async (parseResult, cancellationToken) =>
         {
             var server = parseResult.GetValue(serverOption);
@@ -34,10 +43,39 @@ public static class LoginCommand
                 _logger.Error("Server URL is required.");
                 Environment.Exit(1);
             }
-            Console.Error.Write("Username: ");
-            var username = Console.ReadLine()?.Trim();
-            Console.Error.Write("Password: ");
-            var password = ReadPassword();
+            var usernameFlag = parseResult.GetValue(usernameOption);
+            var passwordFlag = parseResult.GetValue(passwordOption);
+            var passwordStdin = parseResult.GetValue(passwordStdinOption);
+            if (passwordFlag != null && passwordStdin)
+            {
+                _logger.Error("Provide --password or --password-stdin, not both.");
+                Environment.Exit(1);
+            }
+            var username = usernameFlag;
+            if (string.IsNullOrEmpty(username))
+            {
+                Console.Error.Write("Username: ");
+                username = Console.ReadLine()?.Trim();
+            }
+            string? password;
+            if (passwordFlag != null)
+            {
+                password = passwordFlag;
+            }
+            else if (passwordStdin)
+            {
+                password = ReadPasswordFromStdin(Console.In);
+                if (string.IsNullOrEmpty(password))
+                {
+                    _logger.Error("No password on stdin.");
+                    Environment.Exit(1);
+                }
+            }
+            else
+            {
+                Console.Error.Write("Password: ");
+                password = ReadPassword();
+            }
             if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
             {
                 _logger.Error("Username and password are required.");
@@ -76,6 +114,17 @@ public static class LoginCommand
             return 0;
         });
         return command;
+    }
+
+    /// <summary>
+    /// Read a password from stdin: the first line, stripped of a single
+    /// trailing CRLF/LF. Returns "" if stdin is empty. A password with an
+    /// embedded newline is not supportable via this path.
+    /// </summary>
+    internal static string ReadPasswordFromStdin(TextReader reader)
+    {
+        var line = reader.ReadLine();
+        return line ?? "";
     }
 
     private static string ReadPassword()

--- a/src/AbsCli/Services/ItemsService.cs
+++ b/src/AbsCli/Services/ItemsService.cs
@@ -75,6 +75,20 @@ public class ItemsService
         return await _client.PostAsync(ApiEndpoints.ItemsBatchGet, jsonBody, AppJsonContext.Default.BatchGetResponse);
     }
 
+    public async Task DeleteAsync(string id, bool hard)
+    {
+        var url = ApiEndpoints.Item(id);
+        if (hard) url += "?hard=1";
+        await _client.DeleteAsync(url, "'delete' permission");
+    }
+
+    public async Task BatchDeleteAsync(string jsonBody, bool hard)
+    {
+        var url = ApiEndpoints.ItemsBatchDelete;
+        if (hard) url += "?hard=1";
+        await _client.PostAsync(url, jsonBody, "'delete' permission");
+    }
+
     public async Task<ScanResult> ScanAsync(string id)
     {
         return await _client.PostEmptyAsync(ApiEndpoints.ItemScan(id),

--- a/tests/AbsCli.Tests/Commands/ItemsDeleteCommandTests.cs
+++ b/tests/AbsCli.Tests/Commands/ItemsDeleteCommandTests.cs
@@ -1,0 +1,58 @@
+using System.CommandLine;
+using AbsCli.Commands;
+using Xunit;
+
+namespace AbsCli.Tests.Commands;
+
+public class ItemsDeleteCommandTests
+{
+    private static string RenderHelp(params string[] path)
+    {
+        var root = new RootCommand();
+        root.Subcommands.Add(ItemsCommand.Create());
+        root.UseCustomHelpSections();
+        var output = new StringWriter();
+        var config = new InvocationConfiguration { Output = output };
+        var args = path.Concat(new[] { "--help" }).ToArray();
+        root.Parse(args).Invoke(config);
+        return output.ToString();
+    }
+
+    [Fact]
+    public void Items_HasDeleteAndBatchDelete()
+    {
+        var verbs = ItemsCommand.Create().Subcommands.Select(c => c.Name).ToList();
+        Assert.Contains("delete", verbs);
+        Assert.Contains("batch-delete", verbs);
+    }
+
+    [Fact]
+    public void ItemsDelete_Help_DocumentsIdHardAndSoftDefault()
+    {
+        var output = RenderHelp("items", "delete");
+        Assert.Contains("--id", output);
+        Assert.Contains("--hard", output);
+        Assert.Contains("database only", output);
+        Assert.Contains("irreversible", output);
+    }
+
+    [Fact]
+    public void ItemsBatchDelete_Help_DocumentsInputStdinHardAndCaveats()
+    {
+        var output = RenderHelp("items", "batch-delete");
+        Assert.Contains("--input", output);
+        Assert.Contains("--stdin", output);
+        Assert.Contains("--hard", output);
+        Assert.Contains("every id in the batch", output);
+        Assert.Contains("all-or-nothing", output);
+    }
+
+    [Fact]
+    public void ItemsUpdate_Help_DocumentsStdinAndDropsInlineJson()
+    {
+        var output = RenderHelp("items", "update");
+        Assert.Contains("--input", output);
+        Assert.Contains("--stdin", output);
+        Assert.Contains("Inline JSON", output);
+    }
+}

--- a/tests/AbsCli.Tests/Commands/LoginCommandTests.cs
+++ b/tests/AbsCli.Tests/Commands/LoginCommandTests.cs
@@ -1,0 +1,42 @@
+using AbsCli.Commands;
+using Xunit;
+
+namespace AbsCli.Tests.Commands;
+
+public class LoginCommandTests
+{
+    [Fact]
+    public void ReadPasswordFromStdin_TakesFirstLine_StripsTrailingNewline()
+    {
+        using var reader = new StringReader("hunter2\n");
+        Assert.Equal("hunter2", LoginCommand.ReadPasswordFromStdin(reader));
+    }
+
+    [Fact]
+    public void ReadPasswordFromStdin_HandlesCrLf()
+    {
+        using var reader = new StringReader("hunter2\r\n");
+        Assert.Equal("hunter2", LoginCommand.ReadPasswordFromStdin(reader));
+    }
+
+    [Fact]
+    public void ReadPasswordFromStdin_NoTrailingNewline()
+    {
+        using var reader = new StringReader("hunter2");
+        Assert.Equal("hunter2", LoginCommand.ReadPasswordFromStdin(reader));
+    }
+
+    [Fact]
+    public void ReadPasswordFromStdin_TakesOnlyFirstLine()
+    {
+        using var reader = new StringReader("hunter2\nignored\n");
+        Assert.Equal("hunter2", LoginCommand.ReadPasswordFromStdin(reader));
+    }
+
+    [Fact]
+    public void ReadPasswordFromStdin_EmptyReturnsEmpty()
+    {
+        using var reader = new StringReader("");
+        Assert.Equal("", LoginCommand.ReadPasswordFromStdin(reader));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `items delete --id <id> [--hard]` and `items batch-delete {--input|--stdin} [--hard]` (soft = DB-only, `--hard` = also removes files; `delete` permission; author/series cascade-prune).
- `login` gains `--username` / `--password` / `--password-stdin`, each falling back to the interactive prompt. `--password-stdin` avoids process-list/history exposure.
- `items update` switched to `--input <file>` / `--stdin` (breaking — inline JSON strings no longer accepted; non-file `--input` is rejected), matching the batch-* shape.
- De-curls the smoke test: all auth now goes through `abs-cli login` and all fixture cleanup through `abs-cli items delete`. The smoke contains **zero curl** afterward.

## Notable
- The de-curled smoke logs in ~34 times; ABS rate-limits `/login` (40/10min), so the dev + CI ABS stacks set `RATE_LIMIT_AUTH_MAX=0`.
- Fixed a latent `items update` gap: the file-only `--input` was documented but not enforced — now rejected with a clear message steering to `--stdin`.

## Test plan
- [x] unit tests pass (`dotnet test` — 260 passed)
- [x] self-test passes (`abs-cli self-test` — 68 passed)
- [x] `dotnet format AbsCli.sln --verify-no-changes` clean
- [x] smoke test green against local dev stack (`docker/smoke-test.sh` — 253 passed, 0 failed; zero curl; new `=== Item Delete ===` section + de-curled auth/cleanup)
- [x] delete permission-denial verified as `readonlyuser`

## Spec
- Research: `docs/specs/research/2026-05-30-delete-login-update-stdin.md`
- Spec: `docs/specs/2026-05-30-v0.6.0-delete-login-update-stdin.md`
- Plan: `docs/plans/2026-05-30-v0.6.0-delete-login-update-stdin.md`