### PR TITLE
fix: resolve upload --wait false-negative on long titles (#54)

### DIFF
--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -695,6 +695,24 @@ run_drift_case "illegal char stripped" "Pipe|Title" "Sanitize Author Pipe" \
 run_drift_case "whitespace collapsed" "Extra   Spaces   Title" "Sanitize Author WS" \
     "Sanitize Author WS/Extra Spaces Title" "" ""
 
+# --- Long-title --wait (issue #54) ---
+# A title long enough that ABS truncates the path segment. We cannot predict
+# the exact truncated relPath, so assert --wait still resolves the item (the
+# per-segment matcher tolerates the tail divergence). Pre-fix this timed out.
+LONG_TITLE="Ich täuschte Amnesie vor um meinen Verlobten loszuwerden da behauptete er Vor deinem Gedächtnisverlust warst du in mich verliebt und das ist die ganze lange Geschichte"
+abs_login uploaduser uploadpass
+long_out=$($CLI upload --title "$LONG_TITLE" --author "Long Title Author" \
+    --folder "$FOLDER_ID" --wait --files "$UPLOAD_TMP/test.mp3" 2>&1)
+long_rc=$?
+abs_login root root
+if [ $long_rc -eq 0 ] && json_get "$long_out" "['id']" >/dev/null 2>&1; then
+    pass "long-title upload --wait resolves item (issue #54)"
+    long_id=$(json_get "$long_out" "['id']")
+    [ -n "$long_id" ] && $CLI items delete --id "$long_id" --hard >/dev/null 2>&1 || true
+else
+    fail "long-title upload --wait resolves item (issue #54)" "rc=$long_rc out=${long_out:0:300}"
+fi
+
 rm -rf "$UPLOAD_TMP"
 
 # Filename-collision tests: build a 2-dir source tree where both dirs have a file

--- a/docs/plans/2026-06-17-upload-wait-relpath-match.md
+++ b/docs/plans/2026-06-17-upload-wait-relpath-match.md
@@ -1,0 +1,502 @@
+# upload --wait per-segment relPath matching — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `upload --wait` confirm long-titled uploads by matching the library item with tolerant per-segment relPath prefix matching instead of exact equality.
+
+**Architecture:** Add a pure `RelPathMatcher` (per-segment prefix matching, unique-match selection). `UploadService.WaitForItemByPathAsync` uses it over the items it already polls. Delete the now-dead client-side truncation (`FilenameSanitizer.TruncateToByteLimit`). Reword the no-confident-match path so it no longer reads as data loss.
+
+**Tech Stack:** C# / .NET, xUnit, NLog. Reference: `docs/specs/2026-06-17-upload-wait-relpath-match-design.md`.
+
+---
+
+## File Structure
+
+- Create: `src/AbsCli/Api/RelPathMatcher.cs` — pure matching logic (per-segment prefix match + unique-match filter).
+- Create: `tests/AbsCli.Tests/Api/RelPathMatcherTests.cs` — unit tests for the matcher.
+- Modify: `src/AbsCli/Services/UploadService.cs` — `WaitForItemByPathAsync` uses the matcher; ambiguous ⇒ stop, no guess.
+- Modify: `src/AbsCli/Api/FilenameSanitizer.cs` — delete `TruncateToByteLimit` + `MaxFilenameBytes`; update class doc.
+- Modify: `tests/AbsCli.Tests/Api/FilenameSanitizerTests.cs` — remove the truncation test.
+- Modify: `src/AbsCli/Commands/UploadCommand.cs` — reword no-match branch, drop stale comment, update help.
+- Modify: `docker/smoke-test.sh` — add a long-title `--wait` success case.
+
+No README change: no CLI verb or user-visible flag is added/removed/renamed.
+
+---
+
+### Task 1: Commit the approved spec
+
+**Files:**
+- Commit: `docs/specs/2026-06-17-upload-wait-relpath-match-design.md` (already on disk, untracked)
+
+- [ ] **Step 1: Confirm branch and stage the spec**
+
+Run: `git branch --show-current` (expect `fix/upload-wait-relpath-match`), then
+```bash
+git add docs/specs/2026-06-17-upload-wait-relpath-match-design.md
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "docs: add upload --wait relpath matching design"
+```
+
+---
+
+### Task 2: RelPathMatcher — per-segment prefix matching (TDD)
+
+**Files:**
+- Create: `src/AbsCli/Api/RelPathMatcher.cs`
+- Test: `tests/AbsCli.Tests/Api/RelPathMatcherTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/AbsCli.Tests/Api/RelPathMatcherTests.cs`:
+
+```csharp
+using AbsCli.Api;
+
+namespace AbsCli.Tests.Api;
+
+public class RelPathMatcherTests
+{
+    // A series segment long enough (>247 UTF-16 bytes ≈ >123 chars) to be
+    // truncated by ABS. 130 'a's = 260 bytes.
+    private static string Long(char c, int n) => new string(c, n);
+
+    [Fact]
+    public void IsMatch_ShortSegments_RequireExactEquality()
+    {
+        Assert.True(RelPathMatcher.IsMatch("Yone/Series/Title", "Yone/Series/Title"));
+        Assert.False(RelPathMatcher.IsMatch("Yone/Series/Title", "Yone/Series/Other"));
+    }
+
+    [Fact]
+    public void IsMatch_DifferentSegmentCount_NoMatch()
+    {
+        Assert.False(RelPathMatcher.IsMatch("Author/Title", "Author/Series/Title"));
+    }
+
+    [Fact]
+    public void IsMatch_LongSegment_TruncatedTailsMatchOnPrefix()
+    {
+        // Predicted (untruncated) vs server (cut + re-appended ".«") share a
+        // >100-char common prefix → same segment.
+        var predicted = "Yone/" + Long('x', 130);
+        var actual = "Yone/" + Long('x', 123) + ".«";
+        Assert.True(RelPathMatcher.IsMatch(predicted, actual));
+    }
+
+    [Fact]
+    public void IsMatch_LongSegments_DifferingBeforePrefixFloor_NoMatch()
+    {
+        // Two different long segments that diverge early (here at char 0).
+        var predicted = "Yone/" + Long('x', 130);
+        var actual = "Yone/" + Long('y', 130);
+        Assert.False(RelPathMatcher.IsMatch(predicted, actual));
+    }
+
+    [Fact]
+    public void IsMatch_LongSharedSeries_DistinguishesByTitleSequencePrefix()
+    {
+        var series = Long('s', 130);
+        var predictedVol1 = $"Yone/{series}/1. - {Long('t', 130)}";
+        var actualVol1 = $"Yone/{series[..123]}.«/1. - {Long('t', 123)}.«";
+        var actualVol2 = $"Yone/{series[..123]}.«/2. - {Long('t', 123)}.«";
+        Assert.True(RelPathMatcher.IsMatch(predictedVol1, actualVol1));
+        Assert.False(RelPathMatcher.IsMatch(predictedVol1, actualVol2));
+    }
+
+    [Fact]
+    public void Matches_ReturnsAllMatchingCandidates()
+    {
+        var predicted = "Yone/Series/Title";
+        var candidates = new[] { "Other/X/Y", "Yone/Series/Title", "Yone/Series/Title" };
+        Assert.Equal(2, RelPathMatcher.Matches(predicted, candidates).Count);
+    }
+
+    [Fact]
+    public void Matches_NoCandidate_ReturnsEmpty()
+    {
+        var matches = RelPathMatcher.Matches("Yone/Series/Title", new[] { "A/B/C" });
+        Assert.Empty(matches);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj --filter RelPathMatcherTests`
+Expected: FAIL — `RelPathMatcher` does not exist (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/AbsCli/Api/RelPathMatcher.cs`:
+
+```csharp
+using System.Text;
+
+namespace AbsCli.Api;
+
+/// <summary>
+/// Matches a CLI-predicted relPath against the relPath ABS actually stored.
+/// The two diverge only in the truncated tail of long path segments (ABS
+/// truncates each segment to ~255 UTF-16 bytes and re-appends what
+/// <c>Path.extname</c> treats as an extension — see
+/// <c>temp/audiobookshelf/server/utils/fileUtils.js</c>). We therefore compare
+/// per segment: short segments must be equal; long (near-limit) segments may
+/// differ in the tail provided they share a long common prefix.
+/// </summary>
+public static class RelPathMatcher
+{
+    // UTF-16 byte length at/above which a segment may have been truncated by
+    // ABS. ABS's limit is 255; the margin covers the re-appended extension.
+    private const int NearTruncationLimitBytes = 247;
+
+    // Minimum common-prefix length (chars) for two differing near-limit
+    // segments to count as the same segment truncated differently. Comfortably
+    // below the ~127-char truncation point and above any realistic
+    // distinguishing prefix (differing authors/series/sequences diverge far
+    // earlier — e.g. the "N. -" title prefix diverges at char 0).
+    private const int MinTruncatedSegmentPrefix = 100;
+
+    /// <summary>True if a candidate relPath matches the predicted relPath.</summary>
+    public static bool IsMatch(string predicted, string actual)
+    {
+        var p = predicted.Split('/');
+        var a = actual.Split('/');
+        if (p.Length != a.Length) return false;
+        for (int i = 0; i < p.Length; i++)
+        {
+            if (!SegmentMatch(p[i], a[i])) return false;
+        }
+        return true;
+    }
+
+    /// <summary>All candidate relPaths that match <paramref name="predicted"/>.</summary>
+    public static List<string> Matches(string predicted, IEnumerable<string> candidates)
+    {
+        var result = new List<string>();
+        foreach (var c in candidates)
+        {
+            if (IsMatch(predicted, c)) result.Add(c);
+        }
+        return result;
+    }
+
+    private static bool SegmentMatch(string p, string a)
+    {
+        if (string.Equals(p, a, StringComparison.Ordinal)) return true;
+        // Segments may only legitimately differ if one looks truncated;
+        // otherwise they are simply different segments.
+        if (!IsNearLimit(p) && !IsNearLimit(a)) return false;
+        return CommonPrefixLength(p, a) >= MinTruncatedSegmentPrefix;
+    }
+
+    private static bool IsNearLimit(string s) =>
+        Encoding.Unicode.GetByteCount(s) >= NearTruncationLimitBytes;
+
+    private static int CommonPrefixLength(string x, string y)
+    {
+        int n = Math.Min(x.Length, y.Length);
+        int i = 0;
+        while (i < n && x[i] == y[i]) i++;
+        return i;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test tests/AbsCli.Tests/AbsCli.Tests.csproj --filter RelPathMatcherTests`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dotnet format AbsCli.sln
+git add src/AbsCli/Api/RelPathMatcher.cs tests/AbsCli.Tests/Api/RelPathMatcherTests.cs
+git commit -m "feat: add per-segment relPath matcher for upload --wait"
+```
+
+---
+
+### Task 3: Wire WaitForItemByPathAsync to the matcher
+
+**Files:**
+- Modify: `src/AbsCli/Services/UploadService.cs:75-112`
+
+- [ ] **Step 1: Replace the method body**
+
+In `src/AbsCli/Services/UploadService.cs`, replace the doc comment + method (lines 75-112) with:
+
+```csharp
+    /// <summary>
+    /// Poll items list (sorted by addedAt desc) and return the just-uploaded
+    /// item, matched against <paramref name="expectedRelPath"/> with tolerant
+    /// per-segment prefix matching (see <see cref="RelPathMatcher"/>) because
+    /// the CLI's predicted path and ABS's stored path diverge in the truncated
+    /// tail of long segments. Returns null if nothing matches within the window
+    /// OR if more than one recent item matches — an unresolvable collision the
+    /// caller must not guess at.
+    /// </summary>
+    public async Task<LibraryItemMinified?> WaitForItemByPathAsync(
+        string libraryId, string expectedRelPath,
+        int timeoutSeconds = 120, int pollIntervalMs = 3000)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            var query = HttpUtility.ParseQueryString("");
+            query["sort"] = "addedAt";
+            query["desc"] = "1";
+            query["limit"] = "20";
+            var url = ApiEndpoints.LibraryItems(libraryId) + "?" + query;
+            var result = await _client.GetAsync(url, AppJsonContext.Default.PaginatedResponse);
+            var candidates = new List<(string RelPath, JsonElement Element)>();
+            foreach (var itemElement in result.Results)
+            {
+                if (!itemElement.TryGetProperty("relPath", out var relPathProp)) continue;
+                var relPath = relPathProp.GetString();
+                if (relPath == null) continue;
+                // ABS stores relPath with a leading slash; strip it for comparison.
+                candidates.Add((relPath.TrimStart('/'), itemElement));
+            }
+            var matches = RelPathMatcher.Matches(expectedRelPath, candidates.Select(c => c.RelPath));
+            if (matches.Count == 1)
+            {
+                var element = candidates.First(c => c.RelPath == matches[0]).Element;
+                return JsonSerializer.Deserialize(element.GetRawText(),
+                    AppJsonContext.Default.LibraryItemMinified);
+            }
+            // matches.Count > 1 ⇒ ambiguous collision; polling won't resolve it.
+            if (matches.Count > 1) return null;
+            await Task.Delay(pollIntervalMs);
+        }
+        return null;
+    }
+```
+
+- [ ] **Step 2: Add the System.Text.Json using**
+
+At the top of `src/AbsCli/Services/UploadService.cs`, add `using System.Text.Json;` after the existing `using System.Web;` line (so `JsonElement` and `JsonSerializer` resolve unqualified).
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `dotnet build AbsCli.sln`
+Expected: Build succeeded, no errors.
+
+- [ ] **Step 4: Run the full unit suite**
+
+Run: `dotnet test AbsCli.sln`
+Expected: PASS (existing tests + the new matcher tests).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dotnet format AbsCli.sln
+git add src/AbsCli/Services/UploadService.cs
+git commit -m "fix: match upload --wait item by tolerant per-segment relPath"
+```
+
+---
+
+### Task 4: Delete dead client-side truncation
+
+**Files:**
+- Modify: `src/AbsCli/Api/FilenameSanitizer.cs`
+- Modify: `tests/AbsCli.Tests/Api/FilenameSanitizerTests.cs:105-113`
+
+- [ ] **Step 1: Remove the truncation test**
+
+In `tests/AbsCli.Tests/Api/FilenameSanitizerTests.cs`, delete the entire
+`LongBasename_TruncatedToByteLimit` test (lines 105-113, the `[Fact]` and its method).
+
+- [ ] **Step 2: Remove TruncateToByteLimit and the constant**
+
+In `src/AbsCli/Api/FilenameSanitizer.cs`:
+- Delete the `private const int MaxFilenameBytes = 255;` line.
+- Change the end of `Sanitize` from `return TruncateToByteLimit(s);` to `return s;`.
+- Delete the entire `private static string TruncateToByteLimit(string s) { ... }` method.
+
+- [ ] **Step 3: Update the class doc comment**
+
+In `src/AbsCli/Api/FilenameSanitizer.cs`, replace doc point 10 and the drift note. Change the numbered list item:
+
+```
+///  10. If basename in UTF-16 bytes &gt; 255, truncate the basename (ext preserved).
+```
+
+to:
+
+```
+/// Note: ABS truncates over-long path segments (~255 UTF-16 bytes) in a way the
+/// CLI does not reproduce; upload --wait tolerates that tail divergence via
+/// RelPathMatcher rather than predicting the exact truncated path.
+```
+
+And replace the "Drift risk / Smoke-test asserts… same relPath we predicted" lines with:
+
+```
+/// Drift risk: if ABS changes sanitise rules, predictions desync. The smoke
+/// test asserts upload --wait still resolves the scanned item (exact match for
+/// short titles, per-segment prefix match for long ones).
+```
+
+- [ ] **Step 4: Build and test**
+
+Run: `dotnet build AbsCli.sln && dotnet test AbsCli.sln`
+Expected: PASS. (`Sanitize` no longer truncates; no remaining test depends on truncation.)
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dotnet format AbsCli.sln
+git add src/AbsCli/Api/FilenameSanitizer.cs tests/AbsCli.Tests/Api/FilenameSanitizerTests.cs
+git commit -m "refactor: drop dead client-side path truncation"
+```
+
+---
+
+### Task 5: Reword the no-match path and update help
+
+**Files:**
+- Modify: `src/AbsCli/Commands/UploadCommand.cs:63-70` (help) and `:134-154` (caller)
+
+- [ ] **Step 1: Reword the no-confident-match branch**
+
+In `src/AbsCli/Commands/UploadCommand.cs`, replace the `if (wait) { ... }` block body (the comment at lines 136-141, the `if (item == null)` error, lines 134-154) with:
+
+```csharp
+            if (wait)
+            {
+                var item = await service.WaitForItemByPathAsync(libraryId, receipt.RelPath);
+                if (item == null)
+                {
+                    _logger.Warn(
+                        "Upload succeeded, but the library item could not be auto-confirmed " +
+                        "within the wait window — ABS may still be scanning, or the title is " +
+                        "long enough that more than one recent item matched the predicted path. " +
+                        "The files have landed; do NOT re-upload. Identify the item with: " +
+                        "abs-cli items list --sort addedAt --desc --limit 5");
+                    ConsoleOutput.WriteJson(receipt, AppJsonContext.Default.UploadReceipt);
+                    Environment.Exit(1);
+                    return 1;
+                }
+                ConsoleOutput.WriteJson(item, AppJsonContext.Default.LibraryItemMinified);
+            }
+```
+
+- [ ] **Step 2: Update the "Output" help section**
+
+In `src/AbsCli/Commands/UploadCommand.cs`, replace the `command.AddHelpSection("Output", ...)` call (lines 63-70) with:
+
+```csharp
+        command.AddHelpSection("Output",
+            "Without --wait: returns an upload receipt. The files have landed but the",
+            "item is not scanned yet. The receipt's relPath is a best-effort prediction;",
+            "for very long titles ABS truncates path segments, so the real on-disk path",
+            "is the server's, not the receipt's.",
+            "",
+            "With --wait: polls until the item appears and returns it as a",
+            "LibraryItemMinified, matched by per-segment path prefix (tolerant of the",
+            "server's title truncation). If it can't be auto-confirmed within ~2 min",
+            "(still scanning, or a long title colliding with another recent item) the",
+            "receipt is emitted with a warning and the command exits 1 — the files are",
+            "uploaded regardless, so do not re-upload.");
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `dotnet build AbsCli.sln && dotnet test AbsCli.sln`
+Expected: PASS.
+
+- [ ] **Step 4: Eyeball the help**
+
+Run: `dotnet run --project src/AbsCli -- upload --help`
+Expected: the "Output" section shows the new wording; no stray blank-line issues.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dotnet format AbsCli.sln
+git add src/AbsCli/Commands/UploadCommand.cs
+git commit -m "fix: reword upload --wait no-match as success-with-warning"
+```
+
+---
+
+### Task 6: Smoke-test coverage for long titles
+
+**Files:**
+- Modify: `docker/smoke-test.sh` (after the drift cases, before `rm -rf "$UPLOAD_TMP"` at line ~698)
+
+- [ ] **Step 1: Add a long-title --wait success case**
+
+In `docker/smoke-test.sh`, immediately before the `rm -rf "$UPLOAD_TMP"` that follows the drift cases (~line 698), insert:
+
+```bash
+# --- Long-title --wait (issue #54) ---
+# A title long enough that ABS truncates the path segment. We cannot predict
+# the exact truncated relPath, so assert --wait still resolves the item (the
+# per-segment matcher tolerates the tail divergence). Pre-fix this timed out.
+LONG_TITLE="Ich täuschte Amnesie vor um meinen Verlobten loszuwerden da behauptete er Vor deinem Gedächtnisverlust warst du in mich verliebt und das ist die ganze lange Geschichte"
+abs_login uploaduser uploadpass
+long_out=$($CLI upload --title "$LONG_TITLE" --author "Long Title Author" \
+    --folder "$FOLDER_ID" --wait --files "$UPLOAD_TMP/test.mp3" 2>&1)
+long_rc=$?
+abs_login root root
+if [ $long_rc -eq 0 ] && json_get "$long_out" "['id']" >/dev/null 2>&1; then
+    pass "long-title upload --wait resolves item (issue #54)"
+    long_id=$(json_get "$long_out" "['id']")
+    [ -n "$long_id" ] && $CLI items delete --id "$long_id" --hard >/dev/null 2>&1 || true
+else
+    fail "long-title upload --wait resolves item (issue #54)" "rc=$long_rc out=${long_out:0:300}"
+fi
+```
+
+- [ ] **Step 2: Commit (smoke run happens in Task 7)**
+
+```bash
+git add docker/smoke-test.sh
+git commit -m "test: smoke-cover long-title upload --wait (issue #54)"
+```
+
+---
+
+### Task 7: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Format check (as CI runs it)**
+
+Run: `dotnet format AbsCli.sln --verify-no-changes`
+Expected: no output, exit 0. If it fails, run `dotnet format AbsCli.sln`, commit the fix, re-run.
+
+- [ ] **Step 2: Full unit suite**
+
+Run: `dotnet test AbsCli.sln`
+Expected: all pass.
+
+- [ ] **Step 3: Bring up the docker stack and resolve the container IP**
+
+```bash
+cd docker && docker compose up -d && cd ..
+ABS_IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+echo "ABS_IP=$ABS_IP"
+```
+
+- [ ] **Step 4: Seed if the stack is fresh**
+
+Run: `ABS_URL=http://$ABS_IP:80 bash docker/seed.sh`
+Expected: seed completes (skip only if the stack was already seeded this session).
+
+- [ ] **Step 5: Run the smoke test**
+
+Run: `ABS_URL=http://$ABS_IP:80 bash docker/smoke-test.sh`
+Expected: all assertions pass — including the existing "sanitize drift" cases and the new "long-title upload --wait resolves item (issue #54)".
+
+- [ ] **Step 6: Report results**
+
+Confirm: format clean, unit tests green, smoke green (quote the relevant smoke lines). Only then is the work ready for a PR.

--- a/docs/specs/2026-06-17-upload-wait-relpath-match-design.md
+++ b/docs/specs/2026-06-17-upload-wait-relpath-match-design.md
@@ -1,0 +1,136 @@
+# upload --wait: per-segment relPath matching
+
+**Issue:** [#54](https://github.com/thomaslazar/abs-cli/issues/54) — `upload --wait`
+false-negative on long titles; predicted `relPath` diverges from the server's
+path truncation.
+
+## Problem
+
+`upload --wait` polls `items list` and matches the just-uploaded item by **exact
+`relPath` equality** (`UploadService.WaitForItemByPathAsync`). ABS's upload
+endpoint returns HTTP 200 with an **empty body** (`MiscController.handleUpload`),
+so the CLI cannot learn the real path or id — it *predicts* the path by
+re-implementing ABS's `sanitizeFilename` client-side (`FilenameSanitizer`).
+
+The prediction diverges from the server for titles long enough to be truncated.
+Confirmed against the v2.35.1 checkout (`server/utils/fileUtils.js:360-421`):
+ABS runs `Path.extname()` on **every** directory part, truncates the *basename*
+to `255 − len(ext)` UTF-16 bytes, `.trim()`s it, and **re-appends the
+extension**:
+
+```js
+const ext = Path.extname(sanitized)          // ".«" for a title ending "verliebt.«"
+const basename = Path.basename(sanitized, ext)
+...
+trimmedBasename = trimmedBasename.trim()
+sanitized = trimmedBasename + ext            // basename cut, ext re-appended
+```
+
+The CLI (`FilenameSanitizer.TruncateToByteLimit`) instead assumes "no extension
+here" and does a plain byte-prefix cut — so `…warst du in mich.«` (server) vs
+`…warst du in mich ve` (CLI). Exact equality can therefore never match a
+truncated-title item.
+
+**Impact (from the issue):** false-negative on every long-titled item; scary
+exit-1 "did not appear" wording that reads as data loss; the post-`--wait`
+`items update` metadata step is skipped; re-running on the "failure" duplicates
+the item.
+
+The stored `relPath` is exactly the upload directory path — the scanner takes it
+verbatim (`Watcher.js`, `LibraryScanner.js`), no metadata-driven renaming. So the
+divergence is purely CLI-vs-server truncation drift.
+
+## Decision
+
+Replicating the server's truncation exactly (issue suggestion #3) is fragile and
+version-coupled — it is the strategy the CLI already bet on and lost, and the
+server's `Path.extname`-on-directories behaviour has further pathologies
+(e.g. a sequence-only dot can make `extname` swallow the title). Matching by the
+server's item id (suggestion #1) is impossible: the response has no body.
+
+**Chosen: tolerant per-segment prefix matching** (issue suggestion #2). The key
+property: client and server consume the *same leading characters in the same
+order*; they only ever diverge in the truncated **tail** of a long segment.
+Per-segment comparison lets long leading segments (author, series) prefix-match
+while a distinguishing later segment — the `N. -` sequence prefix on the title —
+still separates volumes of the same series.
+
+## Design
+
+### Matching (`UploadService.WaitForItemByPathAsync`)
+
+Replace the exact-equality check with per-segment matching over the recent items
+already polled (`sort=addedAt&desc=1&limit=20`):
+
+1. Split both the candidate's `relPath` (leading `/` stripped, as today) and the
+   predicted `relPath` on `/`. Different segment count ⇒ not a match.
+2. Each segment must **segment-prefix-match**:
+   - equal ⇒ match; else
+   - the segment is only allowed to differ if it is **near the truncation limit**
+     (UTF-16 byte length ≥ ~247 on either side) — short segments require exact
+     equality, which rejects unrelated items naturally (a different author fails
+     on segment 0); and
+   - the common prefix length must be ≥ `MinTruncatedSegmentPrefix` (start at
+     **100** chars — comfortably below the ~127-char truncation point, and above
+     any realistic distinguishing prefix, since differing books/series/sequences
+     diverge far earlier).
+3. Collect all recent items that match. Return the item **iff exactly one
+   matches**. Zero or ≥2 ⇒ no confident match (return null).
+
+**Invariant: never return an item we are not certain of.** A tie (≥2 matches)
+means a genuine, unresolvable collision — same author, same/no series, and titles
+identical up to truncation, which the *server* writes into the **same folder**
+anyway. We warn rather than guess.
+
+### Caller (`UploadCommand`)
+
+- Confident match → print the `LibraryItemMinified`, exit 0 (unchanged success
+  path; now reached for long titles too).
+- No confident match → emit the receipt and a **reworded** message: the files
+  uploaded **successfully**, the item was not auto-confirmed (still scanning, or
+  multiple long-title candidates matched), identify it via
+  `abs-cli items list --sort addedAt --desc --limit 5`, and **do not re-upload**.
+  Exit 1 (preserves the "stdout has an item ⇔ exit 0" contract for scripts) but
+  without the data-loss wording.
+- Remove the now-inaccurate "Match by relPath — deterministic" comment block.
+
+### Cleanup
+
+`FilenameSanitizer.TruncateToByteLimit` and `MaxFilenameBytes` become dead weight:
+the per-segment prefix match depends only on the first ~100 chars, which
+truncation does not alter. Delete them (and the misleading "ext preserved"
+doc point). `PredictRelPath`/`Sanitize` stay — they produce the match key. The
+predicted segment is then untruncated, which is fine (it only feeds the prefix
+comparison, and the `--wait` success path returns the server's real `relPath`
+anyway).
+
+### Help text (`UploadCommand`, "Output" section)
+
+Update to reflect the new behaviour: `--wait` matches by per-segment path prefix;
+for very long titles the exact on-disk path is the server's, not the receipt's
+prediction; on no-confident-match the files are still uploaded — re-run
+`items list` rather than re-uploading.
+
+## Known limitation (explicitly out of scope)
+
+Two uploads that the server sanitizes to a **byte-identical folder** (same long
+author, same/no series, titles diverging only past the truncation point, no
+distinguishing sequence) cannot be told apart — the server has already merged
+them into one directory. This also covers the server's own `Path.extname`
+pathologies (e.g. a sequence-only dot). These degrade to the safe
+"couldn't auto-confirm" path; never to a wrong match. Not worked around.
+
+## Testing
+
+- TDD the matcher with concrete cases, pinning the `MinTruncatedSegmentPrefix`
+  and near-limit constants:
+  - normal short title: exact match unchanged;
+  - long title, single upload: matches despite tail divergence;
+  - two volumes of one long-named series (`1. -` / `2. -`): each resolves to its
+    own item;
+  - unrelated recent item (different author): rejected;
+  - byte-identical collision: two matches ⇒ no confident match (warn).
+- Update/remove unit tests covering `TruncateToByteLimit`.
+- Update `docker/smoke-test.sh`: the existing exact-round-trip `relPath`
+  assertion changes to the per-segment match; add a long-title upload case so the
+  regression is covered in the live HTTP path. Extend `docker/seed.sh` if needed.

--- a/src/AbsCli/Api/FilenameSanitizer.cs
+++ b/src/AbsCli/Api/FilenameSanitizer.cs
@@ -20,16 +20,17 @@ namespace AbsCli.Api;
 ///   7. Strip Windows reserved basenames (con, prn, aux, nul, com[0-9], lpt[0-9]).
 ///   8. Strip trailing sequences of '.' or ' '.
 ///   9. Collapse runs of whitespace to a single space.
-///  10. If basename in UTF-16 bytes &gt; 255, truncate the basename (ext preserved).
 ///
-/// Drift risk: if ABS changes sanitise rules, CLI predictions desync silently.
-/// Smoke-test asserts that upload round-trips produce the same relPath we
-/// predicted — catches drift before it ships.
+/// Note: ABS truncates over-long path segments (~255 UTF-16 bytes) in a way the
+/// CLI does not reproduce; upload --wait tolerates that tail divergence via
+/// RelPathMatcher rather than predicting the exact truncated path.
+///
+/// Drift risk: if ABS changes sanitise rules, predictions desync. The smoke
+/// test asserts upload --wait still resolves the scanned item (exact match for
+/// short titles, per-segment prefix match for long ones).
 /// </summary>
 public static class FilenameSanitizer
 {
-    private const int MaxFilenameBytes = 255;
-
     private static readonly Regex IllegalChars = new(@"[/\?<>\\:\*\|""]", RegexOptions.Compiled);
     private static readonly Regex ControlChars = new(@"[\x00-\x1f\x80-\x9f]", RegexOptions.Compiled);
     private static readonly Regex DotsOnly = new(@"^\.+$", RegexOptions.Compiled);
@@ -59,7 +60,7 @@ public static class FilenameSanitizer
         s = TrailingDotsOrSpaces.Replace(s, "");
         s = WhitespaceRun.Replace(s, " ");
 
-        return TruncateToByteLimit(s);
+        return s;
     }
 
     /// <summary>
@@ -78,25 +79,5 @@ public static class FilenameSanitizer
             if (!string.IsNullOrEmpty(sanitized)) parts.Add(sanitized);
         }
         return string.Join('/', parts);
-    }
-
-    private static string TruncateToByteLimit(string s)
-    {
-        // ABS measures basename only (extension preserved). On upload ABS sanitises
-        // each directory part separately before Path.join, so there's no extension
-        // here — we treat the whole string as basename.
-        var byteLen = Encoding.Unicode.GetByteCount(s);
-        if (byteLen <= MaxFilenameBytes) return s;
-
-        var sb = new StringBuilder();
-        var total = 0;
-        foreach (var c in s)
-        {
-            var charBytes = Encoding.Unicode.GetByteCount(new[] { c });
-            if (total + charBytes > MaxFilenameBytes) break;
-            sb.Append(c);
-            total += charBytes;
-        }
-        return sb.ToString();
     }
 }

--- a/src/AbsCli/Api/RelPathMatcher.cs
+++ b/src/AbsCli/Api/RelPathMatcher.cs
@@ -1,0 +1,70 @@
+using System.Text;
+
+namespace AbsCli.Api;
+
+/// <summary>
+/// Matches a CLI-predicted relPath against the relPath ABS actually stored.
+/// The two diverge only in the truncated tail of long path segments (ABS
+/// truncates each segment to ~255 UTF-16 bytes and re-appends what
+/// <c>Path.extname</c> treats as an extension — see
+/// <c>temp/audiobookshelf/server/utils/fileUtils.js</c>). We therefore compare
+/// per segment: short segments must be equal; long (near-limit) segments may
+/// differ in the tail provided they share a long common prefix.
+/// </summary>
+public static class RelPathMatcher
+{
+    // UTF-16 byte length at/above which a segment may have been truncated by
+    // ABS. ABS's limit is 255; the margin covers the re-appended extension.
+    private const int NearTruncationLimitBytes = 247;
+
+    // Minimum common-prefix length (chars) for two differing near-limit
+    // segments to count as the same segment truncated differently. Comfortably
+    // below the ~127-char truncation point and above any realistic
+    // distinguishing prefix (differing authors/series/sequences diverge far
+    // earlier — e.g. the "N. -" title prefix diverges at char 0).
+    private const int MinTruncatedSegmentPrefix = 100;
+
+    /// <summary>True if a candidate relPath matches the predicted relPath.</summary>
+    public static bool IsMatch(string predicted, string actual)
+    {
+        var p = predicted.Split('/');
+        var a = actual.Split('/');
+        if (p.Length != a.Length) return false;
+        for (int i = 0; i < p.Length; i++)
+        {
+            if (!SegmentMatch(p[i], a[i])) return false;
+        }
+        return true;
+    }
+
+    /// <summary>All candidate relPaths that match <paramref name="predicted"/>.</summary>
+    public static List<string> Matches(string predicted, IEnumerable<string> candidates)
+    {
+        var result = new List<string>();
+        foreach (var c in candidates)
+        {
+            if (IsMatch(predicted, c)) result.Add(c);
+        }
+        return result;
+    }
+
+    private static bool SegmentMatch(string p, string a)
+    {
+        if (string.Equals(p, a, StringComparison.Ordinal)) return true;
+        // Segments may only legitimately differ if one looks truncated;
+        // otherwise they are simply different segments.
+        if (!IsNearLimit(p) && !IsNearLimit(a)) return false;
+        return CommonPrefixLength(p, a) >= MinTruncatedSegmentPrefix;
+    }
+
+    private static bool IsNearLimit(string s) =>
+        Encoding.Unicode.GetByteCount(s) >= NearTruncationLimitBytes;
+
+    private static int CommonPrefixLength(string x, string y)
+    {
+        int n = Math.Min(x.Length, y.Length);
+        int i = 0;
+        while (i < n && x[i] == y[i]) i++;
+        return i;
+    }
+}

--- a/src/AbsCli/Api/RelPathMatcher.cs
+++ b/src/AbsCli/Api/RelPathMatcher.cs
@@ -10,6 +10,8 @@ namespace AbsCli.Api;
 /// <c>temp/audiobookshelf/server/utils/fileUtils.js</c>). We therefore compare
 /// per segment: short segments must be equal; long (near-limit) segments may
 /// differ in the tail provided they share a long common prefix.
+/// Two uploads ABS sanitises to a byte-identical folder cannot be told apart
+/// (the server merges them); such collisions are out of scope here.
 /// </summary>
 public static class RelPathMatcher
 {
@@ -27,8 +29,10 @@ public static class RelPathMatcher
     /// <summary>True if a candidate relPath matches the predicted relPath.</summary>
     public static bool IsMatch(string predicted, string actual)
     {
-        var p = predicted.Split('/');
-        var a = actual.Split('/');
+        // ABS stores relPath with a leading slash; normalise both sides so the
+        // match does not depend on the caller stripping it.
+        var p = predicted.TrimStart('/').Split('/');
+        var a = actual.TrimStart('/').Split('/');
         if (p.Length != a.Length) return false;
         for (int i = 0; i < p.Length; i++)
         {

--- a/src/AbsCli/Commands/UploadCommand.cs
+++ b/src/AbsCli/Commands/UploadCommand.cs
@@ -61,13 +61,17 @@ public static class UploadCommand
             "abs-cli upload --title \"My Audiobook\" --files-manifest manifest.json",
             "cat manifest.json | abs-cli upload --title \"My Audiobook\" --files-manifest -");
         command.AddHelpSection("Output",
-            "Without --wait: returns an upload receipt (the files have landed but the",
-            "library item has not been scanned yet). The receipt's relPath identifies",
-            "the item once 'items scan' or the next scan tick picks it up.",
+            "Without --wait: returns an upload receipt. The files have landed but the",
+            "item is not scanned yet. The receipt's relPath is a best-effort prediction;",
+            "for very long titles ABS truncates path segments, so the real on-disk path",
+            "is the server's, not the receipt's.",
             "",
-            "With --wait: polls until the item appears, returns it as a",
-            "LibraryItemMinified. On timeout (~2 min) the receipt is emitted to stdout",
-            "and the command exits 1.");
+            "With --wait: polls until the item appears and returns it as a",
+            "LibraryItemMinified, matched by per-segment path prefix (tolerant of the",
+            "server's title truncation). If it can't be auto-confirmed within ~2 min",
+            "(still scanning, or a long title colliding with another recent item) the",
+            "receipt is emitted with a warning and the command exits 1 — the files are",
+            "uploaded regardless, so do not re-upload.");
         command.AddResponseExample<UploadReceipt>();
         command.AddShapeSection("Response shape (with --wait, on success)",
             "LibraryItemMinified — same shape as 'abs-cli items get --help'.");
@@ -133,19 +137,15 @@ public static class UploadCommand
             var receipt = await service.UploadAsync(libraryId, folderId, title, author, series, sequence, uploadList);
             if (wait)
             {
-                // Match by relPath — deterministic given that we compute the
-                // exact path ABS wrote to using the same sanitisation. The
-                // old title-substring search failed with --sequence because
-                // ABS strips the "N. -" prefix from media.metadata.title when
-                // scanning, so the CLI's search query (which included the
-                // prefix) no longer matched what ABS had indexed.
                 var item = await service.WaitForItemByPathAsync(libraryId, receipt.RelPath);
                 if (item == null)
                 {
-                    _logger.Error(
-                        $"Upload completed but the library item did not appear within the wait window. " +
-                        $"Expected relPath: '{receipt.RelPath}'. " +
-                        $"ABS may still be scanning — re-run: abs-cli items list --sort addedAt --desc --limit 5");
+                    _logger.Warn(
+                        "Upload succeeded, but the library item could not be auto-confirmed " +
+                        "within the wait window — ABS may still be scanning, or the title is " +
+                        "long enough that more than one recent item matched the predicted path. " +
+                        "The files have landed; do NOT re-upload. Identify the item with: " +
+                        "abs-cli items list --sort addedAt --desc --limit 5");
                     ConsoleOutput.WriteJson(receipt, AppJsonContext.Default.UploadReceipt);
                     Environment.Exit(1);
                     return 1;

--- a/src/AbsCli/Services/UploadService.cs
+++ b/src/AbsCli/Services/UploadService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Web;
 using AbsCli.Api;
 using AbsCli.Models;
@@ -73,12 +74,13 @@ public class UploadService
     }
 
     /// <summary>
-    /// Poll items list (sorted by addedAt desc) and return the first item whose
-    /// relPath matches <paramref name="expectedRelPath"/>. Path-based match is
-    /// deterministic: we computed the exact folder ABS wrote the files into
-    /// using the same sanitisation ABS applies, so there is no false positive
-    /// and no false negative from title substring matching (which broke when
-    /// --sequence prefixed the uploaded title).
+    /// Poll items list (sorted by addedAt desc) and return the just-uploaded
+    /// item, matched against <paramref name="expectedRelPath"/> with tolerant
+    /// per-segment prefix matching (see <see cref="RelPathMatcher"/>) because
+    /// the CLI's predicted path and ABS's stored path diverge in the truncated
+    /// tail of long segments. Returns null if nothing matches within the window
+    /// OR if more than one recent item matches — an unresolvable collision the
+    /// caller must not guess at.
     /// </summary>
     public async Task<LibraryItemMinified?> WaitForItemByPathAsync(
         string libraryId, string expectedRelPath,
@@ -93,19 +95,24 @@ public class UploadService
             query["limit"] = "20";
             var url = ApiEndpoints.LibraryItems(libraryId) + "?" + query;
             var result = await _client.GetAsync(url, AppJsonContext.Default.PaginatedResponse);
+            var candidates = new List<(string RelPath, JsonElement Element)>();
             foreach (var itemElement in result.Results)
             {
                 if (!itemElement.TryGetProperty("relPath", out var relPathProp)) continue;
                 var relPath = relPathProp.GetString();
                 if (relPath == null) continue;
                 // ABS stores relPath with a leading slash; strip it for comparison.
-                var normalised = relPath.TrimStart('/');
-                if (string.Equals(normalised, expectedRelPath, StringComparison.Ordinal))
-                {
-                    return System.Text.Json.JsonSerializer.Deserialize(itemElement.GetRawText(),
-                        AppJsonContext.Default.LibraryItemMinified);
-                }
+                candidates.Add((relPath.TrimStart('/'), itemElement));
             }
+            var matches = RelPathMatcher.Matches(expectedRelPath, candidates.Select(c => c.RelPath));
+            if (matches.Count == 1)
+            {
+                var element = candidates.First(c => c.RelPath == matches[0]).Element;
+                return JsonSerializer.Deserialize(element.GetRawText(),
+                    AppJsonContext.Default.LibraryItemMinified);
+            }
+            // matches.Count > 1 ⇒ ambiguous collision; polling won't resolve it.
+            if (matches.Count > 1) return null;
             await Task.Delay(pollIntervalMs);
         }
         return null;

--- a/tests/AbsCli.Tests/Api/FilenameSanitizerTests.cs
+++ b/tests/AbsCli.Tests/Api/FilenameSanitizerTests.cs
@@ -103,16 +103,6 @@ public class FilenameSanitizerTests
     }
 
     [Fact]
-    public void LongBasename_TruncatedToByteLimit()
-    {
-        // UTF-16 is 2 bytes per ASCII char → 300 chars = 600 bytes, exceeds 255.
-        var longName = new string('a', 300);
-        var result = FilenameSanitizer.Sanitize(longName);
-        // MaxFilenameBytes / 2 = 127 chars for ASCII-only.
-        Assert.Equal(127, result.Length);
-    }
-
-    [Fact]
     public void PredictRelPath_JoinsSanitisedPartsWithSlash()
     {
         Assert.Equal("Author/Series/Title",

--- a/tests/AbsCli.Tests/Api/RelPathMatcherTests.cs
+++ b/tests/AbsCli.Tests/Api/RelPathMatcherTests.cs
@@ -1,0 +1,68 @@
+using AbsCli.Api;
+
+namespace AbsCli.Tests.Api;
+
+public class RelPathMatcherTests
+{
+    // A series segment long enough (>247 UTF-16 bytes ≈ >123 chars) to be
+    // truncated by ABS. 130 'a's = 260 bytes.
+    private static string Long(char c, int n) => new string(c, n);
+
+    [Fact]
+    public void IsMatch_ShortSegments_RequireExactEquality()
+    {
+        Assert.True(RelPathMatcher.IsMatch("Yone/Series/Title", "Yone/Series/Title"));
+        Assert.False(RelPathMatcher.IsMatch("Yone/Series/Title", "Yone/Series/Other"));
+    }
+
+    [Fact]
+    public void IsMatch_DifferentSegmentCount_NoMatch()
+    {
+        Assert.False(RelPathMatcher.IsMatch("Author/Title", "Author/Series/Title"));
+    }
+
+    [Fact]
+    public void IsMatch_LongSegment_TruncatedTailsMatchOnPrefix()
+    {
+        // Predicted (untruncated) vs server (cut + re-appended ".«") share a
+        // >100-char common prefix → same segment.
+        var predicted = "Yone/" + Long('x', 130);
+        var actual = "Yone/" + Long('x', 123) + ".«";
+        Assert.True(RelPathMatcher.IsMatch(predicted, actual));
+    }
+
+    [Fact]
+    public void IsMatch_LongSegments_DifferingBeforePrefixFloor_NoMatch()
+    {
+        // Two different long segments that diverge early (here at char 0).
+        var predicted = "Yone/" + Long('x', 130);
+        var actual = "Yone/" + Long('y', 130);
+        Assert.False(RelPathMatcher.IsMatch(predicted, actual));
+    }
+
+    [Fact]
+    public void IsMatch_LongSharedSeries_DistinguishesByTitleSequencePrefix()
+    {
+        var series = Long('s', 130);
+        var predictedVol1 = $"Yone/{series}/1. - {Long('t', 130)}";
+        var actualVol1 = $"Yone/{series[..123]}.«/1. - {Long('t', 123)}.«";
+        var actualVol2 = $"Yone/{series[..123]}.«/2. - {Long('t', 123)}.«";
+        Assert.True(RelPathMatcher.IsMatch(predictedVol1, actualVol1));
+        Assert.False(RelPathMatcher.IsMatch(predictedVol1, actualVol2));
+    }
+
+    [Fact]
+    public void Matches_ReturnsAllMatchingCandidates()
+    {
+        var predicted = "Yone/Series/Title";
+        var candidates = new[] { "Other/X/Y", "Yone/Series/Title", "Yone/Series/Title" };
+        Assert.Equal(2, RelPathMatcher.Matches(predicted, candidates).Count);
+    }
+
+    [Fact]
+    public void Matches_NoCandidate_ReturnsEmpty()
+    {
+        var matches = RelPathMatcher.Matches("Yone/Series/Title", new[] { "A/B/C" });
+        Assert.Empty(matches);
+    }
+}

--- a/tests/AbsCli.Tests/Api/RelPathMatcherTests.cs
+++ b/tests/AbsCli.Tests/Api/RelPathMatcherTests.cs
@@ -65,4 +65,11 @@ public class RelPathMatcherTests
         var matches = RelPathMatcher.Matches("Yone/Series/Title", new[] { "A/B/C" });
         Assert.Empty(matches);
     }
+
+    [Fact]
+    public void IsMatch_NormalisesLeadingSlashOnEitherSide()
+    {
+        Assert.True(RelPathMatcher.IsMatch("Yone/Series/Title", "/Yone/Series/Title"));
+        Assert.True(RelPathMatcher.IsMatch("/Yone/Series/Title", "Yone/Series/Title"));
+    }
 }


### PR DESCRIPTION
## Summary

`upload --wait` reported a false-negative failure for long titles. It matched the uploaded library item by **exact relPath equality**, predicting the path by replicating ABS's `sanitizeFilename`. For long titles ABS truncates each path segment (re-appending what `Path.extname` treats as an extension), so the prediction diverged from the stored path and the match never succeeded — even though the upload itself succeeded. The exit-1 "did not appear" error read as data loss and risked duplicate re-uploads.

## Changes

- **`RelPathMatcher`** (new): tolerant per-segment prefix matching — short segments must match exactly; long, near-truncation-limit segments match on a ≥100-char common prefix. Divergence is always confined to the truncated tail, so the leading segments still match.
- **`WaitForItemByPathAsync`**: uses the matcher over the recent items it already polls. Returns the item only when **exactly one** recent item matches; an ambiguous (>1) collision returns null rather than guessing.
- **Caller/help**: the no-confident-match path is reworded from a scary `ERROR`+exit-1 to a `WARN`+exit-1 ("upload succeeded; do not re-upload"); `--help` documents the per-segment matching and long-title caveat.
- **Cleanup**: deleted the now-dead client-side truncation (`FilenameSanitizer.TruncateToByteLimit` + `MaxFilenameBytes`).

Known limitation (out of scope): two uploads ABS sanitizes to a byte-identical folder cannot be told apart — the server merges them. These degrade to the safe "couldn't auto-confirm" path, never a wrong match.

Design/plan: `docs/specs/2026-06-17-upload-wait-relpath-match-design.md`, `docs/plans/2026-06-17-upload-wait-relpath-match.md`.

Closes #54

## Test Plan

- [x] Unit tests: 270/270 pass (incl. `RelPathMatcherTests` covering exact match, truncated-tail prefix match, volume-1-vs-2 discrimination, ambiguity, leading-slash normalization).
- [x] `dotnet format --verify-no-changes` clean.
- [x] Docker smoke test: 254/254 pass, including the new **"long-title upload --wait resolves item (issue #54)"** regression case and all 6 sanitize-drift cases.