### PR TITLE
feat: add item file management (download, delete, ffprobe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ abs-cli config set defaultLibrary <library-id>
 | `items cover set --id <id> [--url \| --file \| --server-path]` | Apply a cover image |
 | `items cover get --id <id> --output <path>` | Download the cover image |
 | `items cover remove --id <id>` | Remove the cover |
+| `items file download --id <id> --ino <ino> --output <path\|->` | Download a single file of an item (requires download) |
+| `items file delete --id <id> --ino <ino>` | Delete a single file from disk (requires delete — destructive) |
+| `items file ffprobe --id <id> --ino <ino>` | Print raw ffprobe data for an audio file (admin) |
 | `items chapters lookup --asin <asin> [--region <r>]` | Look up chapter timings on Audnexus by ASIN |
 | `items chapters set --id <id> {--input <file> \| --stdin}` | Write chapters onto an item (DB + sidecar; does NOT touch audio file) |
 | `items toggle-ebook-status --id <id> --ino <ino>` | Toggle which ebook file is primary on a multi-format item |

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -125,6 +125,7 @@ for cmd in "login" "config get" "config set" \
            "libraries list" "libraries get" "libraries scan" \
            "items list" "items get" \
            "items update" "items batch-update" "items batch-get" "items scan" \
+           "items file download" "items file delete" "items file ffprobe" \
            "series list" "series get" \
            "series update" \
            "narrators list" "narrators rename" "narrators delete" \
@@ -2004,6 +2005,86 @@ if echo "$output" | grep -q "'update' permission"; then
 else
     fail "toggle-ebook-status: readonlyuser hits 'update' permission denial" "unexpected: ${output:0:200}"
 fi
+
+# ============================================================
+echo ""
+echo "=== Item File Management ==="
+# ============================================================
+
+# Pick a seeded audiobook and one of its audio-file inodes.
+AUDIO_ITEM_ID=$($CLI items list --library "$LIB_ID" --limit 100 2>/dev/null \
+    | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for r in d['results']:
+    if r.get('mediaType') == 'book' and r.get('media',{}).get('metadata',{}).get('title','') != 'Multi Ebook Test':
+        print(r['id']); break
+" 2>/dev/null)
+AUDIO_INO=$($CLI items get --id "$AUDIO_ITEM_ID" --expanded 2>/dev/null \
+    | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+audio = [lf for lf in d.get('libraryFiles',[]) if lf.get('fileType')=='audio']
+print(audio[0]['ino'] if audio else '')
+" 2>/dev/null)
+
+if [ -n "$AUDIO_ITEM_ID" ] && [ -n "$AUDIO_INO" ]; then
+    pass "items file: located audiobook + audio inode ($AUDIO_ITEM_ID / $AUDIO_INO)"
+else
+    fail "items file: located audiobook + audio inode" "item=$AUDIO_ITEM_ID ino=$AUDIO_INO"
+fi
+
+# download to a temp file, assert non-empty
+DL_TMP=$(mktemp)
+$CLI items file download --id "$AUDIO_ITEM_ID" --ino "$AUDIO_INO" --output "$DL_TMP" 2>/dev/null > /dev/null
+if [ -s "$DL_TMP" ]; then pass "items file download: wrote non-empty file"; else fail "items file download: wrote non-empty file" "empty/missing"; fi
+rm -f "$DL_TMP"
+
+# ffprobe the same audio file, assert streams + format
+output=$($CLI items file ffprobe --id "$AUDIO_ITEM_ID" --ino "$AUDIO_INO" 2>&1)
+assert_json_key "items file ffprobe returns streams" "streams" "$output"
+assert_json_key "items file ffprobe returns format" "format" "$output"
+
+# delete a throwaway: the supplementary ebook file of the multi-ebook fixture.
+FIX_ITEM_ID=$($CLI items list --library "$LIB_ID" --limit 100 2>/dev/null \
+    | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for r in d['results']:
+    if r.get('media',{}).get('metadata',{}).get('title','')=='Multi Ebook Test':
+        print(r['id']); break
+" 2>/dev/null)
+SUPP_INO=$($CLI items get --id "$FIX_ITEM_ID" --expanded 2>/dev/null \
+    | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+supp = [lf for lf in d.get('libraryFiles',[]) if lf.get('fileType')=='ebook' and lf.get('isSupplementary') is True]
+print(supp[0]['ino'] if supp else '')
+" 2>/dev/null)
+output=$($CLI items file delete --id "$FIX_ITEM_ID" --ino "$SUPP_INO" 2>&1)
+assert_json_expr "items file delete returns success" "d.get('success')=='true'" "$output"
+
+# 403 coverage. These MUST run after AUDIO_ITEM_ID/AUDIO_INO are resolved
+# above: the ABS LibraryItemController.middleware loads the item by :id and
+# returns 404 before reaching the delete/admin permission checks, so an empty
+# id would surface "not found" instead of the permission denial. The earlier
+# Permission Errors / Item Delete groups run before this section, hence the
+# checks live here (each toggles its own login, then restores root).
+abs_login readonlyuser readonlypass
+error_output=$($CLI items file delete --id "$AUDIO_ITEM_ID" --ino "$AUDIO_INO" 2>&1 || true)
+if echo "$error_output" | grep -q "'delete' permission"; then
+    pass "items file delete as readonlyuser hits 'delete' permission denial"
+else
+    fail "items file delete as readonlyuser hits 'delete' permission denial" "got: ${error_output:0:200}"
+fi
+abs_login testuser testpass
+error_output=$($CLI items file ffprobe --id "$AUDIO_ITEM_ID" --ino "$AUDIO_INO" 2>&1 || true)
+if echo "$error_output" | grep -qi "permission denied\|admin"; then
+    pass "items file ffprobe as testuser shows admin permission denied"
+else
+    fail "items file ffprobe as testuser shows admin permission denied" "got: ${error_output:0:200}"
+fi
+abs_login root root
 
 # ============================================================
 echo ""

--- a/docs/abs-api-coverage.md
+++ b/docs/abs-api-coverage.md
@@ -92,10 +92,10 @@ any) that implements it.
 | POST | `/api/items/:id/scan` | Scan item | update | `items scan` ✅ |
 | GET | `/api/items/:id/metadata-object` | Get metadata object | | — |
 | POST | `/api/items/:id/chapters` | Update chapters | update | `items chapters set` ✅ |
-| GET | `/api/items/:id/ffprobe/:fileid` | FFprobe data for file | | — |
+| GET | `/api/items/:id/ffprobe/:fileid` | FFprobe data for file | admin | `items file ffprobe` ✅ |
 | GET | `/api/items/:id/file/:fileid` | Get library file | | — |
-| DELETE | `/api/items/:id/file/:fileid` | Delete library file | delete | — |
-| GET | `/api/items/:id/file/:fileid/download` | Download library file | download | — |
+| DELETE | `/api/items/:id/file/:fileid` | Delete library file | delete | `items file delete` ✅ |
+| GET | `/api/items/:id/file/:fileid/download` | Download library file | download | `items file download` ✅ |
 | GET | `/api/items/:id/ebook/:fileid?` | Get ebook file | | — |
 | PATCH | `/api/items/:id/ebook/:fileid/status` | Toggle ebook primary/supplementary | update | `items toggle-ebook-status` ✅ |
 | POST | `/api/items/batch/delete` | Batch delete | delete | `items batch-delete` ✅ |

--- a/docs/plans/2026-07-13-item-file-management.md
+++ b/docs/plans/2026-07-13-item-file-management.md
@@ -1,0 +1,491 @@
+# Item File Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an `items file` subgroup — `download`, `delete`, `ffprobe` — as thin pass-throughs over the ABS per-file endpoints, keyed by item `--id` + file `--ino`.
+
+**Architecture:** Extend `ItemsService` (3 methods) and `ApiEndpoints` (3 helpers); add `CreateFileCommand()` to `ItemsCommand`. Reuse existing patterns: `download` mirrors `items cover get` (stream → file/stdout, reusing `CoverFileSavedDescriptor`); `delete` mirrors `authors delete` (`{ "success": "true" }`); `ffprobe` mirrors `authors lookup` (raw JSON passthrough). No new models.
+
+**Tech Stack:** C# / .NET, System.CommandLine, xUnit.
+
+**Spec:** `docs/specs/2026-07-13-item-file-management-design.md`
+
+**Conventions:** No unnecessary blank lines in method bodies. `dotnet format AbsCli.sln` before each commit. Conventional Commits, imperative lowercase no period; NO `Co-Authored-By`, NO "Generated with Claude Code". Do NOT edit `CHANGELOG.md`.
+
+**Permission tag ↔ hint mirroring:** `download` ↔ `"'download' permission"`; `delete` ↔ `"'delete' permission"`; `admin` ↔ `"admin permission"` (no quotes around admin).
+
+---
+
+## File Structure
+
+Modified:
+- `src/AbsCli/Api/ApiEndpoints.cs` — `ItemFile`, `ItemFileDownload`, `ItemFfprobe`
+- `src/AbsCli/Services/ItemsService.cs` — `DownloadFileStreamAsync`, `DeleteFileAsync`, `FfprobeAsync`
+- `src/AbsCli/Commands/ItemsCommand.cs` — `CreateFileCommand()` + register in `Create()`
+- `tests/AbsCli.Tests/Api/ApiEndpointsTests.cs` — 3 new assertions
+- `tests/AbsCli.Tests/Commands/ItemsCommandTests.cs` — file-subgroup tests
+- `README.md`, `docs/abs-api-coverage.md`, `docker/smoke-test.sh`
+
+No new models / `JsonContext` / generator changes.
+
+---
+
+## Task 1: Endpoint helpers
+
+**Files:** Modify `src/AbsCli/Api/ApiEndpoints.cs`; append to `tests/AbsCli.Tests/Api/ApiEndpointsTests.cs`.
+
+- [ ] **Step 1: Add failing tests**
+
+Append inside the `ApiEndpointsTests` class (before its closing brace):
+
+```csharp
+    [Fact]
+    public void ItemFile_BuildsPath()
+    {
+        Assert.Equal("api/items/li_1/file/12345", ApiEndpoints.ItemFile("li_1", "12345"));
+    }
+
+    [Fact]
+    public void ItemFileDownload_BuildsPath()
+    {
+        Assert.Equal("api/items/li_1/file/12345/download", ApiEndpoints.ItemFileDownload("li_1", "12345"));
+    }
+
+    [Fact]
+    public void ItemFfprobe_BuildsPath()
+    {
+        Assert.Equal("api/items/li_1/ffprobe/12345", ApiEndpoints.ItemFfprobe("li_1", "12345"));
+    }
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `dotnet test tests/AbsCli.Tests --filter ApiEndpointsTests`
+Expected: FAIL (members don't exist).
+
+- [ ] **Step 3: Add the endpoints**
+
+In `src/AbsCli/Api/ApiEndpoints.cs`, near the other `Item*` helpers (after `ItemEbookFileStatus`):
+
+```csharp
+    public static string ItemFile(string id, string ino) => $"api/items/{id}/file/{ino}";
+    public static string ItemFileDownload(string id, string ino) => $"api/items/{id}/file/{ino}/download";
+    public static string ItemFfprobe(string id, string ino) => $"api/items/{id}/ffprobe/{ino}";
+```
+
+(Plain interpolation of `ino`, matching the existing `ItemEbookFileStatus` precedent.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet test tests/AbsCli.Tests --filter ApiEndpointsTests`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dotnet format AbsCli.sln
+git add src/AbsCli/Api/ApiEndpoints.cs tests/AbsCli.Tests/Api/ApiEndpointsTests.cs
+git commit -m "feat: add item file/ffprobe endpoint helpers"
+```
+
+---
+
+## Task 2: ItemsService methods
+
+**Files:** Modify `src/AbsCli/Services/ItemsService.cs`. No new unit tests (thin pass-through; covered by endpoint tests, command tests, live smoke).
+
+- [ ] **Step 1: Add the three methods**
+
+Add to `ItemsService` (confirm signatures against existing usage: `GetStreamAsync(endpoint, permissionHint?)`, `DeleteAsync(endpoint, permissionHint?)`, `GetAsync(endpoint, permissionHint?)` — all already used in this file / `CoversService`). Add `using System.IO;` only if not already available via global usings (it is — omit unless the build complains):
+
+```csharp
+    public async Task<Stream> DownloadFileStreamAsync(string id, string ino)
+    {
+        return await _client.GetStreamAsync(ApiEndpoints.ItemFileDownload(id, ino), "'download' permission");
+    }
+
+    public async Task DeleteFileAsync(string id, string ino)
+    {
+        await _client.DeleteAsync(ApiEndpoints.ItemFile(id, ino), "'delete' permission");
+    }
+
+    public async Task<string> FfprobeAsync(string id, string ino)
+    {
+        return await _client.GetAsync(ApiEndpoints.ItemFfprobe(id, ino), "admin permission");
+    }
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build src/AbsCli`
+Expected: 0 errors.
+
+- [ ] **Step 3: Format and commit**
+
+```bash
+dotnet format AbsCli.sln
+git add src/AbsCli/Services/ItemsService.cs
+git commit -m "feat: add item file download/delete/ffprobe service methods"
+```
+
+---
+
+## Task 3: `items file` command subgroup
+
+**Files:** Modify `src/AbsCli/Commands/ItemsCommand.cs`; extend `tests/AbsCli.Tests/Commands/ItemsCommandTests.cs`.
+
+- [ ] **Step 1: Add failing tests**
+
+Append inside the `ItemsCommandTests` class:
+
+```csharp
+    private static List<string> FileSubVerbs()
+    {
+        var items = ItemsCommand.Create();
+        var file = items.Subcommands.First(c => c.Name == "file");
+        return file.Subcommands.Select(c => c.Name).ToList();
+    }
+
+    [Fact]
+    public void ItemsFile_HasDownloadDeleteFfprobe()
+    {
+        Assert.Equal(new[] { "download", "delete", "ffprobe" }, FileSubVerbs());
+    }
+
+    [Fact]
+    public void ItemsFileDownload_RequiresDownloadPermissionAndOptions()
+    {
+        var output = RenderHelp("items", "file", "download").Replace("\r\n", "\n");
+        Assert.Contains("Permission required:\n  download", output);
+        Assert.Contains("--id", output);
+        Assert.Contains("--ino", output);
+        Assert.Contains("--output", output);
+    }
+
+    [Fact]
+    public void ItemsFileDelete_RequiresDeletePermission_AndWarnsOnDiskDeletion()
+    {
+        var output = RenderHelp("items", "file", "delete").Replace("\r\n", "\n");
+        Assert.Contains("Permission required:\n  delete", output);
+        Assert.Contains("disk", output.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void ItemsFileFfprobe_RequiresAdmin_AndDocumentsAudioOnly()
+    {
+        var output = RenderHelp("items", "file", "ffprobe").Replace("\r\n", "\n");
+        Assert.Contains("Permission required:\n  admin", output);
+        Assert.Contains("audio", output.ToLowerInvariant());
+    }
+```
+
+(The existing `ItemsCommandTests.cs` already has the `RenderHelp` harness — reuse it. The class already has `using System.Linq` via global usings for `.First`/`.Select`.)
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `dotnet test tests/AbsCli.Tests --filter ItemsCommandTests`
+Expected: FAIL (no `file` subcommand).
+
+- [ ] **Step 3: Add `CreateFileCommand()` and register it**
+
+In `ItemsCommand.Create()`, register alongside the other subgroups (e.g. after the `CreateProgressCommand()` line):
+
+```csharp
+        command.Subcommands.Add(CreateFileCommand());
+```
+
+Add these methods to the class:
+
+```csharp
+    private static Command CreateFileCommand()
+    {
+        var command = new Command("file", "Manage individual files of a library item (download, delete, ffprobe)");
+        command.Subcommands.Add(CreateFileDownloadCommand());
+        command.Subcommands.Add(CreateFileDeleteCommand());
+        command.Subcommands.Add(CreateFileFfprobeCommand());
+        return command;
+    }
+
+    private static Command CreateFileDownloadCommand()
+    {
+        var idOption = new Option<string>("--id") { Description = "Library item ID", Required = true };
+        var inoOption = new Option<string>("--ino") { Description = "File inode (from items get --expanded → libraryFiles[].ino)", Required = true };
+        var outputOption = new Option<string>("--output") { Description = "Output file path, or '-' for binary to stdout", Required = true };
+        var command = new Command("download", "Download a single file of a library item") { idOption, inoOption, outputOption };
+        command.AddPermissionRequired("download");
+        command.AddExamples(
+            "abs-cli items file download --id \"li_abc\" --ino \"12345\" --output track01.mp3",
+            "abs-cli items file download --id \"li_abc\" --ino \"12345\" --output - > track01.mp3");
+        command.AddResponseExample<CoverFileSavedDescriptor>();
+        command.SetAction(async parseResult =>
+        {
+            var id = parseResult.GetValue(idOption)!;
+            var ino = parseResult.GetValue(inoOption)!;
+            var output = parseResult.GetValue(outputOption)!;
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new ItemsService(client);
+            await using var stream = await service.DownloadFileStreamAsync(id, ino);
+            if (output == "-")
+            {
+                await using var stdout = Console.OpenStandardOutput();
+                await stream.CopyToAsync(stdout);
+                return;
+            }
+            long bytes;
+            await using (var fileStream = new FileStream(output, FileMode.Create, FileAccess.Write))
+            {
+                await stream.CopyToAsync(fileStream);
+                bytes = fileStream.Length;
+            }
+            var descriptor = new CoverFileSavedDescriptor { Path = output, Bytes = bytes };
+            ConsoleOutput.WriteJson(descriptor, AppJsonContext.Default.CoverFileSavedDescriptor);
+        });
+        return command;
+    }
+
+    private static Command CreateFileDeleteCommand()
+    {
+        var idOption = new Option<string>("--id") { Description = "Library item ID", Required = true };
+        var inoOption = new Option<string>("--ino") { Description = "File inode (from items get --expanded → libraryFiles[].ino)", Required = true };
+        var command = new Command("delete", "Delete a single file of a library item") { idOption, inoOption };
+        command.AddPermissionRequired("delete");
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "DESTRUCTIVE: permanently deletes the file from disk (not just the DB",
+            "record). If it is the item's last media file, the item is marked",
+            "missing. No confirmation prompt.");
+        command.AddExamples(
+            "abs-cli items file delete --id \"li_abc\" --ino \"12345\"");
+        command.AddShapeSection("Response shape",
+            "{ \"success\": \"true\" }");
+        command.SetAction(async parseResult =>
+        {
+            var id = parseResult.GetValue(idOption)!;
+            var ino = parseResult.GetValue(inoOption)!;
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new ItemsService(client);
+            await service.DeleteFileAsync(id, ino);
+            ConsoleOutput.WriteJson(new Dictionary<string, string> { ["success"] = "true" });
+        });
+        return command;
+    }
+
+    private static Command CreateFileFfprobeCommand()
+    {
+        var idOption = new Option<string>("--id") { Description = "Library item ID", Required = true };
+        var inoOption = new Option<string>("--ino") { Description = "Audio file inode (from items get --expanded → libraryFiles[].ino)", Required = true };
+        var command = new Command("ffprobe", "Print raw ffprobe data for an audio file") { idOption, inoOption };
+        command.AddPermissionRequired("admin");
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "Admin only. Audio files only — a non-audio inode returns Not found",
+            "(exit 2). Output is the raw ffprobe JSON (streams, format, chapters),",
+            "passed through unmodified.");
+        command.AddExamples(
+            "abs-cli items file ffprobe --id \"li_abc\" --ino \"12345\"");
+        command.SetAction(async parseResult =>
+        {
+            var id = parseResult.GetValue(idOption)!;
+            var ino = parseResult.GetValue(inoOption)!;
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new ItemsService(client);
+            var json = await service.FfprobeAsync(id, ino);
+            ConsoleOutput.WriteRawJson(json);
+        });
+        return command;
+    }
+```
+
+Verify against existing `ItemsCommand` code: `AddPermissionRequired`, `AddHelpSection`, `AddExamples`, `AddResponseExample<T>`, `AddShapeSection`, `CommandHelper.BuildClient()`, `ConsoleOutput.WriteJson`/`WriteRawJson`, `CoverFileSavedDescriptor` are all already used in this file (cover get uses the descriptor; authors delete uses the `{success:true}` shape). Adjust to match real signatures if any differ.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet test tests/AbsCli.Tests --filter ItemsCommandTests`
+Expected: PASS (existing + 4 new).
+
+- [ ] **Step 5: Confirm wiring**
+
+Run: `dotnet run --project src/AbsCli -- items file --help`
+Expected: shows `download`, `delete`, `ffprobe`.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+dotnet format AbsCli.sln
+git add src/AbsCli/Commands/ItemsCommand.cs tests/AbsCli.Tests/Commands/ItemsCommandTests.cs
+git status --short   # if ResponseExamples.g.cs shows modified, revert: git checkout src/AbsCli/Commands/ResponseExamples.g.cs
+git commit -m "feat: add items file subgroup (download, delete, ffprobe)"
+```
+
+---
+
+## Task 4: Docs — README + coverage map
+
+**Files:** Modify `README.md`, `docs/abs-api-coverage.md`.
+
+- [ ] **Step 1: README Commands table**
+
+Add three rows near the other `items …` rows (e.g. after the `items cover …` rows):
+
+```markdown
+| `items file download --id <id> --ino <ino> --output <path\|->` | Download a single file of an item (requires download) |
+| `items file delete --id <id> --ino <ino>` | Delete a single file from disk (requires delete — destructive) |
+| `items file ffprobe --id <id> --ino <ino>` | Print raw ffprobe data for an audio file (admin) |
+```
+
+Match the surrounding column format.
+
+- [ ] **Step 2: Coverage doc**
+
+In `docs/abs-api-coverage.md`, update the four `items` file/ffprobe rows:
+- `| GET | \`/api/items/:id/ffprobe/:fileid\` | FFprobe data for file | | — |` → **permission column `admin`** (fix), last column `` `items file ffprobe` ✅ ``.
+- `| GET | \`/api/items/:id/file/:fileid\` | Get library file | | — |` → leave permission blank, last column stays `—` (not exposed).
+- `| DELETE | \`/api/items/:id/file/:fileid\` | Delete library file | delete | — |` → last column `` `items file delete` ✅ ``.
+- `| GET | \`/api/items/:id/file/:fileid/download\` | Download library file | download | — |` → last column `` `items file download` ✅ ``.
+
+- [ ] **Step 3: Verify**
+
+```bash
+rg -n "ffprobe|file/:fileid" docs/abs-api-coverage.md
+rg -n "items file" README.md
+```
+Confirm the ffprobe row shows `admin` and download/delete/ffprobe show ✅; the plain `file/:fileid` row is unchanged (`—`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/abs-api-coverage.md
+git commit -m "docs: document items file commands and fix ffprobe permission"
+```
+
+---
+
+## Task 5: Smoke test
+
+**Files:** Modify `docker/smoke-test.sh`. No `seed.sh` change (existing seeded audiobooks + multi-ebook fixture suffice).
+
+- [ ] **Step 1: Help-example enumeration**
+
+Add to the leaf-command loop (backslash-continued):
+```bash
+           "items file download" "items file delete" "items file ffprobe" \
+```
+(No parent-loop change needed; `items` is already covered. Optionally the `items file` group itself renders help — the parent loop asserts `Description:`/`Usage:` for group commands, so adding `"items file"` there is fine but not required.)
+
+- [ ] **Step 2: Add an "Item File" smoke section**
+
+Place it AFTER the "Items Get Expanded" and "Toggle Ebook Status" sections (both depend on the multi-ebook fixture having BOTH ebook files — the delete below removes one). Use the existing helpers (`assert_json_key`, `assert_json_expr`, `pass`, `fail`, `abs_login`). Ensure it runs as `root` (admin) for the happy-path (ffprobe needs admin); the smoke is logged in as root by default in the main body.
+
+```bash
+# ============================================================
+echo ""
+echo "=== Item File Management ==="
+# ============================================================
+
+# Pick a seeded audiobook and one of its audio-file inodes.
+AUDIO_ITEM_ID=$($CLI items list --library "$LIB_ID" --limit 100 2>/dev/null \
+    | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for r in d['results']:
+    if r.get('media',{}).get('numAudioFiles',0) or r.get('mediaType')=='book':
+        print(r['id']); break
+" 2>/dev/null)
+AUDIO_INO=$($CLI items get --id "$AUDIO_ITEM_ID" --expanded 2>/dev/null \
+    | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+audio = [lf for lf in d.get('libraryFiles',[]) if lf.get('fileType')=='audio']
+print(audio[0]['ino'] if audio else '')
+" 2>/dev/null)
+
+# download to a temp file, assert non-empty
+DL_TMP=$(mktemp)
+$CLI items file download --id "$AUDIO_ITEM_ID" --ino "$AUDIO_INO" --output "$DL_TMP" 2>/dev/null > /dev/null
+if [ -s "$DL_TMP" ]; then pass "items file download: wrote non-empty file"; else fail "items file download: wrote non-empty file" "empty/missing"; fi
+rm -f "$DL_TMP"
+
+# ffprobe the same audio file, assert streams + format
+output=$($CLI items file ffprobe --id "$AUDIO_ITEM_ID" --ino "$AUDIO_INO" 2>&1)
+assert_json_key "items file ffprobe returns streams" "streams" "$output"
+assert_json_key "items file ffprobe returns format" "format" "$output"
+
+# delete a throwaway: the supplementary ebook file of the multi-ebook fixture.
+FIX_ITEM_ID=$($CLI items list --library "$LIB_ID" --limit 100 2>/dev/null \
+    | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for r in d['results']:
+    if r.get('media',{}).get('metadata',{}).get('title','')=='Multi Ebook Test':
+        print(r['id']); break
+" 2>/dev/null)
+SUPP_INO=$($CLI items get --id "$FIX_ITEM_ID" --expanded 2>/dev/null \
+    | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+supp = [lf for lf in d.get('libraryFiles',[]) if lf.get('fileType')=='ebook' and lf.get('isSupplementary') is True]
+print(supp[0]['ino'] if supp else '')
+" 2>/dev/null)
+output=$($CLI items file delete --id "$FIX_ITEM_ID" --ino "$SUPP_INO" 2>&1)
+assert_json_expr "items file delete returns success" "d.get('success')=='true'" "$output"
+```
+
+- [ ] **Step 3: 403 assertions**
+
+In the permission-denial area (search `abs_login readonlyuser readonlypass` / the `testuser` admin-denial group), add:
+
+readonlyuser (delete denial):
+```bash
+error_output=$($CLI items file delete --id "$AUDIO_ITEM_ID" --ino "$AUDIO_INO" 2>&1 || true)
+if echo "$error_output" | grep -q "'delete' permission"; then
+    pass "items file delete as readonlyuser hits 'delete' permission denial"
+else
+    fail "items file delete as readonlyuser hits 'delete' permission denial" "got: ${error_output:0:200}"
+fi
+```
+
+testuser (admin denial):
+```bash
+error_output=$($CLI items file ffprobe --id "$AUDIO_ITEM_ID" --ino "$AUDIO_INO" 2>&1 || true)
+if echo "$error_output" | grep -qi "permission denied\|admin"; then
+    pass "items file ffprobe as testuser shows admin permission denied"
+else
+    fail "items file ffprobe as testuser shows admin permission denied" "got: ${error_output:0:200}"
+fi
+```
+Ensure `$AUDIO_ITEM_ID` / `$AUDIO_INO` are shell globals set earlier (Step 2 runs in the main root-authenticated body, before the permission-denial section). Keep the section's trailing `abs_login root root`.
+
+- [ ] **Step 4: Run the smoke test**
+
+```bash
+cd docker && docker compose up -d
+IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+ABS_URL=http://$IP:80 bash docker/seed.sh
+ABS_URL=http://$IP:80 bash docker/smoke-test.sh
+```
+Expected: all pass, exit 0. If `fileType`/`isSupplementary`/`numAudioFiles` field names differ from what the accessors assume, inspect a live `items get --expanded` payload and adjust the python extraction. Only mark "smoke passed" after seeing it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/smoke-test.sh
+git commit -m "test: add items file smoke assertions and 403 coverage"
+```
+
+---
+
+## Task 6: Full verification
+
+- [ ] **Step 1: Full unit run** — `dotnet test AbsCli.sln` → all pass (incl. `ResponseExamplesDriftTest`).
+- [ ] **Step 2: Format check** — `dotnet format AbsCli.sln --verify-no-changes` → clean (else format + commit `chore: fix formatting`).
+- [ ] **Step 3: Wiring** — `dotnet run --project src/AbsCli -- items file --help` shows the three verbs.
+- [ ] **Step 4: Smoke gate** — confirm Task 5's smoke passed. Gates the PR checkbox — do not check unverified.
+
+---
+
+## Self-Review Notes (author checklist — completed during planning)
+
+- **Spec coverage:** download (Task 1/2/3), delete (destructive, `{success:true}`, on-disk warning), ffprobe (admin, raw JSON, audio-only), coverage-doc fix incl. ffprobe blank→admin (Task 4), smoke incl. download-bytes / ffprobe-JSON / throwaway-delete / 403s (Task 5). `getLibraryFile` intentionally not exposed. No new models.
+- **Reuse:** `CoverFileSavedDescriptor` (already registered — no generator/JsonContext change), `authors delete` `{success:true}` shape, `authors lookup` raw-JSON passthrough.
+- **Permission mirroring:** download↔`'download' permission`, delete↔`'delete' permission`, ffprobe↔`admin permission`. Command tests assert the full `Permission required:\n  <token>` line.
+- **Smoke ordering:** the throwaway-delete of the multi-ebook fixture's supplementary file runs AFTER the get-expanded/toggle-ebook sections so it doesn't disturb them.
+- **Type consistency:** `DownloadFileStreamAsync`/`DeleteFileAsync`/`FfprobeAsync` signatures match their call sites; endpoints `ItemFile`/`ItemFileDownload`/`ItemFfprobe` match service + tests.
+- **CHANGELOG untouched** (release-owned).

--- a/docs/specs/2026-07-13-item-file-management-design.md
+++ b/docs/specs/2026-07-13-item-file-management-design.md
@@ -1,0 +1,121 @@
+# Item File Management — Design
+
+Date: 2026-07-13
+Status: Approved (brainstorm)
+
+## Goal
+
+Add CLI coverage for per-file operations on a library item: download a file,
+delete a file, and read raw ffprobe data. Thin 1:1 pass-through. New `items file`
+subgroup.
+
+## API reference (verified against ABS v2.35.1 — LibraryItemController)
+
+`:fileid` is the file's **inode** (`ino`), the same identifier used by
+`items toggle-ebook-status --ino` and surfaced in
+`items get --expanded → libraryFiles[].ino`. The controller middleware resolves
+`req.libraryFile = getLibraryFileWithIno(fileid)`; unknown ino → 404.
+
+| Endpoint | Handler | Behavior | Permission |
+|---|---|---|---|
+| `GET /api/items/:id/file/:fileid/download` | `downloadLibraryFile` | Streams raw file bytes as an attachment (filename set). | `download` (`canDownload`) |
+| `DELETE /api/items/:id/file/:fileid` | `deleteLibraryFile` | **Deletes the file from disk** (`fs.remove`) and updates the item: drops it from `libraryFiles`/`audioFiles`/`ebookFile` (or removes the podcast episode); if no media files remain, sets `isMissing`. Returns `200` empty. | `delete` (`canDelete`, checked in middleware for DELETE) |
+| `GET /api/items/:id/ffprobe/:fileid` | `getFFprobeData` | Runs ffprobe server-side on the audio file, returns the raw ffprobe JSON verbatim. **Audio files only** — non-audio ino → 404. | **admin** (`isAdminOrUp`) |
+
+Not exposed: `GET /api/items/:id/file/:fileid` (`getLibraryFile`) — streams the
+same bytes inline without the download-permission check; deliberately omitted as
+redundant with the `/download` variant.
+
+**Coverage-doc bug:** `GET /api/items/:id/ffprobe/:fileid` is listed with a blank
+permission — it is actually **admin**. Must be fixed.
+
+## Command structure
+
+New `items file` subgroup registered in `ItemsCommand.Create()` (alongside
+`cover`/`chapters`/`progress`). Common options: `--id` (item ID, required),
+`--ino` (file inode, required; help points at `items get --expanded →
+libraryFiles[].ino`).
+
+```
+abs-cli items file download --id <id> --ino <ino> --output <path|->
+abs-cli items file delete   --id <id> --ino <ino>
+abs-cli items file ffprobe  --id <id> --ino <ino>
+```
+
+### download
+- Tag `download`; service hint `"'download' permission"`.
+- Streams to `--output <path>` file, or `-` for raw bytes to stdout — mirrors
+  `items cover get` (`CoversService.GetStreamAsync` → copy to file/stdout).
+- `--output` required.
+- On file save, print the saved-file descriptor (`{ path, bytes }`) like
+  `items cover get` / `authors image get`; `-` writes bytes to stdout only.
+
+### delete
+- Tag `delete`; service hint `"'delete' permission"`.
+- Returns `200` empty → CLI prints `{ "success": "true" }` (matches
+  `authors delete`).
+- No confirmation prompt. `--help` warns prominently: permanently deletes the
+  file from disk (not just a DB record); if it is the item's last media file the
+  item becomes missing.
+
+### ffprobe
+- Tag `admin`; service hint `"admin permission"`.
+- Raw JSON passed straight through (`ConsoleOutput.WriteRawJson`, like
+  `authors lookup`). No model.
+- `--help`: admin-only; audio files only (non-audio ino → exit 2, "Not found").
+
+## Files
+
+Modified:
+- `src/AbsCli/Api/ApiEndpoints.cs` — add:
+  - `ItemFileDownload(string id, string ino) => $"api/items/{id}/file/{ino}/download"`
+  - `ItemFile(string id, string ino) => $"api/items/{id}/file/{ino}"`
+  - `ItemFfprobe(string id, string ino) => $"api/items/{id}/ffprobe/{ino}"`
+  (Plain interpolation of `ino`, matching the existing `ItemEbookFileStatus`
+  precedent — no base64.)
+- `src/AbsCli/Services/ItemsService.cs` — add:
+  - `Task<Stream> DownloadFileStreamAsync(string id, string ino)` → `GetStreamAsync(endpoint, "'download' permission")`
+  - `Task DeleteFileAsync(string id, string ino)` → `DeleteAsync(endpoint, "'delete' permission")`
+  - `Task<string> FfprobeAsync(string id, string ino)` → `GetAsync(endpoint, "admin permission")` (raw JSON string)
+- `src/AbsCli/Commands/ItemsCommand.cs` — add `CreateFileCommand()` (the `file`
+  group + three leaf subcommands) and register it in `Create()`.
+- `README.md`, `docs/abs-api-coverage.md`.
+
+No new models, `JsonContext`, or response-example generator changes (bytes /
+empty-200 / raw-JSON passthrough).
+
+## Docs
+- README Commands table: add three `items file …` rows.
+- Coverage doc: mark `download`/`delete`/`ffprobe` rows ✅, and **fix the
+  `ffprobe` permission column blank → admin**. `getLibraryFile` row stays `—`
+  (intentionally not exposed).
+
+## Testing
+- Unit:
+  - `ApiEndpointsTests` — the three new helpers build the expected paths.
+  - `ItemsCommandTests` — `items file` has `download`/`delete`/`ffprobe`;
+    permission tags (`download`/`delete`/`admin`); `--id`/`--ino`/`--output`
+    present where expected; delete `--help` documents on-disk deletion; ffprobe
+    `--help` documents admin/audio-only.
+- Smoke (`docker/smoke-test.sh`):
+  - Add `items file`/`items file download`/`items file delete`/`items file
+    ffprobe` to the help-example enumeration loops.
+  - `download`: pick an audio item, read a `libraryFiles[].ino` via
+    `items get --expanded`, download to a temp path, assert bytes > 0.
+  - `ffprobe`: same audio ino → assert JSON has `streams` and `format`.
+  - `delete`: use a **throwaway** file — the seeded multi-ebook fixture has two
+    ebook files; read one ebook file's ino and delete it, assert
+    `{ success: "true" }` and that the item still exists (survives with the other
+    file). (If the fixture is unavailable, upload a small dedicated throwaway item
+    and delete one of its files.)
+  - 403s: `items file delete` as `readonlyuser` (no delete) → `'delete'`
+    denial; `items file ffprobe` as `testuser` (non-admin) → admin denial.
+  - Run `docker/smoke-test.sh` before the PR; only then mark it passed.
+
+## Out of scope (YAGNI)
+- `getLibraryFile` (redundant with `download`).
+- No confirmation prompt on delete.
+- No file-metadata command (that data is in `items get --expanded`).
+
+## Notes
+- Do NOT edit `CHANGELOG.md` (release-owned).

--- a/src/AbsCli/Api/ApiEndpoints.cs
+++ b/src/AbsCli/Api/ApiEndpoints.cs
@@ -17,6 +17,9 @@ public static class ApiEndpoints
     public static string ItemCover(string id) => $"api/items/{id}/cover";
     public static string ItemChapters(string id) => $"api/items/{id}/chapters";
     public static string ItemEbookFileStatus(string id, string fileIno) => $"api/items/{id}/ebook/{fileIno}/status";
+    public static string ItemFile(string id, string ino) => $"api/items/{id}/file/{ino}";
+    public static string ItemFileDownload(string id, string ino) => $"api/items/{id}/file/{ino}/download";
+    public static string ItemFfprobe(string id, string ino) => $"api/items/{id}/ffprobe/{ino}";
     public const string ItemsBatchUpdate = "api/items/batch/update";
     public const string ItemsBatchGet = "api/items/batch/get";
     public const string ItemsBatchDelete = "api/items/batch/delete";

--- a/src/AbsCli/Commands/ItemsCommand.cs
+++ b/src/AbsCli/Commands/ItemsCommand.cs
@@ -43,6 +43,7 @@ public static class ItemsCommand
         command.Subcommands.Add(CreateEncodeM4bCommand());
         command.Subcommands.Add(CreateChaptersCommand());
         command.Subcommands.Add(CreateProgressCommand());
+        command.Subcommands.Add(CreateFileCommand());
         command.Subcommands.Add(CreateEmbedMetadataCommand());
         command.Subcommands.Add(CreateBatchEmbedMetadataCommand());
         command.Subcommands.Add(CreateToggleEbookStatusCommand());
@@ -851,6 +852,102 @@ public static class ItemsCommand
             await service.RemoveAsync(lid);
             ConsoleOutput.WriteJson(new Dictionary<string, string> { ["success"] = "true" });
             return 0;
+        });
+        return command;
+    }
+
+    private static Command CreateFileCommand()
+    {
+        var command = new Command("file", "Manage individual files of a library item (download, delete, ffprobe)");
+        command.Subcommands.Add(CreateFileDownloadCommand());
+        command.Subcommands.Add(CreateFileDeleteCommand());
+        command.Subcommands.Add(CreateFileFfprobeCommand());
+        return command;
+    }
+
+    private static Command CreateFileDownloadCommand()
+    {
+        var idOption = new Option<string>("--id") { Description = "Library item ID", Required = true };
+        var inoOption = new Option<string>("--ino") { Description = "File inode (from items get --expanded → libraryFiles[].ino)", Required = true };
+        var outputOption = new Option<string>("--output") { Description = "Output file path, or '-' for binary to stdout", Required = true };
+        var command = new Command("download", "Download a single file of a library item") { idOption, inoOption, outputOption };
+        command.AddPermissionRequired("download");
+        command.AddExamples(
+            "abs-cli items file download --id \"li_abc\" --ino \"12345\" --output track01.mp3",
+            "abs-cli items file download --id \"li_abc\" --ino \"12345\" --output - > track01.mp3");
+        command.AddResponseExample<CoverFileSavedDescriptor>();
+        command.SetAction(async parseResult =>
+        {
+            var id = parseResult.GetValue(idOption)!;
+            var ino = parseResult.GetValue(inoOption)!;
+            var output = parseResult.GetValue(outputOption)!;
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new ItemsService(client);
+            await using var stream = await service.DownloadFileStreamAsync(id, ino);
+            if (output == "-")
+            {
+                await using var stdout = Console.OpenStandardOutput();
+                await stream.CopyToAsync(stdout);
+                return;
+            }
+            long bytes;
+            await using (var fileStream = new FileStream(output, FileMode.Create, FileAccess.Write))
+            {
+                await stream.CopyToAsync(fileStream);
+                bytes = fileStream.Length;
+            }
+            var descriptor = new CoverFileSavedDescriptor { Path = output, Bytes = bytes };
+            ConsoleOutput.WriteJson(descriptor, AppJsonContext.Default.CoverFileSavedDescriptor);
+        });
+        return command;
+    }
+
+    private static Command CreateFileDeleteCommand()
+    {
+        var idOption = new Option<string>("--id") { Description = "Library item ID", Required = true };
+        var inoOption = new Option<string>("--ino") { Description = "File inode (from items get --expanded → libraryFiles[].ino)", Required = true };
+        var command = new Command("delete", "Delete a single file of a library item") { idOption, inoOption };
+        command.AddPermissionRequired("delete");
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "DESTRUCTIVE: permanently deletes the file from disk (not just the DB",
+            "record). If it is the item's last media file, the item is marked",
+            "missing. No confirmation prompt.");
+        command.AddExamples(
+            "abs-cli items file delete --id \"li_abc\" --ino \"12345\"");
+        command.AddShapeSection("Response shape",
+            "{ \"success\": \"true\" }");
+        command.SetAction(async parseResult =>
+        {
+            var id = parseResult.GetValue(idOption)!;
+            var ino = parseResult.GetValue(inoOption)!;
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new ItemsService(client);
+            await service.DeleteFileAsync(id, ino);
+            ConsoleOutput.WriteJson(new Dictionary<string, string> { ["success"] = "true" });
+        });
+        return command;
+    }
+
+    private static Command CreateFileFfprobeCommand()
+    {
+        var idOption = new Option<string>("--id") { Description = "Library item ID", Required = true };
+        var inoOption = new Option<string>("--ino") { Description = "Audio file inode (from items get --expanded → libraryFiles[].ino)", Required = true };
+        var command = new Command("ffprobe", "Print raw ffprobe data for an audio file") { idOption, inoOption };
+        command.AddPermissionRequired("admin");
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "Admin only. Audio files only — a non-audio inode returns Not found",
+            "(exit 2). Output is the raw ffprobe JSON (streams, format, chapters),",
+            "passed through unmodified.");
+        command.AddExamples(
+            "abs-cli items file ffprobe --id \"li_abc\" --ino \"12345\"");
+        command.SetAction(async parseResult =>
+        {
+            var id = parseResult.GetValue(idOption)!;
+            var ino = parseResult.GetValue(inoOption)!;
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new ItemsService(client);
+            var json = await service.FfprobeAsync(id, ino);
+            ConsoleOutput.WriteRawJson(json);
         });
         return command;
     }

--- a/src/AbsCli/Services/ItemsService.cs
+++ b/src/AbsCli/Services/ItemsService.cs
@@ -110,4 +110,19 @@ public class ItemsService
             jsonBody: "",
             permissionHint: "'update' permission");
     }
+
+    public async Task<Stream> DownloadFileStreamAsync(string id, string ino)
+    {
+        return await _client.GetStreamAsync(ApiEndpoints.ItemFileDownload(id, ino), "'download' permission");
+    }
+
+    public async Task DeleteFileAsync(string id, string ino)
+    {
+        await _client.DeleteAsync(ApiEndpoints.ItemFile(id, ino), "'delete' permission");
+    }
+
+    public async Task<string> FfprobeAsync(string id, string ino)
+    {
+        return await _client.GetAsync(ApiEndpoints.ItemFfprobe(id, ino), "admin permission");
+    }
 }

--- a/tests/AbsCli.Tests/Api/ApiEndpointsTests.cs
+++ b/tests/AbsCli.Tests/Api/ApiEndpointsTests.cs
@@ -46,4 +46,22 @@ public class ApiEndpointsTests
         // "a" -> base64 "YQ==" -> URI-escaped "YQ%3D%3D"
         Assert.Equal("api/libraries/lib_1/narrators/YQ%3D%3D", ApiEndpoints.LibraryNarratorByName("lib_1", "a"));
     }
+
+    [Fact]
+    public void ItemFile_BuildsPath()
+    {
+        Assert.Equal("api/items/li_1/file/12345", ApiEndpoints.ItemFile("li_1", "12345"));
+    }
+
+    [Fact]
+    public void ItemFileDownload_BuildsPath()
+    {
+        Assert.Equal("api/items/li_1/file/12345/download", ApiEndpoints.ItemFileDownload("li_1", "12345"));
+    }
+
+    [Fact]
+    public void ItemFfprobe_BuildsPath()
+    {
+        Assert.Equal("api/items/li_1/ffprobe/12345", ApiEndpoints.ItemFfprobe("li_1", "12345"));
+    }
 }

--- a/tests/AbsCli.Tests/Commands/ItemsCommandTests.cs
+++ b/tests/AbsCli.Tests/Commands/ItemsCommandTests.cs
@@ -71,4 +71,43 @@ public class ItemsCommandTests
     {
         Assert.DoesNotContain("Permission required:", RenderHelp("items", "list"));
     }
+
+    private static List<string> FileSubVerbs()
+    {
+        var items = ItemsCommand.Create();
+        var file = items.Subcommands.First(c => c.Name == "file");
+        return file.Subcommands.Select(c => c.Name).ToList();
+    }
+
+    [Fact]
+    public void ItemsFile_HasDownloadDeleteFfprobe()
+    {
+        Assert.Equal(new[] { "download", "delete", "ffprobe" }, FileSubVerbs());
+    }
+
+    [Fact]
+    public void ItemsFileDownload_RequiresDownloadPermissionAndOptions()
+    {
+        var output = RenderHelp("items", "file", "download").Replace("\r\n", "\n");
+        Assert.Contains("Permission required:\n  download", output);
+        Assert.Contains("--id", output);
+        Assert.Contains("--ino", output);
+        Assert.Contains("--output", output);
+    }
+
+    [Fact]
+    public void ItemsFileDelete_RequiresDeletePermission_AndWarnsOnDiskDeletion()
+    {
+        var output = RenderHelp("items", "file", "delete").Replace("\r\n", "\n");
+        Assert.Contains("Permission required:\n  delete", output);
+        Assert.Contains("disk", output.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void ItemsFileFfprobe_RequiresAdmin_AndDocumentsAudioOnly()
+    {
+        var output = RenderHelp("items", "file", "ffprobe").Replace("\r\n", "\n");
+        Assert.Contains("Permission required:\n  admin", output);
+        Assert.Contains("audio", output.ToLowerInvariant());
+    }
 }


### PR DESCRIPTION
## Summary

New `items file` subgroup covering the per-file endpoints of a library item, keyed by item `--id` + file `--ino` (the inode from `items get --expanded → libraryFiles[].ino`):

- **`items file download --id <id> --ino <ino> --output <path|->`** — `GET /api/items/:id/file/:fileid/download`; streams bytes to a file or stdout (mirrors `items cover get`). Permission `download`.
- **`items file delete --id <id> --ino <ino>`** — `DELETE /api/items/:id/file/:fileid`; **permanently deletes the file from disk** and updates the item (marks it missing if it was the last media file). Permission `delete`. No confirmation prompt; `--help` warns.
- **`items file ffprobe --id <id> --ino <ino>`** — `GET /api/items/:id/ffprobe/:fileid`; raw ffprobe JSON passed through unmodified. Permission `admin`; audio files only (non-audio → exit 2).

## Changes

- New: `CreateFileCommand()` in `ItemsCommand`, 3 `ItemsService` methods, 3 `ApiEndpoints` helpers. No new models (reuses `CoverFileSavedDescriptor`; delete → `{ "success": "true" }`; ffprobe → raw passthrough).
- Fix: `docs/abs-api-coverage.md` — `ffprobe` permission corrected blank → **admin**.
- README Commands table updated. `getLibraryFile` (GET file without `/download`) intentionally **not** exposed (redundant with `download`).

## Test Plan

- [x] 361/361 unit tests (endpoint path tests + command help/wiring tests); `dotnet format --verify-no-changes` clean
- [x] Smoke test passed against local docker-compose stack (301 passed, 0 failed): download non-empty bytes, ffprobe streams+format JSON, throwaway supplementary-ebook delete, plus 403s (delete as readonlyuser, ffprobe as non-admin testuser)
- [ ] Reviewer sanity check