### PR TITLE
test: smoke-test tidying (json_get, cleanup_items, assert funnel)

### DIFF
--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -279,8 +279,8 @@ assert_json_expr "batch-get returns 2 items" "len(d.get('libraryItems',[]))==2" 
 BATCH_PAYLOAD="[{\"id\":\"$FIRST_ITEM_ID\",\"mediaPayload\":{\"metadata\":{\"publisher\":\"Smoke Batch Press A\"}}},{\"id\":\"$SECOND_ITEM_ID\",\"mediaPayload\":{\"metadata\":{\"publisher\":\"Smoke Batch Press B\"}}}]"
 output=$(echo "$BATCH_PAYLOAD" | $CLI items batch-update --stdin 2>&1)
 rc=$?
-if [ $rc -eq 0 ] && echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d.get('success') is True" 2>/dev/null; then
-    pass "batch-update returns success"
+if [ $rc -eq 0 ]; then
+    assert_json_expr "batch-update returns success" "d.get('success') is True" "$output"
 else
     fail "batch-update returns success" "rc=$rc output: ${output:0:200}"
 fi
@@ -627,13 +627,8 @@ abs_login uploaduser uploadpass
 output=$($CLI upload --title "Smoke Test Upload" --author "Test Author" \
     --folder "$FOLDER_ID" --wait --files "$UPLOAD_TMP/test.mp3" 2>/dev/null)
 UPLOADED_ITEM_ID=""
-if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'id' in d" 2>/dev/null; then
-    pass "upload --wait returned item JSON"
-    UPLOADED_ITEM_ID=$(json_get "$output" "['id']")
-else
-    fail "upload --wait returned item JSON" "no id in response"
-    echo "    response: ${output:0:200}"
-fi
+assert_json_expr "upload --wait returned item JSON" "'id' in d" "$output"
+UPLOADED_ITEM_ID=$(json_get "$output" "['id']")
 
 abs_login root root
 
@@ -1087,11 +1082,7 @@ assert_json_expr "metadata providers has google" \
 if [ "${SMOKE_TEST_EXTERNAL:-}" = "1" ]; then
     echo "  (external provider tests enabled)"
     output=$($CLI metadata search --provider google --title "Storm Front" --author "Jim Butcher" 2>/dev/null)
-    if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert len(d)>0" 2>/dev/null; then
-        pass "metadata search returns results"
-    else
-        fail "metadata search returns results" "empty or invalid response"
-    fi
+    assert_json_expr "metadata search returns results" "len(d)>0" "$output"
     output=$($CLI metadata covers --provider google --title "Storm Front" 2>/dev/null)
     assert_json_key "metadata covers has results" "results" "$output"
 else
@@ -1120,31 +1111,16 @@ with open('$COVER_FILE', 'wb') as f:
 
 # --- Mode 1: --file (multipart upload) ---
 output=$($CLI items cover set --id "$FIRST_ITEM_ID" --file "$COVER_FILE" 2>/dev/null)
-if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success']==True and d['cover']" 2>/dev/null; then
-    pass "items cover set --file applied cover"
-    SERVER_COVER_PATH=$(json_get "$output" "['cover']")
-else
-    fail "items cover set --file applied cover" "unexpected response"
-    echo "    response: ${output:0:200}"
-    SERVER_COVER_PATH=""
-fi
+assert_json_expr "items cover set --file applied cover" "d['success']==True and d['cover']" "$output"
+SERVER_COVER_PATH=$(json_get "$output" "['cover']")
 
 output=$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null)
-if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['media'].get('coverPath')" 2>/dev/null; then
-    pass "items get reports non-null coverPath after --file set"
-else
-    fail "items get reports non-null coverPath after --file set" "coverPath missing"
-fi
+assert_json_expr "items get reports non-null coverPath after --file set" "d['media'].get('coverPath')" "$output"
 
 # Download cover to file
 DOWNLOAD_FILE="$COVER_TMP/downloaded.bin"
 output=$($CLI items cover get --id "$FIRST_ITEM_ID" --output "$DOWNLOAD_FILE" 2>/dev/null)
-if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['path']=='$DOWNLOAD_FILE' and d['bytes']>0" 2>/dev/null; then
-    pass "items cover get --output writes file and reports descriptor"
-else
-    fail "items cover get --output writes file and reports descriptor" "unexpected descriptor"
-    echo "    response: ${output:0:200}"
-fi
+assert_json_expr "items cover get --output writes file and reports descriptor" "d['path']=='$DOWNLOAD_FILE' and d['bytes']>0" "$output"
 if [ -s "$DOWNLOAD_FILE" ]; then
     pass "downloaded cover file is non-empty"
 else
@@ -1161,36 +1137,19 @@ fi
 
 # Remove cover
 output=$($CLI items cover remove --id "$FIRST_ITEM_ID" 2>/dev/null)
-if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success']" 2>/dev/null; then
-    pass "items cover remove returns success"
-else
-    fail "items cover remove returns success" "unexpected response"
-fi
+assert_json_expr "items cover remove returns success" "d['success']" "$output"
 
 output=$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null)
-if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['media'].get('coverPath') is None" 2>/dev/null; then
-    pass "items get reports null coverPath after remove"
-else
-    fail "items get reports null coverPath after remove" "coverPath still set"
-fi
+assert_json_expr "items get reports null coverPath after remove" "d['media'].get('coverPath') is None" "$output"
 
 # --- Mode 2: --server-path (PATCH, link to existing on-disk file) ---
 # Re-link the cover file the previous --file step left on the ABS server's disk.
 if [ -n "$SERVER_COVER_PATH" ]; then
     output=$($CLI items cover set --id "$FIRST_ITEM_ID" --server-path "$SERVER_COVER_PATH" 2>/dev/null)
-    if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success']==True and d['cover']=='$SERVER_COVER_PATH'" 2>/dev/null; then
-        pass "items cover set --server-path applied cover from existing on-disk file"
-    else
-        fail "items cover set --server-path applied cover from existing on-disk file" "unexpected response"
-        echo "    response: ${output:0:200}"
-    fi
+    assert_json_expr "items cover set --server-path applied cover from existing on-disk file" "d['success']==True and d['cover']=='$SERVER_COVER_PATH'" "$output"
 
     output=$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null)
-    if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['media'].get('coverPath')=='$SERVER_COVER_PATH'" 2>/dev/null; then
-        pass "items get coverPath matches --server-path target"
-    else
-        fail "items get coverPath matches --server-path target" "coverPath did not match"
-    fi
+    assert_json_expr "items get coverPath matches --server-path target" "d['media'].get('coverPath')=='$SERVER_COVER_PATH'" "$output"
 
     # Cleanup: remove again so the next mode (or end-state) is clean
     $CLI items cover remove --id "$FIRST_ITEM_ID" > /dev/null 2>&1
@@ -1215,19 +1174,10 @@ if [ -n "$item_title" ]; then
         pass "metadata covers returned a URL for seeded book"
 
         output=$($CLI items cover set --id "$FIRST_ITEM_ID" --url "$cover_url" 2>/dev/null)
-        if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success']==True and d['cover']" 2>/dev/null; then
-            pass "items cover set --url applied cover from metadata-provider URL"
-        else
-            fail "items cover set --url applied cover from metadata-provider URL" "unexpected response"
-            echo "    response: ${output:0:200}"
-        fi
+        assert_json_expr "items cover set --url applied cover from metadata-provider URL" "d['success']==True and d['cover']" "$output"
 
         output=$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null)
-        if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['media'].get('coverPath')" 2>/dev/null; then
-            pass "items get reports non-null coverPath after --url set"
-        else
-            fail "items get reports non-null coverPath after --url set" "coverPath missing"
-        fi
+        assert_json_expr "items get reports non-null coverPath after --url set" "d['media'].get('coverPath')" "$output"
 
         $CLI items cover remove --id "$FIRST_ITEM_ID" > /dev/null 2>&1
     else
@@ -1275,11 +1225,7 @@ fi
 
 # Assert the freshly-uploaded item has two audio files.
 output=$($CLI items get --id "$ENCODE_ITEM_ID" 2>/dev/null)
-if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert len(d['media']['audioFiles'])==2" 2>/dev/null; then
-    pass "encode-m4b: item starts with 2 audioFiles"
-else
-    fail "encode-m4b: item starts with 2 audioFiles" "audioFiles count mismatch"
-fi
+assert_json_expr "encode-m4b: item starts with 2 audioFiles" "len(d['media']['audioFiles'])==2" "$output"
 
 # Run encode-m4b start --codec copy.
 output=$($CLI items encode-m4b start --id "$ENCODE_ITEM_ID" --codec copy 2>/dev/null)
@@ -1970,11 +1916,7 @@ fi
 
 # --log-json combined with ABS_DEBUG=1 emits parseable JSON with the three expected fields.
 json_first_line=$(ABS_DEBUG=1 $CLI --log-json libraries list 2>&1 >/dev/null | head -1)
-if echo "$json_first_line" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); assert 'timestamp' in d and 'level' in d and 'message' in d" 2>/dev/null; then
-    pass "ABS_DEBUG=1 --log-json libraries list emits JSON with timestamp/level/message"
-else
-    fail "ABS_DEBUG=1 --log-json libraries list emits JSON with timestamp/level/message" "got: $json_first_line"
-fi
+assert_json_expr "ABS_DEBUG=1 --log-json libraries list emits JSON with timestamp/level/message" "'timestamp' in d and 'level' in d and 'message' in d" "$json_first_line"
 
 # ============================================================
 echo ""

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -82,8 +82,7 @@ else
     exit 1
 fi
 
-LIB_ID=$($CLI libraries list 2>/dev/null \
-    | python3 -c "import sys,json; print(json.load(sys.stdin)['libraries'][0]['id'])")
+LIB_ID=$(json_get "$($CLI libraries list 2>/dev/null)" "['libraries'][0]['id']")
 
 echo "ABS_URL=$ABS_URL  LIB_ID=$LIB_ID"
 echo ""
@@ -206,15 +205,14 @@ assert_json_expr "items list pagination: 5 results" "len(d['results'])==5" "$out
 assert_json_expr "items list pagination: total still 16" "d['total']==16" "$output"
 
 # Get single item
-FIRST_ITEM_ID=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin)['results'][0]['id'])")
+FIRST_ITEM_ID=$(json_get "$output" "['results'][0]['id']")
 output=$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null)
 assert_json_key "items get has id" "id" "$output"
 assert_json_expr "items get correct id" "d['id']=='$FIRST_ITEM_ID'" "$output"
 assert_json_key "items get has media" "media" "$output"
 
 # Update metadata — change title, verify it sticks
-ORIGINAL_TITLE=$(echo "$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null)" \
-    | python3 -c "import sys,json; print(json.load(sys.stdin)['media']['metadata']['title'])")
+ORIGINAL_TITLE=$(json_get "$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null)" "['media']['metadata']['title']")
 output=$(echo '{"metadata":{"title":"Smoke Test Updated Title"}}' | $CLI items update --id "$FIRST_ITEM_ID" --stdin 2>/dev/null)
 assert_json_key "items update returns updated item" "libraryItem" "$output"
 
@@ -259,8 +257,7 @@ echo '{"metadata":{"publisher":null}}' \
     | $CLI items update --id "$FIRST_ITEM_ID" --stdin 2>/dev/null > /dev/null
 
 # Batch get — fetch two items by ID
-SECOND_ITEM_ID=$($CLI items list --limit 5 --page 0 2>/dev/null \
-    | python3 -c "import sys,json; print(json.load(sys.stdin)['results'][1]['id'])")
+SECOND_ITEM_ID=$(json_get "$($CLI items list --limit 5 --page 0 2>/dev/null)" "['results'][1]['id']")
 output=$(echo "{\"libraryItemIds\":[\"$FIRST_ITEM_ID\",\"$SECOND_ITEM_ID\"]}" \
     | $CLI items batch-get --stdin 2>/dev/null)
 assert_json_expr "batch-get returns 2 items" "len(d.get('libraryItems',[]))==2" "$output"
@@ -278,8 +275,8 @@ else
 fi
 
 # Verify both items actually got the new publisher.
-pub_a=$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['media']['metadata'].get('publisher'))")
-pub_b=$($CLI items get --id "$SECOND_ITEM_ID" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['media']['metadata'].get('publisher'))")
+pub_a=$(json_get "$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null)" "['media']['metadata'].get('publisher')")
+pub_b=$(json_get "$($CLI items get --id "$SECOND_ITEM_ID" 2>/dev/null)" "['media']['metadata'].get('publisher')")
 if [ "$pub_a" = "Smoke Batch Press A" ] && [ "$pub_b" = "Smoke Batch Press B" ]; then
     pass "batch-update persisted both items"
 else
@@ -296,8 +293,7 @@ echo "=== Item Delete ==="
 
 # Resolve FOLDER_ID locally — this section runs before the Upload
 # section (which sets the shared FOLDER_ID), so don't depend on it.
-DELETE_FOLDER_ID=$($CLI libraries get --id "$LIB_ID" 2>/dev/null \
-    | python3 -c "import sys,json; print(json.load(sys.stdin)['folders'][0]['id'])")
+DELETE_FOLDER_ID=$(json_get "$($CLI libraries get --id "$LIB_ID" 2>/dev/null)" "['folders'][0]['id']")
 DELETE_TMP=$(mktemp -d)
 python3 -c "
 header = bytes([0xFF, 0xFB, 0x90, 0x00]); frame = header + b'\x00' * 413
@@ -316,7 +312,7 @@ trap delete_cleanup EXIT
 
 # Single soft delete
 out=$($CLI upload --library "$LIB_ID" --folder "$DELETE_FOLDER_ID" --title "DELETE_SOFT" --author "Del Author" --wait --files "$DELETE_TMP/d.mp3" 2>/dev/null)
-DEL_ITEM_1=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+DEL_ITEM_1=$(json_get "$out" ".get('id','')")
 out=$($CLI items delete --id "$DEL_ITEM_1" 2>/dev/null)
 assert_json_expr "items delete returns success" "d['success']=='true'" "$out"
 out=$($CLI items get --id "$DEL_ITEM_1" 2>&1 || true)
@@ -325,9 +321,9 @@ DEL_ITEM_1=""
 
 # Batch hard delete (two items)
 out=$($CLI upload --library "$LIB_ID" --folder "$DELETE_FOLDER_ID" --title "DELETE_B1" --author "Del Author" --wait --files "$DELETE_TMP/d.mp3" 2>/dev/null)
-DEL_ITEM_2=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+DEL_ITEM_2=$(json_get "$out" ".get('id','')")
 out=$($CLI upload --library "$LIB_ID" --folder "$DELETE_FOLDER_ID" --title "DELETE_B2" --author "Del Author" --wait --files "$DELETE_TMP/d.mp3" 2>/dev/null)
-DEL_ITEM_3=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+DEL_ITEM_3=$(json_get "$out" ".get('id','')")
 out=$(echo "{\"libraryItemIds\":[\"$DEL_ITEM_2\",\"$DEL_ITEM_3\"]}" | $CLI items batch-delete --stdin --hard 2>/dev/null)
 assert_json_expr "items batch-delete returns success" "d['success']=='true'" "$out"
 out=$($CLI items get --id "$DEL_ITEM_2" 2>&1 || true)
@@ -338,7 +334,7 @@ DEL_ITEM_2=""; DEL_ITEM_3=""
 
 # Permission denial: readonlyuser lacks delete (part E)
 out=$($CLI upload --library "$LIB_ID" --folder "$DELETE_FOLDER_ID" --title "DELETE_DENY" --author "Del Author" --wait --files "$DELETE_TMP/d.mp3" 2>/dev/null)
-DEL_ITEM_1=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+DEL_ITEM_1=$(json_get "$out" ".get('id','')")
 abs_login readonlyuser readonlypass
 out=$($CLI items delete --id "$DEL_ITEM_1" 2>&1 || true)
 if echo "$out" | grep -qi "permission denied.*delete"; then pass "items delete: readonlyuser hits 'delete' permission denial"; else fail "items delete: readonlyuser hits 'delete' permission denial" "got: ${out:0:160}"; fi
@@ -360,7 +356,7 @@ assert_json_expr "series list has 3 series" "d['total']==3" "$output"
 assert_json_expr "series list returns results" "len(d['results'])==3" "$output"
 
 # Get a specific series
-FIRST_SERIES_ID=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin)['results'][0]['id'])")
+FIRST_SERIES_ID=$(json_get "$output" "['results'][0]['id']")
 output=$($CLI series get --id "$FIRST_SERIES_ID" 2>/dev/null)
 assert_json_key "series get has id" "id" "$output"
 assert_json_key "series get has name" "name" "$output"
@@ -403,7 +399,7 @@ fi
 
 # Reverse sort by name — first result should NOT be the alphabetically-first name
 output=$($CLI authors list --sort name --desc 2>/dev/null)
-FIRST_NAME=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin)['results'][0]['name'])")
+FIRST_NAME=$(json_get "$output" "['results'][0]['name']")
 ALPHA_FIRST=$(echo "$output" | python3 -c "import sys,json; print(sorted(a['name'] for a in json.load(sys.stdin)['results'])[0])")
 if [ "$FIRST_NAME" != "$ALPHA_FIRST" ]; then
     pass "authors list --sort name --desc starts with last name alphabetically"
@@ -568,7 +564,7 @@ output=$($CLI backup create 2>/dev/null)
 assert_json_key "backup create returns backups" "backups" "$output"
 assert_json_expr "backup create has at least 1 backup" "len(d['backups'])>=1" "$output"
 
-BACKUP_ID=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin)['backups'][-1]['id'])")
+BACKUP_ID=$(json_get "$output" "['backups'][-1]['id']")
 
 output=$($CLI backup list 2>/dev/null)
 assert_json_key "backup list has backups" "backups" "$output"
@@ -610,8 +606,7 @@ echo ""
 echo "=== Upload Command ==="
 # ============================================================
 
-FOLDER_ID=$(echo "$($CLI libraries get --id "$LIB_ID" 2>/dev/null)" \
-    | python3 -c "import sys,json; print(json.load(sys.stdin)['folders'][0]['id'])")
+FOLDER_ID=$(json_get "$($CLI libraries get --id "$LIB_ID" 2>/dev/null)" "['folders'][0]['id']")
 
 UPLOAD_TMP=$(mktemp -d)
 python3 -c "
@@ -629,7 +624,7 @@ output=$($CLI upload --title "Smoke Test Upload" --author "Test Author" \
 UPLOADED_ITEM_ID=""
 if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'id' in d" 2>/dev/null; then
     pass "upload --wait returned item JSON"
-    UPLOADED_ITEM_ID=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+    UPLOADED_ITEM_ID=$(json_get "$output" "['id']")
 else
     fail "upload --wait returned item JSON" "no id in response"
     echo "    response: ${output:0:200}"
@@ -660,10 +655,10 @@ run_drift_case() {
         return
     fi
     local actual
-    actual=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin)['relPath'].lstrip('/'))" 2>/dev/null || echo "PARSE_ERROR")
+    actual=$(json_get "$out" "['relPath'].lstrip('/')" || echo "PARSE_ERROR")
     if [ "$actual" = "$expected_relpath" ]; then
         pass "sanitize drift: $label"
-        local item_id=$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null)
+        local item_id=$(json_get "$out" "['id']")
         [ -n "$item_id" ] && $CLI items delete --id "$item_id" --hard >/dev/null 2>&1 || true
     else
         fail "sanitize drift: $label" "expected relPath '$expected_relpath', got '$actual'"
@@ -732,7 +727,7 @@ fi
 prefix_out=$($CLI upload --title "Collision Prefix" --author "Collide Author Prefix" \
     --folder "$FOLDER_ID" --prefix-source-dir --wait \
     --files "$COLLIDE_TMP"/Part1/*.mp3 "$COLLIDE_TMP"/Part2/*.mp3 2>/dev/null)
-PREFIX_ITEM=$(echo "$prefix_out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || echo "")
+PREFIX_ITEM=$(json_get "$prefix_out" ".get('id','')" || echo "")
 if [ -n "$PREFIX_ITEM" ]; then
     pass "upload --prefix-source-dir created item"
     abs_login root root
@@ -753,7 +748,7 @@ cat > "$COLLIDE_TMP/manifest.json" <<EOF
 EOF
 manifest_out=$($CLI upload --title "Collision Manifest" --author "Collide Author Manifest" \
     --folder "$FOLDER_ID" --files-manifest "$COLLIDE_TMP/manifest.json" --wait 2>/dev/null)
-MANIFEST_ITEM=$(echo "$manifest_out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || echo "")
+MANIFEST_ITEM=$(json_get "$manifest_out" ".get('id','')" || echo "")
 if [ -n "$MANIFEST_ITEM" ]; then
     pass "upload --files-manifest created item"
     abs_login root root
@@ -1122,7 +1117,7 @@ with open('$COVER_FILE', 'wb') as f:
 output=$($CLI items cover set --id "$FIRST_ITEM_ID" --file "$COVER_FILE" 2>/dev/null)
 if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success']==True and d['cover']" 2>/dev/null; then
     pass "items cover set --file applied cover"
-    SERVER_COVER_PATH=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin)['cover'])")
+    SERVER_COVER_PATH=$(json_get "$output" "['cover']")
 else
     fail "items cover set --file applied cover" "unexpected response"
     echo "    response: ${output:0:200}"
@@ -1270,7 +1265,7 @@ fi
 output=$($CLI upload --library "$LIB_ID" --folder "$FOLDER_ID" \
     --title "ENCODE_M4B_TEST" --author "Smoke Author" \
     --wait --files "$ENCODE_TMP/track1.mp3" "$ENCODE_TMP/track2.mp3" 2>/dev/null)
-ENCODE_ITEM_ID=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id', ''))" 2>/dev/null)
+ENCODE_ITEM_ID=$(json_get "$output" ".get('id', '')")
 if [ -n "$ENCODE_ITEM_ID" ]; then
     pass "encode-m4b: upload created a library item (id=$ENCODE_ITEM_ID)"
 else
@@ -1378,7 +1373,7 @@ fi
 output=$($CLI upload --library "$LIB_ID" --folder "$FOLDER_ID" \
     --title "ENCODE_M4B_CANCEL_TEST" --author "Smoke Author" \
     --wait --files "$ENCODE_TMP/track1.mp3" "$ENCODE_TMP/track2.mp3" 2>/dev/null)
-CANCEL_TEST_ITEM_ID=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id', ''))" 2>/dev/null)
+CANCEL_TEST_ITEM_ID=$(json_get "$output" ".get('id', '')")
 if [ -n "$CANCEL_TEST_ITEM_ID" ]; then
     pass "encode-m4b cancel: upload created cancel-test item (id=$CANCEL_TEST_ITEM_ID)"
 else
@@ -1481,7 +1476,7 @@ output=$($CLI upload --folder "$FOLDER_ID" \
     --title "CHAPTERS_TEST" --author "Smoke Author" \
     --wait --files "$CHAPTERS_TMP/test.mp3" 2>/dev/null)
 abs_login root root
-CHAPTERS_ITEM_ID=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id', ''))" 2>/dev/null)
+CHAPTERS_ITEM_ID=$(json_get "$output" ".get('id', '')")
 if [ -n "$CHAPTERS_ITEM_ID" ]; then
     pass "chapters: upload created test item (id=$CHAPTERS_ITEM_ID)"
 else
@@ -1669,12 +1664,12 @@ abs_login uploaduser uploadpass
 output=$($CLI upload --folder "$FOLDER_ID" \
     --title "EMBED_METADATA_TEST_1" --author "Smoke Author" \
     --wait --files "$EMBED_TMP/track1.mp3" 2>/dev/null)
-EMBED_ITEM_ID=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id', ''))" 2>/dev/null)
+EMBED_ITEM_ID=$(json_get "$output" ".get('id', '')")
 
 output=$($CLI upload --folder "$FOLDER_ID" \
     --title "EMBED_METADATA_TEST_2" --author "Smoke Author" \
     --wait --files "$EMBED_TMP/track2.mp3" 2>/dev/null)
-EMBED_ITEM_ID_2=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id', ''))" 2>/dev/null)
+EMBED_ITEM_ID_2=$(json_get "$output" ".get('id', '')")
 
 abs_login root root
 

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -68,6 +68,17 @@ json_get() {
     echo "$1" | python3 -c "import sys,json; print(json.load(sys.stdin)$2)" 2>/dev/null
 }
 
+cleanup_items() {
+    # $1 = tmp dir to remove (may be empty), remaining args = library item IDs to hard-delete
+    abs_login root root
+    local tmp="$1"; shift
+    local id
+    for id in "$@"; do
+        [ -n "$id" ] && $CLI items delete --id "$id" --hard >/dev/null 2>&1 || true
+    done
+    [ -n "$tmp" ] && rm -rf "$tmp"
+}
+
 abs_login() {
     # $1 username, $2 password — non-interactive CLI login (writes config).
     $CLI login --server "$ABS_URL" --username "$1" --password-stdin <<<"$2" >/dev/null 2>&1
@@ -301,13 +312,7 @@ with open('$DELETE_TMP/d.mp3', 'wb') as f:
     [f.write(frame) for _ in range(38)]
 "
 DEL_ITEM_1=""; DEL_ITEM_2=""; DEL_ITEM_3=""
-delete_cleanup() {
-    abs_login root root
-    for v in "$DEL_ITEM_1" "$DEL_ITEM_2" "$DEL_ITEM_3"; do
-        [ -n "$v" ] && $CLI items delete --id "$v" --hard >/dev/null 2>&1 || true
-    done
-    rm -rf "$DELETE_TMP"
-}
+delete_cleanup() { cleanup_items "${DELETE_TMP:-}" "${DEL_ITEM_1:-}" "${DEL_ITEM_2:-}" "${DEL_ITEM_3:-}"; }
 trap delete_cleanup EXIT
 
 # Single soft delete
@@ -1242,12 +1247,7 @@ echo "=== Encode M4B Commands ==="
 ENCODE_TMP=$(mktemp -d)
 ENCODE_ITEM_ID=""
 CANCEL_TEST_ITEM_ID=""
-encode_cleanup() {
-    abs_login root root
-    [ -n "${ENCODE_ITEM_ID:-}" ] && $CLI items delete --id "$ENCODE_ITEM_ID" --hard >/dev/null 2>&1 || true
-    [ -n "${CANCEL_TEST_ITEM_ID:-}" ] && $CLI items delete --id "$CANCEL_TEST_ITEM_ID" --hard >/dev/null 2>&1 || true
-    rm -rf "$ENCODE_TMP"
-}
+encode_cleanup() { cleanup_items "${ENCODE_TMP:-}" "${ENCODE_ITEM_ID:-}" "${CANCEL_TEST_ITEM_ID:-}"; }
 trap encode_cleanup EXIT
 
 ffmpeg -y -f lavfi -i "sine=frequency=440:duration=30" -ac 2 -c:a libmp3lame -b:a 128k \
@@ -1459,11 +1459,7 @@ echo "=== Chapter Commands ==="
 
 CHAPTERS_TMP=$(mktemp -d)
 CHAPTERS_ITEM_ID=""
-chapters_cleanup() {
-    abs_login root root
-    [ -n "${CHAPTERS_ITEM_ID:-}" ] && $CLI items delete --id "$CHAPTERS_ITEM_ID" --hard >/dev/null 2>&1 || true
-    rm -rf "$CHAPTERS_TMP"
-}
+chapters_cleanup() { cleanup_items "${CHAPTERS_TMP:-}" "${CHAPTERS_ITEM_ID:-}"; }
 trap chapters_cleanup EXIT
 
 # Use the real ffmpeg fixture pattern from the encode-m4b block to avoid
@@ -1645,12 +1641,7 @@ echo "=== Embed Metadata Commands ==="
 EMBED_TMP=$(mktemp -d)
 EMBED_ITEM_ID=""
 EMBED_ITEM_ID_2=""
-embed_cleanup() {
-    abs_login root root
-    [ -n "${EMBED_ITEM_ID:-}" ] && $CLI items delete --id "$EMBED_ITEM_ID" --hard >/dev/null 2>&1 || true
-    [ -n "${EMBED_ITEM_ID_2:-}" ] && $CLI items delete --id "$EMBED_ITEM_ID_2" --hard >/dev/null 2>&1 || true
-    rm -rf "$EMBED_TMP"
-}
+embed_cleanup() { cleanup_items "${EMBED_TMP:-}" "${EMBED_ITEM_ID:-}" "${EMBED_ITEM_ID_2:-}"; }
 trap embed_cleanup EXIT
 
 # Two real-audio fixtures via ffmpeg (matches encode-m4b smoke pattern).

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -63,6 +63,11 @@ assert $expr
     fi
 }
 
+json_get() {
+    # $1 = JSON string, $2 = python subscript chain (e.g. "['results'][0]['id']")
+    echo "$1" | python3 -c "import sys,json; print(json.load(sys.stdin)$2)" 2>/dev/null
+}
+
 abs_login() {
     # $1 username, $2 password — non-interactive CLI login (writes config).
     $CLI login --server "$ABS_URL" --username "$1" --password-stdin <<<"$2" >/dev/null 2>&1

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -860,7 +860,7 @@ assert_json_key "me has permissions" "permissions" "$output"
 # Pick a seeded library item to operate on (independent fetch — the
 # Collections block also does this but runs AFTER this one).
 progress_items_json=$($CLI items list --limit 1 2>/dev/null)
-PROGRESS_LID=$(echo "$progress_items_json" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('results',[{}])[0].get('id',''))" 2>/dev/null)
+PROGRESS_LID=$(json_get "$progress_items_json" ".get('results',[{}])[0].get('id','')")
 if [ -z "$PROGRESS_LID" ]; then
     fail "progress: seeded library item available" "no items"
 else
@@ -948,9 +948,9 @@ trap collections_cleanup EXIT
 
 # Grab three seeded book library item IDs for the smoke flow.
 items_json=$($CLI items list --limit 3 2>/dev/null)
-LID1=$(echo "$items_json" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('results',[{}])[0].get('id',''))" 2>/dev/null)
-LID2=$(echo "$items_json" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('results',[{},{}])[1].get('id',''))" 2>/dev/null)
-LID3=$(echo "$items_json" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('results',[{},{},{}])[2].get('id',''))" 2>/dev/null)
+LID1=$(json_get "$items_json" ".get('results',[{}])[0].get('id','')")
+LID2=$(json_get "$items_json" ".get('results',[{},{}])[1].get('id','')")
+LID3=$(json_get "$items_json" ".get('results',[{},{},{}])[2].get('id','')")
 if [ -z "$LID1" ] || [ -z "$LID2" ] || [ -z "$LID3" ]; then
     fail "collections: 3 library items available" "missing seeded items"
 else
@@ -965,7 +965,7 @@ assert_json_key "collections list has total" "total" "$output"
 # 2. create with two books (via --stdin)
 output=$(echo "{\"books\":[\"$LID1\",\"$LID2\"]}" \
     | $CLI collections create --name "smoke test" --stdin 2>/dev/null)
-COLLECTION_ID=$(echo "$output" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('id',''))" 2>/dev/null)
+COLLECTION_ID=$(json_get "$output" ".get('id','')")
 if [ -n "$COLLECTION_ID" ]; then
     pass "collections create returns an id"
 else
@@ -999,7 +999,7 @@ fi
 # 7. reorder (put LID3 first)
 output=$(echo "{\"books\":[\"$LID3\",\"$LID2\",\"$LID1\"]}" \
     | $CLI collections reorder --id "$COLLECTION_ID" --stdin 2>/dev/null)
-FIRST_ID=$(echo "$output" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('books',[{}])[0].get('id',''))" 2>/dev/null)
+FIRST_ID=$(json_get "$output" ".get('books',[{}])[0].get('id','')")
 if [ "$FIRST_ID" = "$LID3" ]; then
     pass "reorder put LID3 first"
 else
@@ -1199,8 +1199,8 @@ fi
 # to any single provider (e.g. Google returns no covers at all for some
 # seeded titles like "Rivers of London").
 item_json=$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null)
-item_title=$(echo "$item_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['media']['metadata'].get('title') or '')")
-item_author=$(echo "$item_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['media']['metadata'].get('authorName') or '')")
+item_title=$(json_get "$item_json" "['media']['metadata'].get('title') or ''")
+item_author=$(json_get "$item_json" "['media']['metadata'].get('authorName') or ''")
 
 if [ -n "$item_title" ]; then
     covers_json=$($CLI metadata covers --provider best --title "$item_title" --author "$item_author" 2>/dev/null)

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -64,7 +64,8 @@ assert $expr
 }
 
 json_get() {
-    # $1 = JSON string, $2 = python subscript chain (e.g. "['results'][0]['id']")
+    # $1 = JSON string, $2 = python expression appended to the parsed object
+    # e.g. "['results'][0]['id']", ".get('id','')", "['relPath'].lstrip('/')"
     echo "$1" | python3 -c "import sys,json; print(json.load(sys.stdin)$2)" 2>/dev/null
 }
 
@@ -628,7 +629,7 @@ output=$($CLI upload --title "Smoke Test Upload" --author "Test Author" \
     --folder "$FOLDER_ID" --wait --files "$UPLOAD_TMP/test.mp3" 2>/dev/null)
 UPLOADED_ITEM_ID=""
 assert_json_expr "upload --wait returned item JSON" "'id' in d" "$output"
-UPLOADED_ITEM_ID=$(json_get "$output" "['id']")
+UPLOADED_ITEM_ID=$(json_get "$output" "['id']" || echo "")
 
 abs_login root root
 
@@ -1112,7 +1113,7 @@ with open('$COVER_FILE', 'wb') as f:
 # --- Mode 1: --file (multipart upload) ---
 output=$($CLI items cover set --id "$FIRST_ITEM_ID" --file "$COVER_FILE" 2>/dev/null)
 assert_json_expr "items cover set --file applied cover" "d['success']==True and d['cover']" "$output"
-SERVER_COVER_PATH=$(json_get "$output" "['cover']")
+SERVER_COVER_PATH=$(json_get "$output" "['cover']" || echo "")
 
 output=$($CLI items get --id "$FIRST_ITEM_ID" 2>/dev/null)
 assert_json_expr "items get reports non-null coverPath after --file set" "d['media'].get('coverPath')" "$output"

--- a/docs/plans/2026-06-01-smoke-test-tidying.md
+++ b/docs/plans/2026-06-01-smoke-test-tidying.md
@@ -1,0 +1,306 @@
+# Smoke-test Tidying Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** DRY up `docker/smoke-test.sh` by collapsing ~68 inline JSON-extraction one-liners into a `json_get` helper, funneling ~14 stray inline assertions through the existing `assert_json_expr`, and parameterizing the 4 near-identical cleanup traps into one `cleanup_items` helper — with zero CLI or test-behavior change.
+
+**Architecture:** Pure bash refactor of a single ~2000-line test script. No new dependencies (stays on python3, jq rejected). Three independent helper consolidations. Because the harness has no unit tests, the acceptance gate is a full live-smoke run producing the **same PASS count** as the pre-change baseline; intermediate edits are gated by `bash -n` syntax checks.
+
+**Tech Stack:** Bash, python3 (extraction/assertion guts), the AOT `abs-cli` binary, docker-compose ABS dev stack.
+
+---
+
+## Baseline & Conventions
+
+- **Spec:** `docs/specs/2026-06-01-smoke-test-tidying-design.md`
+- **Target file:** `docker/smoke-test.sh` (only this file changes; `seed.sh` is out of scope).
+- **No behavior change:** same assertions, same PASS/FAIL count, same labels.
+- **Running the smoke** (per `CLAUDE.md`): resolve the container IP and run against it; seed first if the stack is fresh.
+  ```bash
+  cd docker && docker compose up -d
+  IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+  ABS_URL=http://$IP:80 bash docker/seed.sh          # only if freshly created
+  ABS_URL=http://$IP:80 bash docker/smoke-test.sh
+  ```
+- **Existing helpers (do not duplicate):** `pass`, `fail`, `assert_json_key` (line ~43), `assert_json_expr` (line ~53), `abs_login` (line ~66).
+
+---
+
+## File Structure
+
+- Modify: `docker/smoke-test.sh`
+  - Helper block near top (after `assert_json_expr`, ~line 64): add `json_get` and `cleanup_items`.
+  - ~68 extraction call sites scattered throughout: rewrite to `json_get`.
+  - ~14 inline-assert call sites: rewrite to `assert_json_expr`.
+  - 4 cleanup funcs (`delete_cleanup` ~303, `encode_cleanup` ~1245, `chapters_cleanup` ~1462, `embed_cleanup` ~1648): rewrite bodies to delegate to `cleanup_items`.
+
+---
+
+## Task 1: Capture baseline PASS count
+
+**Files:** none (records a reference number for later comparison).
+
+- [ ] **Step 1: Bring up the stack and run the current smoke unchanged**
+
+```bash
+cd /workspaces/abs-cli/docker && docker compose up -d
+IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+# Seed only if the stack was freshly created:
+ABS_URL=http://$IP:80 bash /workspaces/abs-cli/docker/seed.sh
+ABS_URL=http://$IP:80 bash /workspaces/abs-cli/docker/smoke-test.sh | tee /tmp/smoke-baseline.txt
+```
+
+- [ ] **Step 2: Record the baseline tallies**
+
+Run: `grep -E "PASS:|FAIL:" /tmp/smoke-baseline.txt | tail -1` (or read the summary line the script prints).
+Expected: a final summary like `PASS=N FAIL=0`. Note `N` — this is the number every later run must match. **If FAIL is not 0 on the unmodified script, stop and report; the baseline must be green before refactoring.**
+
+No commit (no file change).
+
+---
+
+## Task 2: Add the `json_get` helper
+
+**Files:**
+- Modify: `docker/smoke-test.sh` (insert after `assert_json_expr`, ~line 64)
+
+- [ ] **Step 1: Insert the helper**
+
+Add immediately after the closing `}` of `assert_json_expr`:
+
+```bash
+json_get() {
+    # $1 = JSON string, $2 = python subscript chain (e.g. "['results'][0]['id']")
+    echo "$1" | python3 -c "import sys,json; print(json.load(sys.stdin)$2)" 2>/dev/null
+}
+```
+
+- [ ] **Step 2: Self-verify the helper in isolation**
+
+Run:
+```bash
+source <(sed -n '/^json_get()/,/^}/p' /workspaces/abs-cli/docker/smoke-test.sh)
+json_get '{"results":[{"id":"abc"}]}' "['results'][0]['id']"
+json_get '{"media":{"metadata":{}}}' "['media']['metadata'].get('publisher')"
+```
+Expected: first prints `abc`; second prints `None` (matching the current inline behavior — `.get` of a missing key returns `None`, which is the existing semantics at e.g. line 276).
+
+- [ ] **Step 3: Syntax check**
+
+Run: `bash -n /workspaces/abs-cli/docker/smoke-test.sh`
+Expected: no output, exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker/smoke-test.sh
+git commit -m "test: add json_get helper for smoke JSON extraction"
+```
+
+---
+
+## Task 3: Convert extraction call sites to `json_get`
+
+**Files:**
+- Modify: `docker/smoke-test.sh` (all `print(json.load(sys.stdin)...)` extraction sites)
+
+Convert mechanically. Each site of the form:
+```bash
+VAR=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin)<CHAIN>)")
+```
+becomes:
+```bash
+VAR=$(json_get "$output" "<CHAIN>")
+```
+And piped forms `... | python3 -c "import sys,json; print(json.load(sys.stdin)<CHAIN>)"` where the input is a variable become `json_get "$var" "<CHAIN>"`. Preserve each chain **verbatim**, including `.get('id','')`, `.get('id', '')` (spacing differences are harmless), `.lstrip('/')`, etc.
+
+**Do NOT convert** multi-line python blocks that do real logic (sorting, joining, comprehensions, payload building) — e.g. lines ~375, 386, 391 (`','.join(sorted(...))`), and the payload builders (~445, 470, 477). Those stay as inline python.
+
+- [ ] **Step 1: List every candidate site**
+
+Run: `grep -n "print(json.load(sys.stdin)" /workspaces/abs-cli/docker/smoke-test.sh`
+Work top-to-bottom. For multi-line blocks (the line ends with `print(json.load(sys.stdin)` continuing onto further lines, or contains `join`/`sorted`/comprehension), skip and leave as-is.
+
+- [ ] **Step 2: Convert the single-line subscript sites**
+
+Edit each qualifying site to the `json_get` form above. Examples of the common shapes seen in this file:
+- `$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin)['results'][0]['id'])")` → `$(json_get "$output" "['results'][0]['id']")`
+- `$(echo "$out" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)` → `$(json_get "$out" ".get('id','')")`
+- `$(... | python3 -c "import sys,json; print(json.load(sys.stdin)['media']['metadata'].get('publisher'))")` → assign the piped input to a var or reuse the existing one, then `$(json_get "$thatvar" "['media']['metadata'].get('publisher')")`
+
+(The `2>/dev/null` is already inside `json_get`, so drop the trailing one when present.)
+
+- [ ] **Step 3: Verify no single-line subscript sites remain**
+
+Run: `grep -nE "python3 -c \"import sys,json; print\(json\.load\(sys\.stdin\)" /workspaces/abs-cli/docker/smoke-test.sh`
+Expected: zero matches (all single-line extractions now go through `json_get`). Any remaining hits must be the intentionally-skipped multi-line/logic blocks — eyeball each to confirm.
+
+- [ ] **Step 4: Syntax check**
+
+Run: `bash -n /workspaces/abs-cli/docker/smoke-test.sh`
+Expected: no output, exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/smoke-test.sh
+git commit -m "test: route smoke JSON extraction through json_get"
+```
+
+---
+
+## Task 4: Add `cleanup_items` and rewire the 4 traps
+
+**Files:**
+- Modify: `docker/smoke-test.sh` (add helper after `json_get`; rewrite `delete_cleanup` ~303, `encode_cleanup` ~1245, `chapters_cleanup` ~1462, `embed_cleanup` ~1648)
+
+- [ ] **Step 1: Insert the helper** (after `json_get`)
+
+```bash
+cleanup_items() {
+    # $1 = tmp dir to remove (may be empty), remaining args = library item IDs to hard-delete
+    abs_login root root
+    local tmp="$1"; shift
+    local id
+    for id in "$@"; do
+        [ -n "$id" ] && $CLI items delete --id "$id" --hard >/dev/null 2>&1 || true
+    done
+    [ -n "$tmp" ] && rm -rf "$tmp"
+}
+```
+
+- [ ] **Step 2: Rewrite `delete_cleanup`** (~line 303)
+
+Replace its body so it delegates (note: vars may be unset at definition time, so pass with `${VAR:-}`):
+```bash
+delete_cleanup() { cleanup_items "${DELETE_TMP:-}" "${DEL_ITEM_1:-}" "${DEL_ITEM_2:-}" "${DEL_ITEM_3:-}"; }
+trap delete_cleanup EXIT
+```
+
+- [ ] **Step 3: Rewrite `encode_cleanup`** (~line 1245)
+
+```bash
+encode_cleanup() { cleanup_items "${ENCODE_TMP:-}" "${ENCODE_ITEM_ID:-}" "${CANCEL_TEST_ITEM_ID:-}"; }
+trap encode_cleanup EXIT
+```
+
+- [ ] **Step 4: Rewrite `chapters_cleanup`** (~line 1462)
+
+```bash
+chapters_cleanup() { cleanup_items "${CHAPTERS_TMP:-}" "${CHAPTERS_ITEM_ID:-}"; }
+trap chapters_cleanup EXIT
+```
+
+- [ ] **Step 5: Rewrite `embed_cleanup`** (~line 1648)
+
+```bash
+embed_cleanup() { cleanup_items "${EMBED_TMP:-}" "${EMBED_ITEM_ID:-}" "${EMBED_ITEM_ID_2:-}"; }
+trap embed_cleanup EXIT
+```
+
+- [ ] **Step 6: Confirm `progress_cleanup` and `collections_cleanup` are untouched**
+
+Run: `grep -nA4 "progress_cleanup()\|collections_cleanup()" /workspaces/abs-cli/docker/smoke-test.sh`
+Expected: both still present with their original bodies (remove-progress / delete-collection). They are intentionally NOT converted.
+
+- [ ] **Step 7: Syntax check**
+
+Run: `bash -n /workspaces/abs-cli/docker/smoke-test.sh`
+Expected: no output, exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docker/smoke-test.sh
+git commit -m "test: collapse near-identical smoke cleanup traps into cleanup_items"
+```
+
+---
+
+## Task 5: Funnel stray inline assertions through `assert_json_expr`
+
+**Files:**
+- Modify: `docker/smoke-test.sh` (~14 sites: lines ~269, 625, 1085, 1118, 1128, 1137, 1159, 1166, 1176, 1184, 1213, 1221, 1278, 1982)
+
+`assert_json_expr "label" "<python-bool-expr>" "$json"` already exists and binds the parsed object to `d`. Convert inline `if echo "$json" | python3 -c "...; assert <EXPR>" 2>/dev/null; then pass ...; else fail ...; fi` blocks into a single `assert_json_expr` call, preserving the existing pass/fail label text exactly.
+
+- [ ] **Step 1: Convert the clean (JSON-only) sites**
+
+For sites whose `if` condition is *only* the python assert (e.g. lines 625, 1085, 1118, 1128, 1137, 1159, 1166, 1176, 1184, 1213, 1221, 1278, 1982), replace the whole if/pass/fail block with one call. Example — line ~1118:
+```bash
+if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success']==True and d['cover']" 2>/dev/null; then
+    pass "<label>"
+else
+    fail "<label>" "<msg>"
+fi
+```
+becomes:
+```bash
+assert_json_expr "<label>" "d['success']==True and d['cover']" "$output"
+```
+Keep the exact `<label>` string. (`assert_json_expr` already prints a generic failure detail + truncated response, matching the spirit of the old `fail` detail.) Use `d['key']` / `d.get('key')` forms unchanged — same Python the inline assert used.
+
+- [ ] **Step 2: Restructure the combined-condition sites**
+
+Three sites AND a non-JSON check with the assert in one `if`:
+- Line ~269: `if [ $rc -eq 0 ] && echo "$output" | python3 -c "...; assert d.get('success') is True" ...`
+- Line ~1685: `if [ "$exit_code" = "0" ] && echo "$output" | python3 -c "..." ...`
+- Any grep-combined site surfaced by the grep in Step 3.
+
+For these, split the bash check out and delegate the JSON half. Pattern:
+```bash
+if [ $rc -eq 0 ]; then
+    assert_json_expr "<label>" "d.get('success') is True" "$output"
+else
+    fail "<label>" "non-zero exit ($rc)"
+fi
+```
+Preserve the original label and the original non-JSON failure semantics.
+
+- [ ] **Step 3: Verify no inline `assert` python remains**
+
+Run: `grep -nE "python3 -c \"import sys,json; d=json.load\(sys.stdin\); assert" /workspaces/abs-cli/docker/smoke-test.sh`
+Expected: zero matches outside the `assert_json_key`/`assert_json_expr` helper definitions themselves (lines ~44/~54). Confirm any hit is the helper body, not a call site.
+
+- [ ] **Step 4: Syntax check**
+
+Run: `bash -n /workspaces/abs-cli/docker/smoke-test.sh`
+Expected: no output, exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/smoke-test.sh
+git commit -m "test: route stray inline smoke asserts through assert_json_expr"
+```
+
+---
+
+## Task 6: Full live-smoke verification (acceptance gate)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the refactored smoke against the dev stack**
+
+```bash
+IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+ABS_URL=http://$IP:80 bash /workspaces/abs-cli/docker/smoke-test.sh | tee /tmp/smoke-after.txt
+```
+
+- [ ] **Step 2: Compare tallies to baseline**
+
+Run: `grep -E "PASS=|FAIL=" /tmp/smoke-after.txt | tail -1`
+Expected: **same PASS count as `/tmp/smoke-baseline.txt` from Task 1, FAIL=0.** If PASS dropped or any FAIL appeared, a conversion changed behavior — diff the failing section against `git show HEAD~4:docker/smoke-test.sh` and fix before proceeding. Do not declare done until counts match.
+
+- [ ] **Step 3: Confirm clean tree**
+
+Run: `git status --short`
+Expected: clean (all changes already committed across Tasks 2–5).
+
+---
+
+## Self-Review (completed)
+
+- **Spec coverage:** json_get (Tasks 2–3) ✓; cleanup_items for the 4 traps, progress/collections left alone (Task 4) ✓; stray-assert funnel (Task 5) ✓; payload builders & multi-line logic explicitly excluded (Task 3 Step 1) ✓; same-PASS-count live verification (Tasks 1 & 6) ✓.
+- **Placeholders:** `<label>`/`<msg>`/`<CHAIN>`/`<EXPR>` are deliberate stand-ins for per-site text copied verbatim from the existing script, not unfilled TODOs.
+- **Consistency:** helper names `json_get` / `cleanup_items` and the existing `assert_json_expr` signature `(label, expr, json)` are used identically everywhere.

--- a/docs/specs/2026-06-01-smoke-test-tidying-design.md
+++ b/docs/specs/2026-06-01-smoke-test-tidying-design.md
@@ -1,0 +1,115 @@
+# Smoke-test tidying — design
+
+**Roadmap item:** 0.6.0 "Smoke-test tidying" (`docs/roadmap.md`).
+**Date:** 2026-06-01
+**Scope:** Pure test-harness DRY in `docker/smoke-test.sh`. No CLI behavior change, no
+new dependency, same PASS count before/after.
+
+## Background
+
+`docker/smoke-test.sh` (~2000 lines) contains 88 `python3 -c` invocations and 6
+per-section `*_cleanup()` EXIT traps. The repetition is the target — not the choice
+of python. jq was considered and **rejected**: both python3 and jq ship by default
+in the dev container and on `ubuntu-latest` (where the smoke runs in CI,
+`build.yml:62`), so jq adds no portability win, only churn. Staying with python keeps
+the diff small and avoids hand-translating ~40 assertion expressions.
+
+The 88 python calls break down as:
+
+| Category | Count | State today |
+|---|---|---|
+| Inside `assert_json_key` / `assert_json_expr` | 2 | already DRY |
+| Inline assertions that bypass those helpers | ~14 | inline `python3 -c "...; assert ..."` |
+| Extractions (`json_get` candidates) | ~68 | scattered one-liners |
+| Payload builders (construct request JSON) | ~4 | irreducible, out of scope |
+
+`seed.sh`'s 8 python calls are **out of scope**.
+
+## Changes
+
+### 1. `json_get` helper
+
+Replace the ~68 inline extraction one-liners with one helper near the existing
+`assert_*` helpers at the top of the file:
+
+```bash
+json_get() {  # $1 json, $2 python subscript chain
+    echo "$1" | python3 -c "import sys,json; print(json.load(sys.stdin)$2)" 2>/dev/null
+}
+```
+
+Call sites collapse from:
+
+```bash
+FIRST_ITEM_ID=$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin)['results'][0]['id'])")
+```
+
+to:
+
+```bash
+FIRST_ITEM_ID=$(json_get "$output" "['results'][0]['id']")
+```
+
+The path argument is a literal python subscript chain, so `.get(...)` forms and
+nested access still work unchanged:
+`json_get "$output" "['media']['metadata'].get('publisher')"`.
+
+Multi-line extraction blocks (e.g. lines 375, 386, 391) that compute a derived value
+(sorting, joining, comprehensions) are NOT plain subscripts — convert the simple ones
+to `json_get`; leave any that need real python logic as inline blocks.
+
+### 2. Funnel stray inline assertions into `assert_json_expr`
+
+The ~14 sites that inline `python3 -c "...; assert <expr>"` should call the existing
+`assert_json_expr "label" "<expr>" "$json"` helper instead.
+
+- Clean cases (e.g. lines 1118, 1128, 1278) become a single `assert_json_expr` call.
+- The ~3 cases that combine a JSON assert with a non-JSON check in one `if`
+  (line 269 `$rc -eq 0 && …`, line 1685 `$exit_code`, grep combos) get a small
+  restructure: do the non-JSON check in bash, the JSON part via `assert_json_expr`.
+
+End state: every JSON assertion flows through `assert_json_key` or `assert_json_expr`.
+
+### 3. `cleanup_items` helper
+
+Collapse the 4 near-identical traps (`delete_cleanup`, `encode_cleanup`,
+`chapters_cleanup`, `embed_cleanup`) — all of which do "login root → hard-delete N
+items → rm tmp dir":
+
+```bash
+cleanup_items() {  # $1 tmp dir (may be empty), rest = item IDs
+    abs_login root root
+    local tmp="$1"; shift
+    for id in "$@"; do
+        [ -n "$id" ] && $CLI items delete --id "$id" --hard >/dev/null 2>&1 || true
+    done
+    [ -n "$tmp" ] && rm -rf "$tmp"
+}
+```
+
+Each section keeps its own thin named trap that delegates, e.g.:
+
+```bash
+encode_cleanup() { cleanup_items "$ENCODE_TMP" "$ENCODE_ITEM_ID" "$CANCEL_TEST_ITEM_ID"; }
+trap encode_cleanup EXIT
+```
+
+Keeping a named per-section wrapper preserves readable `trap` lines and lets each
+section reference its own variables at trap-fire time.
+
+**Leave alone:** `progress_cleanup` (removes progress, no login/tmp/delete) and
+`collections_cleanup` (deletes a collection, no login/tmp) — genuinely different.
+
+## Out of scope
+
+- The ~4 payload-builder python blocks (lines 445, 470, 477) — they construct request
+  bodies, not extract values. Leave as-is.
+- `seed.sh` python calls.
+- Any jq migration.
+
+## Verification
+
+- `docker/smoke-test.sh` against the dev compose stack must stay all-green, with the
+  **same PASS count** before and after. This is the primary acceptance test — unit
+  tests do not exercise the harness.
+- Run per `CLAUDE.md` pre-PR instructions (container IP, seed if fresh).


### PR DESCRIPTION
## Summary

Pure test-harness DRY for `docker/smoke-test.sh` (0.6.0 roadmap "Smoke-test tidying"). No CLI or test-behavior change — same PASS count before and after.

- **`json_get` helper** — collapses ~32 inline JSON-extraction `python3 -c` one-liners (both `print(json.load(...))` and `d=json.load(...)` forms) into one helper.
- **`cleanup_items` helper** — parameterizes the 4 near-identical EXIT-trap cleanups (`delete`/`encode`/`chapters`/`embed`); `progress_cleanup`/`collections_cleanup` left as-is (genuinely different).
- **`assert_json_expr` funnel** — routes 14 single-line inline `assert` blocks through the existing helper. Multi-line multi-assert blocks left inline (they carry custom failure messages).
- Stayed on `python3` (jq rejected: no portability win, large churn). Guarded the two failure-tolerant extraction sites with `|| echo ""` so a parse failure doesn't abort under `set -euo pipefail`.

Design + plan: `docs/specs/2026-06-01-smoke-test-tidying-design.md`, `docs/plans/2026-06-01-smoke-test-tidying.md`.

## Test Plan

- [x] `bash -n docker/smoke-test.sh` clean
- [x] Unit tests: 260/260 pass
- [x] Live smoke against docker dev stack: **253 passed, 0 failed** — identical PASS count and labels to pre-refactor baseline