### PR TITLE
chore: bump ABS tested version to 2.35.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       audiobookshelf:
-        image: advplyr/audiobookshelf:2.35.0
+        image: advplyr/audiobookshelf:2.35.1
         # The smoke authenticates via `abs-cli login` at every section, which
         # exceeds ABS's default auth rate limit (40 logins / 10 min). Disable
         # it on this disposable CI instance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ test: add metadata update assertion to smoke tests
 - Expected location: `temp/audiobookshelf/` (gitignored). If missing, clone the currently supported version before referencing API code:
   ```bash
   # Supported version is set in src/AbsCli/Api/AbsApiClient.cs (MinSupportedVersion / MaxTestedVersion)
-  git clone --depth 1 --branch v2.35.0 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
+  git clone --depth 1 --branch v2.35.1 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
   ```
 - Replace the version tag with whatever `MaxTestedVersion` is currently set to.
 - Use this checkout to verify endpoints, controllers, request/response shapes, and permission checks before designing or changing CLI commands.

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ See [docs/](docs/) for architecture, authentication, build targets, and more.
 
 ## Compatibility
 
-Tested against Audiobookshelf **2.33.1 — 2.35.0**. The CLI warns on login if the server version is outside the tested range. See [docs/abs-compatibility.md](docs/abs-compatibility.md) for the full compatibility matrix and policy.
+Tested against Audiobookshelf **2.33.1 — 2.35.1**. The CLI warns on login if the server version is outside the tested range. See [docs/abs-compatibility.md](docs/abs-compatibility.md) for the full compatibility matrix and policy.
 
 ## License
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   audiobookshelf:
-    image: advplyr/audiobookshelf:2.35.0
+    image: advplyr/audiobookshelf:2.35.1
     ports:
       - "13378:80"
     volumes:

--- a/docs/abs-compatibility.md
+++ b/docs/abs-compatibility.md
@@ -9,7 +9,7 @@ the project README and checked at runtime.
 |----------------|--------------|-------|
 | 0.1.x — 0.2.4   | 2.33.1        | Initial release, baseline API |
 | 0.2.5 — 0.4.0   | 2.33.1 — 2.33.2 | No API surface changes in 2.33.2 (maintenance release; internal refactors, image-endpoint clamping, cross-library bulk-download guard) |
-| 0.5.0+          | 2.33.1 — 2.35.0 | v2.34 closes the upstream batch-update `canUpdate` gap (now returns 403 for users without update permission); v2.35 adds a 60s server-side refresh-token grace period (CLI behavior unchanged). DTO sweep confirmed no response-shape changes for endpoints abs-cli consumes. |
+| 0.5.0+          | 2.33.1 — 2.35.1 | v2.34 closes the upstream batch-update `canUpdate` gap (now returns 403 for users without update permission); v2.35 adds a 60s server-side refresh-token grace period (CLI behavior unchanged). v2.35.1 is a patch with internal-only fixes (BookAuthor dedup guard, case-insensitive user lookup) — no response-shape, endpoint, or permission changes for endpoints abs-cli consumes. DTO sweep confirmed no response-shape changes for endpoints abs-cli consumes. |
 
 This table grows as new ABS versions are tested. A single CLI version may support
 multiple ABS versions if the API surface hasn't changed.
@@ -19,7 +19,7 @@ multiple ABS versions if the API surface hasn't changed.
 On first API call, the CLI reads the ABS server version from the login response
 (`serverSettings.version`). If the version is outside the known-compatible range:
 
-- **Newer than tested:** Warning to stderr: `Warning: ABS server version 2.35.0 has not been tested with this version of abs-cli. Proceed with caution.`
+- **Newer than tested:** Warning to stderr: `Warning: ABS server version 2.36.0 has not been tested with this version of abs-cli. Proceed with caution.`
 - **Older than supported:** Warning to stderr: `Warning: ABS server version 2.30.0 is older than the minimum supported version (2.33.1). Some features may not work.`
 
 Warnings only — the CLI does not refuse to run. The user decides whether to proceed.

--- a/docs/abs-compatibility.md
+++ b/docs/abs-compatibility.md
@@ -19,7 +19,7 @@ multiple ABS versions if the API surface hasn't changed.
 On first API call, the CLI reads the ABS server version from the login response
 (`serverSettings.version`). If the version is outside the known-compatible range:
 
-- **Newer than tested:** Warning to stderr: `Warning: ABS server version 2.36.0 has not been tested with this version of abs-cli. Proceed with caution.`
+- **Newer than tested:** Warning to stderr — e.g. against a hypothetical future release above the tested ceiling: `Warning: ABS server version 2.36.0 has not been tested with this version of abs-cli. Proceed with caution.`
 - **Older than supported:** Warning to stderr: `Warning: ABS server version 2.30.0 is older than the minimum supported version (2.33.1). Some features may not work.`
 
 Warnings only — the CLI does not refuse to run. The user decides whether to proceed.

--- a/docs/plans/2026-06-02-abs-2.35.1-bump.md
+++ b/docs/plans/2026-06-02-abs-2.35.1-bump.md
@@ -1,0 +1,181 @@
+# ABS 2.35.1 Compatibility Bump Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the CLI's tested-version ceiling from ABS 2.35.0 to 2.35.1, with docs updated and live-smoke proof of compatibility.
+
+**Architecture:** Pure version-pin + docs change. The 2.35.0→2.35.1 server diff is internal-only (no API-contract change), so no CLI logic changes. Two tasks: (1) bump the three version pins + five doc references; (2) verify against a live 2.35.1 stack.
+
+**Tech Stack:** C# / .NET 10, docker-compose ABS dev stack, `docker/smoke-test.sh`.
+
+---
+
+## Baseline & conventions
+
+- **Spec:** `docs/specs/2026-06-02-abs-2.35.1-bump-design.md`
+- **Branch:** `chore/abs-2.35.1-bump` (already created).
+- The reference checkout `temp/audiobookshelf` is already at `v2.35.1`.
+- No unit test pins the version string (verified: `grep -rn "2.35.0\|MaxTested" tests/` is empty), so the bump breaks no tests.
+- Run `dotnet format AbsCli.sln` before committing (CI enforces `--verify-no-changes`).
+- Out of scope: CLI `<Version>` bump and CHANGELOG (release-owned); `MinSupportedVersion` stays `2.33.1`.
+
+## File structure
+
+- Modify: `src/AbsCli/Api/AbsApiClient.cs` — `MaxTestedVersion` constant.
+- Modify: `docker/docker-compose.yml`, `.github/workflows/build.yml` — ABS image tag.
+- Modify: `README.md`, `CLAUDE.md`, `docs/abs-compatibility.md` — docs.
+
+---
+
+## Task 1: Bump version pins and docs
+
+**Files:**
+- `src/AbsCli/Api/AbsApiClient.cs`
+- `docker/docker-compose.yml`
+- `.github/workflows/build.yml`
+- `README.md`
+- `CLAUDE.md`
+- `docs/abs-compatibility.md`
+
+- [ ] **Step 1: Bump `MaxTestedVersion`**
+
+In `src/AbsCli/Api/AbsApiClient.cs` (~line 236), change:
+```csharp
+    private static readonly string MaxTestedVersion = "2.35.0";
+```
+to:
+```csharp
+    private static readonly string MaxTestedVersion = "2.35.1";
+```
+(Leave `MinSupportedVersion = "2.33.1"` unchanged.)
+
+- [ ] **Step 2: Bump the docker-compose image**
+
+In `docker/docker-compose.yml` (~line 3), change:
+```yaml
+    image: advplyr/audiobookshelf:2.35.0
+```
+to:
+```yaml
+    image: advplyr/audiobookshelf:2.35.1
+```
+
+- [ ] **Step 3: Bump the CI smoke-test image**
+
+In `.github/workflows/build.yml` (~line 30), change:
+```yaml
+        image: advplyr/audiobookshelf:2.35.0
+```
+to:
+```yaml
+        image: advplyr/audiobookshelf:2.35.1
+```
+
+- [ ] **Step 4: Update the README tested range**
+
+In `README.md` (~line 331), change `2.33.1 — 2.35.0` to `2.33.1 — 2.35.1`. The full line becomes:
+```
+Tested against Audiobookshelf **2.33.1 — 2.35.1**. The CLI warns on login if the server version is outside the tested range. See [docs/abs-compatibility.md](docs/abs-compatibility.md) for the full compatibility matrix and policy.
+```
+
+- [ ] **Step 5: Update the CLAUDE.md clone instruction**
+
+In `CLAUDE.md` (~line 57), change:
+```
+  git clone --depth 1 --branch v2.35.0 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
+```
+to:
+```
+  git clone --depth 1 --branch v2.35.1 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
+```
+
+- [ ] **Step 6: Update the compatibility matrix**
+
+In `docs/abs-compatibility.md`, change the `0.5.0+` matrix row (~line 12) so its ABS range ends at `2.35.1` and the note records the patch. Replace:
+```
+| 0.5.0+          | 2.33.1 — 2.35.0 | v2.34 closes the upstream batch-update `canUpdate` gap (now returns 403 for users without update permission); v2.35 adds a 60s server-side refresh-token grace period (CLI behavior unchanged). DTO sweep confirmed no response-shape changes for endpoints abs-cli consumes. |
+```
+with:
+```
+| 0.5.0+          | 2.33.1 — 2.35.1 | v2.34 closes the upstream batch-update `canUpdate` gap (now returns 403 for users without update permission); v2.35 adds a 60s server-side refresh-token grace period (CLI behavior unchanged). v2.35.1 is a patch with internal-only fixes (BookAuthor dedup guard, case-insensitive user lookup) — no response-shape, endpoint, or permission changes for endpoints abs-cli consumes. DTO sweep confirmed no response-shape changes for endpoints abs-cli consumes. |
+```
+
+- [ ] **Step 7: Update the runtime-check warning example**
+
+In `docs/abs-compatibility.md` (~line 22), the illustrative "newer than tested" example currently names `2.35.0`, which is now within range. Change it to a version actually outside the range. Replace:
+```
+- **Newer than tested:** Warning to stderr: `Warning: ABS server version 2.35.0 has not been tested with this version of abs-cli. Proceed with caution.`
+```
+with:
+```
+- **Newer than tested:** Warning to stderr: `Warning: ABS server version 2.36.0 has not been tested with this version of abs-cli. Proceed with caution.`
+```
+
+- [ ] **Step 8: Format, build, test**
+
+Run:
+```bash
+dotnet format AbsCli.sln
+dotnet build AbsCli.sln --nologo
+dotnet test AbsCli.sln --nologo
+```
+Expected: build clean; all tests PASS (no test pins the version, so the count is unchanged from the 263 baseline on `main`).
+
+- [ ] **Step 9: Verify no stray `2.35.0` pins remain**
+
+Run:
+```bash
+grep -rn "2\.35\.0" --include="*.cs" --include="*.yml" --include="*.md" --include="*.sh" . | grep -v "temp/audiobookshelf/" | grep -v "docs/specs/\|docs/plans/\|CHANGELOG"
+```
+Expected: only the two intentional **historical** references remain — `CLAUDE.md` (the "PR #43 / 2.35.0 bump" retro note) and `docs/roadmap.md` (v0.5.0 milestone history). No version *pins* should remain. If anything else shows up, fix it.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/AbsCli/Api/AbsApiClient.cs docker/docker-compose.yml .github/workflows/build.yml README.md CLAUDE.md docs/abs-compatibility.md
+git commit -m "chore: bump ABS tested version to 2.35.1"
+```
+
+---
+
+## Task 2: Verify compatibility against a live 2.35.1 stack
+
+**Files:** none (verification only).
+
+This is the actual compatibility proof. The compose stack now pins `:2.35.1`, so a fresh stack runs the new image.
+
+- [ ] **Step 1: Recreate the stack on the 2.35.1 image and seed**
+
+```bash
+cd /workspaces/abs-cli/docker && docker compose down -v && docker compose up -d
+IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+for i in $(seq 1 60); do curl -sf http://$IP:80/healthcheck >/dev/null 2>&1 && break; sleep 1; done
+# Confirm the running image is 2.35.1:
+docker inspect docker-audiobookshelf-1 -f '{{.Config.Image}}'
+ABS_URL=http://$IP:80 bash /workspaces/abs-cli/docker/seed.sh
+```
+Expected: image prints `advplyr/audiobookshelf:2.35.1`; seed ends with `Items: 16`. (seed.sh's first scan-wait loop occasionally throws a transient `KeyError: 'total'` — if seeding fails, `docker compose down -v && up -d`, wait for health, and re-run seed.)
+
+- [ ] **Step 2: Run the full smoke against 2.35.1**
+
+```bash
+IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+ABS_URL=http://$IP:80 bash /workspaces/abs-cli/docker/smoke-test.sh | tee /tmp/smoke-2351.txt
+```
+Expected: `Results: 253 passed, 0 failed` (same as the 2.35.0 baseline). Any FAIL means a real 2.35.1 incompatibility — diagnose before declaring done; do NOT mark the smoke passed unless it actually did.
+
+- [ ] **Step 3: Confirm no version-warning regression**
+
+The smoke logs in against 2.35.1; with `MaxTestedVersion` now `2.35.1`, there must be no "has not been tested" warning. Verify:
+```bash
+grep -i "has not been tested" /tmp/smoke-2351.txt || echo "no untested-version warning (correct)"
+```
+Expected: prints the "correct" line (no warning present).
+
+---
+
+## Self-Review (completed)
+
+- **Spec coverage:** `MaxTestedVersion` bump (T1 S1) ✓; docker-compose image (T1 S2) ✓; CI image (T1 S3) ✓; README (T1 S4) ✓; CLAUDE.md clone (T1 S5) ✓; compatibility matrix + warning example (T1 S6–7) ✓; historical refs left alone (T1 S9 guard) ✓; unit + format + live-smoke verification (T1 S8, T2) ✓; out-of-scope items (version/CHANGELOG, MinSupportedVersion) explicitly excluded ✓.
+- **Placeholder scan:** none — every edit shows exact before/after.
+- **Consistency:** `2.35.1` used uniformly; `MinSupportedVersion` untouched everywhere; the smoke target (253 passed) matches the established baseline.

--- a/docs/specs/2026-06-02-abs-2.35.1-bump-design.md
+++ b/docs/specs/2026-06-02-abs-2.35.1-bump-design.md
@@ -1,0 +1,73 @@
+# ABS 2.35.1 compatibility bump — design
+
+**Date:** 2026-06-02
+**Scope:** Extend the tested-version ceiling from ABS 2.35.0 to 2.35.1. No CLI
+behavior change — verified low-risk patch. Work is version-pin bumps + docs + a
+live smoke run that proves compatibility.
+
+## Background
+
+Latest ABS release is **v2.35.1** (2026-05-28), a patch over the 2.35.0 the CLI
+already tests against. The full 2.35.0→2.35.1 server diff touches only two
+API-relevant files, both internal bug fixes with **no API-contract impact**:
+
+- `server/controllers/AuthorController.js` — adds `{ ignoreDuplicates: true }` to a
+  `bulkCreate` of `BookAuthor` rows during author match/update. Server-side
+  robustness; request/response shape, endpoint, and permission unchanged.
+- `server/models/User.js` — switches username/email lookup from SQL `LIKE` to
+  `lower(col) = lower(value)` (proper case-insensitive exact match). The login/`me`
+  API contract is identical.
+
+No endpoints, response shapes, or permission checks that abs-cli consumes changed.
+The reference checkout at `temp/audiobookshelf` has already been updated to v2.35.1.
+
+## Changes
+
+### Functional (3 version pins)
+
+- `src/AbsCli/Api/AbsApiClient.cs:236` — `MaxTestedVersion` `"2.35.0"` → `"2.35.1"`.
+  `MinSupportedVersion` stays `"2.33.1"` (no support dropped).
+- `docker/docker-compose.yml:3` — `image: advplyr/audiobookshelf:2.35.0` → `:2.35.1`.
+- `.github/workflows/build.yml:30` — smoke-test service image `:2.35.0` → `:2.35.1`.
+
+### Docs (3)
+
+- `README.md:331` — tested range `2.33.1 — 2.35.0` → `2.33.1 — 2.35.1`.
+- `CLAUDE.md:57` — reference-clone instruction `v2.35.0` → `v2.35.1`.
+- `docs/abs-compatibility.md`:
+  - Matrix (line 12): extend the `0.5.0+` row's ABS range to `2.35.1`, appending a
+    note: "v2.35.1 is a patch with internal-only fixes (BookAuthor dedup guard,
+    case-insensitive user lookup) — no response-shape, endpoint, or permission
+    changes for endpoints abs-cli consumes."
+  - Runtime-check example (line 22): the illustrative "newer than tested" warning
+    currently names `2.35.0`, which is now *within* range. Change the example
+    version to one actually outside the range (e.g. `2.36.0`) so it stays accurate.
+
+### Leave unchanged (historical references, not version pins)
+
+- `CLAUDE.md:36` — retro note about "the 2.35.0 bump" landing in PR #43.
+- `docs/roadmap.md:130` — v0.5.0 milestone history.
+
+## Out of scope (release-owned)
+
+- CLI version bump (`AbsCli.csproj` `<Version>`) and the CHANGELOG entry — those land
+  with the release workflow, not this branch.
+- `MinSupportedVersion` change — unchanged.
+
+## Verification
+
+- `dotnet test AbsCli.sln` — exercises the version-compare / range-warning logic in
+  `AbsApiClient`. A test may assert the tested-range string or `MaxTestedVersion`; if
+  so, update it to `2.35.1`.
+- `dotnet format AbsCli.sln --verify-no-changes` — CI style gate.
+- **`docker/smoke-test.sh` against a fresh 2.35.1 stack** — the definitive
+  compatibility proof (live HTTP paths). Per CLAUDE.md: bring up the compose stack on
+  the new image, resolve the container IP, seed, and run the smoke against it. Expect
+  the same all-green result as on 2.35.0.
+
+## Success criteria
+
+- `MaxTestedVersion` is `2.35.1`; logging into a 2.35.1 server emits **no**
+  "not been tested" warning.
+- Unit tests green; smoke test green against the 2.35.1 image.
+- Docs/matrix reflect the new ceiling.

--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -233,7 +233,7 @@ public class AbsApiClient
     }
 
     private static readonly string MinSupportedVersion = "2.33.1";
-    private static readonly string MaxTestedVersion = "2.35.0";
+    private static readonly string MaxTestedVersion = "2.35.1";
 
     private static readonly string AssemblyVersion =
         typeof(AbsApiClient).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";


### PR DESCRIPTION
## Summary

Extends the CLI's tested-version ceiling from ABS 2.35.0 to **2.35.1** (latest release). The 2.35.0→2.35.1 server diff is two internal bug fixes with no API-contract impact, so this is a tested-version bump + docs — no CLI logic change.

- `MaxTestedVersion` → `2.35.1` (`MinSupportedVersion` stays `2.33.1`).
- docker-compose + CI smoke-test ABS image → `2.35.1`.
- Docs: README tested range, CLAUDE.md reference-clone tag, `abs-compatibility.md` matrix (notes the patch's internal-only nature: BookAuthor dedup guard, case-insensitive user lookup) + warning example.
- Out of scope (release-owned): CLI `<Version>` bump and CHANGELOG.

## Test Plan

- [x] Unit tests: 263 pass (no test pins the version string)
- [x] `dotnet format --verify-no-changes` clean
- [x] **Live smoke against `audiobookshelf:2.35.1`: 253 passed, 0 failed** (identical to the 2.35.0 baseline); no "has not been tested" warning emitted