### PR TITLE
feat: add library CRUD (create, update, delete, reorder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ abs-cli config set defaultLibrary <library-id>
 | `libraries list` | List all libraries |
 | `libraries get --id <id>` | Get a single library |
 | `libraries scan [--force]` | Trigger a library scan (admin, async) |
+| `libraries create --name <n> --folder <path>... [--media-type] [--provider] [--icon]` | Create a library (admin; folders are server-side, created if missing) |
+| `libraries update --id <id> [--name] [--media-type] [--provider] [--icon] [--display-order]` | Edit library fields (admin; folders not editable) |
+| `libraries delete --id <id>` | Delete a library and ALL its contents (admin; destructive cascade) |
+| `libraries reorder {--input <file> \| --stdin}` | Reorder libraries by display order (admin) |
 | `items list` | List items (`--filter`, `--sort`, `--limit`, `--page`, `--desc`) |
 | `items get --id <id> [--expanded] [--include progress,rssfeed,share,downloads]` | Get a single item (`--expanded` returns `libraryFiles[]`, `lastScan`, `scanVersion`; `--include` auto-implies `--expanded`) |
 | `items update --id <id> {--input <file> \| --stdin}` | Update item metadata (JSON body from file or stdin; inline JSON no longer accepted) |

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -225,9 +225,19 @@ assert_json_expr "libraries update changed name" "d['name']=='Smoke CRUD Renamed
 output=$(echo "[{\"id\":\"$NEW_LIB_ID\",\"newOrder\":99}]" | $CLI libraries reorder --stdin 2>&1)
 assert_json_key "libraries reorder returns libraries" "libraries" "$output"
 
-# delete it (returns the deleted library)
-output=$($CLI libraries delete --id "$NEW_LIB_ID" 2>&1)
-assert_json_expr "libraries delete returns deleted id" "d['id']=='$NEW_LIB_ID'" "$output"
+# delete is gated: wrong confirmation name must abort (library survives)
+echo "Not The Name" | $CLI libraries delete --id "$NEW_LIB_ID" > /dev/null 2>&1 || true
+output=$($CLI libraries list 2>&1)
+if echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if '$NEW_LIB_ID' in [l['id'] for l in d['libraries']] else 1)"; then
+    pass "libraries delete: wrong confirmation name aborts (library survives)"
+else
+    fail "libraries delete: wrong confirmation name aborts" "library was deleted despite bad confirmation"
+fi
+
+# delete it for real by piping the exact (current) name; returns the deleted library
+# capture stdout only — the confirmation prompt goes to stderr
+output=$(echo "Smoke CRUD Renamed" | $CLI libraries delete --id "$NEW_LIB_ID" 2>/dev/null)
+assert_json_expr "libraries delete (confirmed) returns deleted id" "d['id']=='$NEW_LIB_ID'" "$output"
 
 # confirm it's gone from the list
 output=$($CLI libraries list 2>&1)

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -123,6 +123,7 @@ done
 # Leaf commands must have at least 2 examples (for AI agent usability)
 for cmd in "login" "config get" "config set" \
            "libraries list" "libraries get" "libraries scan" \
+           "libraries create" "libraries update" "libraries delete" "libraries reorder" \
            "items list" "items get" \
            "items update" "items batch-update" "items batch-get" "items scan" \
            "items file download" "items file delete" "items file ffprobe" \
@@ -204,6 +205,33 @@ output=$($CLI libraries get --id "$LIB_ID" 2>/dev/null)
 assert_json_key "libraries get has name" "name" "$output"
 assert_json_expr "libraries get correct id" "d['id']=='$LIB_ID'" "$output"
 assert_json_expr "libraries get name is Test Library" "d['name']=='Test Library'" "$output"
+
+# ============================================================
+echo ""
+echo "=== Library CRUD (admin) ==="
+# ============================================================
+
+# create a throwaway library (server creates /tmp/smoke-crud-lib)
+output=$($CLI libraries create --name "Smoke CRUD Lib" --folder /tmp/smoke-crud-lib --media-type book 2>&1)
+assert_json_key "libraries create returns id" "id" "$output"
+NEW_LIB_ID=$(json_get "$output" "['id']")
+assert_json_expr "libraries create set name" "d['name']=='Smoke CRUD Lib'" "$output"
+
+# update its name
+output=$($CLI libraries update --id "$NEW_LIB_ID" --name "Smoke CRUD Renamed" 2>&1)
+assert_json_expr "libraries update changed name" "d['name']=='Smoke CRUD Renamed'" "$output"
+
+# reorder (send the new lib to a high display order)
+output=$(echo "[{\"id\":\"$NEW_LIB_ID\",\"newOrder\":99}]" | $CLI libraries reorder --stdin 2>&1)
+assert_json_key "libraries reorder returns libraries" "libraries" "$output"
+
+# delete it (returns the deleted library)
+output=$($CLI libraries delete --id "$NEW_LIB_ID" 2>&1)
+assert_json_expr "libraries delete returns deleted id" "d['id']=='$NEW_LIB_ID'" "$output"
+
+# confirm it's gone from the list
+output=$($CLI libraries list 2>&1)
+assert_json_expr "libraries list no longer has the deleted lib" "'$NEW_LIB_ID' not in [l['id'] for l in d['libraries']]" "$output"
 
 # ============================================================
 echo ""
@@ -873,6 +901,13 @@ if echo "$error_output" | grep -qi "permission denied\|admin"; then
     pass "backup list as testuser shows permission denied"
 else
     fail "backup list as testuser shows permission denied" "got: ${error_output:0:200}"
+fi
+
+error_output=$($CLI libraries create --name "Nope" --folder /tmp/nope 2>&1 || true)
+if echo "$error_output" | grep -qi "permission denied\|admin"; then
+    pass "libraries create as testuser shows admin permission denied"
+else
+    fail "libraries create as testuser shows admin permission denied" "got: ${error_output:0:200}"
 fi
 
 error_output=$($CLI tags list 2>&1 || true)

--- a/docs/abs-api-coverage.md
+++ b/docs/abs-api-coverage.md
@@ -44,12 +44,12 @@ any) that implements it.
 
 | Method | Path | Description | Perm | CLI |
 |--------|------|-------------|------|-----|
-| POST | `/api/libraries` | Create library | ? | — |
+| POST | `/api/libraries` | Create library | admin | `libraries create` ✅ |
 | GET | `/api/libraries` | List libraries | | `libraries list` ✅ |
 | GET | `/api/libraries/:id` | Get library | | `libraries get` ✅ |
-| PATCH | `/api/libraries/:id` | Update library | update | — |
-| DELETE | `/api/libraries/:id` | Delete library | delete | — |
-| POST | `/api/libraries/order` | Reorder libraries | ? | — |
+| PATCH | `/api/libraries/:id` | Update library | admin | `libraries update` ✅ |
+| DELETE | `/api/libraries/:id` | Delete library | admin | `libraries delete` ✅ |
+| POST | `/api/libraries/order` | Reorder libraries | admin | `libraries reorder` ✅ |
 | GET | `/api/libraries/:id/items` | List items in library | | `items list` ✅ |
 | DELETE | `/api/libraries/:id/issues` | Remove items with issues | delete | — |
 | GET | `/api/libraries/:id/episode-downloads` | Podcast download queue | | — |

--- a/docs/plans/2026-07-14-library-crud.md
+++ b/docs/plans/2026-07-14-library-crud.md
@@ -1,0 +1,739 @@
+# Library CRUD Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `libraries create`, `update`, `delete`, and `reorder` — the four admin library-management endpoints — to the existing `libraries` command.
+
+**Architecture:** Flags + repeatable `--folder` for create (precedents: `collections update` flags, `upload --files`); scalar flags for update; `--id` for delete (no prompt); `--input`/`--stdin` for reorder (precedent: `collections reorder`). New request models (`LibraryCreateRequest`/`LibraryFolderRequest`/`LibraryUpdateRequest`); responses reuse existing `Library` / `LibraryListResponse`. All four gated `admin`.
+
+**Tech Stack:** C# / .NET, System.CommandLine, System.Text.Json source-gen (`AppJsonContext`), xUnit.
+
+**Spec:** `docs/specs/2026-07-14-library-crud-design.md`
+
+**Conventions:** No unnecessary blank lines in method bodies. `dotnet format AbsCli.sln` before each commit. Conventional Commits, imperative lowercase no period; NO `Co-Authored-By`, NO "Generated with Claude Code". Do NOT edit `CHANGELOG.md`. Permission tag `admin` ↔ hint `"admin permission"` (no quotes around admin).
+
+---
+
+## File Structure
+
+New:
+- `src/AbsCli/Models/LibraryRequests.cs` — `LibraryFolderRequest`, `LibraryCreateRequest`, `LibraryUpdateRequest`
+- `tests/AbsCli.Tests/Services/LibrariesServiceTests.cs` — request round-trip tests
+
+Modified:
+- `src/AbsCli/Models/JsonContext.cs` — register the 3 request types
+- `tools/GenerateResponseExamples/Program.cs` — exclude the 3 request types
+- `src/AbsCli/Commands/ResponseExamples.g.cs` — regenerated
+- `src/AbsCli/Api/ApiEndpoints.cs` — `LibrariesOrder`
+- `src/AbsCli/Services/LibrariesService.cs` — `CreateAsync`/`UpdateAsync`/`DeleteAsync`/`ReorderAsync`
+- `src/AbsCli/Commands/LibrariesCommand.cs` — 4 subcommands + logger field
+- `tests/AbsCli.Tests/Commands/LibrariesCommandTests.cs` — new-verb tests (+ update the existing subcommand-set assertion)
+- `tests/AbsCli.Tests/Api/ApiEndpointsTests.cs` — `LibrariesOrder` assertion
+- `README.md`, `docs/abs-api-coverage.md`, `docker/smoke-test.sh`
+
+---
+
+## Task 1: Request models + JSON context
+
+**Files:** Create `src/AbsCli/Models/LibraryRequests.cs`, `tests/AbsCli.Tests/Services/LibrariesServiceTests.cs`; modify `src/AbsCli/Models/JsonContext.cs`.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/AbsCli.Tests/Services/LibrariesServiceTests.cs`:
+
+```csharp
+using System.Text.Json;
+using AbsCli.Models;
+using Xunit;
+
+namespace AbsCli.Tests.Services;
+
+public class LibrariesServiceTests
+{
+    [Fact]
+    public void LibraryCreateRequest_SerializesFoldersAndName()
+    {
+        var req = new LibraryCreateRequest
+        {
+            Name = "Audiobooks",
+            Folders = new List<LibraryFolderRequest> { new() { FullPath = "/audiobooks" } }
+        };
+        var json = JsonSerializer.Serialize(req, AppJsonContext.Default.LibraryCreateRequest);
+        Assert.Contains("\"name\": \"Audiobooks\"", json);
+        Assert.Contains("\"fullPath\": \"/audiobooks\"", json);
+        // optional fields omitted when null
+        Assert.DoesNotContain("mediaType", json);
+        Assert.DoesNotContain("provider", json);
+        Assert.DoesNotContain("icon", json);
+    }
+
+    [Fact]
+    public void LibraryCreateRequest_IncludesOptionalsWhenSet()
+    {
+        var req = new LibraryCreateRequest
+        {
+            Name = "Pods",
+            Folders = new List<LibraryFolderRequest> { new() { FullPath = "/pods" } },
+            MediaType = "podcast",
+            Provider = "itunes",
+            Icon = "podcast"
+        };
+        var json = JsonSerializer.Serialize(req, AppJsonContext.Default.LibraryCreateRequest);
+        Assert.Contains("\"mediaType\": \"podcast\"", json);
+        Assert.Contains("\"provider\": \"itunes\"", json);
+        Assert.Contains("\"icon\": \"podcast\"", json);
+    }
+
+    [Fact]
+    public void LibraryUpdateRequest_OmitsNullFields()
+    {
+        var req = new LibraryUpdateRequest { Name = "Renamed" };
+        var json = JsonSerializer.Serialize(req, AppJsonContext.Default.LibraryUpdateRequest);
+        Assert.Contains("\"name\": \"Renamed\"", json);
+        Assert.DoesNotContain("mediaType", json);
+        Assert.DoesNotContain("displayOrder", json);
+    }
+
+    [Fact]
+    public void LibraryUpdateRequest_IncludesDisplayOrder()
+    {
+        var req = new LibraryUpdateRequest { DisplayOrder = 3 };
+        var json = JsonSerializer.Serialize(req, AppJsonContext.Default.LibraryUpdateRequest);
+        Assert.Contains("\"displayOrder\": 3", json);
+        Assert.DoesNotContain("\"name\"", json);
+    }
+}
+```
+
+Note: `AppJsonContext` uses `WriteIndented = true` (space after colon).
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `dotnet test tests/AbsCli.Tests --filter LibrariesServiceTests`
+Expected: FAIL (types missing).
+
+- [ ] **Step 3: Create the models**
+
+`src/AbsCli/Models/LibraryRequests.cs`:
+
+```csharp
+using System.Text.Json.Serialization;
+
+namespace AbsCli.Models;
+
+/// <summary>Folder entry for POST /api/libraries (server-side path).</summary>
+public class LibraryFolderRequest
+{
+    [JsonPropertyName("fullPath")]
+    public string FullPath { get; set; } = "";
+}
+
+/// <summary>Request body for POST /api/libraries. Null optionals are omitted (server defaults apply).</summary>
+public class LibraryCreateRequest
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("folders")]
+    public List<LibraryFolderRequest> Folders { get; set; } = new();
+
+    [JsonPropertyName("mediaType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MediaType { get; set; }
+
+    [JsonPropertyName("provider")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Provider { get; set; }
+
+    [JsonPropertyName("icon")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Icon { get; set; }
+}
+
+/// <summary>Request body for PATCH /api/libraries/:id. Null fields are omitted.</summary>
+public class LibraryUpdateRequest
+{
+    [JsonPropertyName("name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("mediaType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MediaType { get; set; }
+
+    [JsonPropertyName("provider")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Provider { get; set; }
+
+    [JsonPropertyName("icon")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Icon { get; set; }
+
+    [JsonPropertyName("displayOrder")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? DisplayOrder { get; set; }
+}
+```
+
+- [ ] **Step 4: Register in `JsonContext.cs`**
+
+Add to the `[JsonSerializable(...)]` block on `AppJsonContext`:
+
+```csharp
+[JsonSerializable(typeof(LibraryFolderRequest))]
+[JsonSerializable(typeof(LibraryCreateRequest))]
+[JsonSerializable(typeof(LibraryUpdateRequest))]
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `dotnet test tests/AbsCli.Tests --filter LibrariesServiceTests`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+dotnet format AbsCli.sln
+git add src/AbsCli/Models/LibraryRequests.cs src/AbsCli/Models/JsonContext.cs tests/AbsCli.Tests/Services/LibrariesServiceTests.cs
+git status --short   # if ResponseExamples.g.cs shows modified, do NOT commit it yet (Task 2 handles it): git checkout src/AbsCli/Commands/ResponseExamples.g.cs
+git commit -m "feat: add library create/update request models"
+```
+
+---
+
+## Task 2: Exclude request types from generator, regenerate
+
+**Files:** Modify `tools/GenerateResponseExamples/Program.cs`, `src/AbsCli/Commands/ResponseExamples.g.cs`.
+
+- [ ] **Step 1: Add to the exclusion set**
+
+In `tools/GenerateResponseExamples/Program.cs`, in the `excluded` `HashSet<Type>` (already has `TagRenameRequest`/`GenreRenameRequest`/`NarratorRenameRequest`), add after those:
+
+```csharp
+            typeof(LibraryFolderRequest),
+            typeof(LibraryCreateRequest),
+            typeof(LibraryUpdateRequest),
+```
+
+- [ ] **Step 2: Regenerate**
+
+Run: `dotnet run --project tools/GenerateResponseExamples -- src/AbsCli/Commands/ResponseExamples.g.cs`
+Expected: exit 0.
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -c "LibraryCreateRequest\|LibraryUpdateRequest\|LibraryFolderRequest" src/AbsCli/Commands/ResponseExamples.g.cs   # expect 0
+```
+
+- [ ] **Step 4: Drift test**
+
+Run: `dotnet test tests/AbsCli.Tests --filter ResponseExamplesDriftTest`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dotnet format AbsCli.sln
+git add tools/GenerateResponseExamples/Program.cs src/AbsCli/Commands/ResponseExamples.g.cs
+git commit -m "chore: exclude library request types from response examples"
+```
+
+---
+
+## Task 3: Endpoint + service methods
+
+**Files:** Modify `src/AbsCli/Api/ApiEndpoints.cs` (+ test), `src/AbsCli/Services/LibrariesService.cs`.
+
+- [ ] **Step 1: Add failing endpoint test**
+
+Append inside `ApiEndpointsTests`:
+
+```csharp
+    [Fact]
+    public void LibrariesOrder_IsStable()
+    {
+        Assert.Equal("api/libraries/order", ApiEndpoints.LibrariesOrder);
+    }
+```
+
+Run `dotnet test tests/AbsCli.Tests --filter ApiEndpointsTests` → FAIL.
+
+- [ ] **Step 2: Add the endpoint**
+
+In `src/AbsCli/Api/ApiEndpoints.cs`, near the other library consts (after `Libraries`):
+
+```csharp
+    public const string LibrariesOrder = "api/libraries/order";
+```
+
+Run `dotnet test tests/AbsCli.Tests --filter ApiEndpointsTests` → PASS.
+
+- [ ] **Step 3: Add service methods**
+
+Add `using System.Text.Json;` to `src/AbsCli/Services/LibrariesService.cs`, then add:
+
+```csharp
+    public async Task<Library> CreateAsync(LibraryCreateRequest body)
+    {
+        var json = JsonSerializer.Serialize(body, AppJsonContext.Default.LibraryCreateRequest);
+        return await _client.PostAsync(ApiEndpoints.Libraries, json, AppJsonContext.Default.Library, "admin permission");
+    }
+
+    public async Task<Library> UpdateAsync(string id, LibraryUpdateRequest body)
+    {
+        var json = JsonSerializer.Serialize(body, AppJsonContext.Default.LibraryUpdateRequest);
+        return await _client.PatchAsync(ApiEndpoints.Library(id), json, AppJsonContext.Default.Library, "admin permission");
+    }
+
+    public async Task<Library> DeleteAsync(string id)
+    {
+        return await _client.DeleteAsync(ApiEndpoints.Library(id), AppJsonContext.Default.Library, "admin permission");
+    }
+
+    public async Task<LibraryListResponse> ReorderAsync(string orderJson)
+    {
+        return await _client.PostAsync(ApiEndpoints.LibrariesOrder, orderJson, AppJsonContext.Default.LibraryListResponse, "admin permission");
+    }
+```
+
+Verify the generic `PostAsync<T>`/`PatchAsync<T>`/`DeleteAsync<T>(endpoint, [jsonBody,] typeInfo, permissionHint?)` signatures against `AuthorsService`/`ItemsService` usage; adjust if the order differs.
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build src/AbsCli`
+Expected: 0 errors.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dotnet format AbsCli.sln
+git add src/AbsCli/Api/ApiEndpoints.cs src/AbsCli/Services/LibrariesService.cs tests/AbsCli.Tests/Api/ApiEndpointsTests.cs
+git commit -m "feat: add library create/update/delete/reorder service methods"
+```
+
+---
+
+## Task 4: `libraries` subcommands + tests
+
+**Files:** Modify `src/AbsCli/Commands/LibrariesCommand.cs`, `tests/AbsCli.Tests/Commands/LibrariesCommandTests.cs`.
+
+- [ ] **Step 1: Update + add failing tests**
+
+In `tests/AbsCli.Tests/Commands/LibrariesCommandTests.cs`, REPLACE the existing `Libraries_HasListGetScan` test's expected array with the full set, and add new tests:
+
+```csharp
+    [Fact]
+    public void Libraries_HasAllSubcommands()
+    {
+        var verbs = LibrariesCommand.Create().Subcommands.Select(c => c.Name).ToList();
+        Assert.Equal(new[] { "list", "get", "scan", "create", "update", "delete", "reorder" }, verbs);
+    }
+
+    [Fact]
+    public void LibrariesCreate_RequiresAdmin_AndHasFolderAndNameOptions()
+    {
+        var output = RenderHelp("libraries", "create").Replace("\r\n", "\n");
+        Assert.Contains("Permission required:\n  admin", output);
+        Assert.Contains("--name", output);
+        Assert.Contains("--folder", output);
+        Assert.Contains("--media-type", output);
+    }
+
+    [Fact]
+    public void LibrariesUpdate_RequiresAdmin()
+    {
+        var output = RenderHelp("libraries", "update").Replace("\r\n", "\n");
+        Assert.Contains("Permission required:\n  admin", output);
+        Assert.Contains("--id", output);
+        Assert.Contains("--display-order", output);
+    }
+
+    [Fact]
+    public void LibrariesDelete_RequiresAdmin_AndWarnsCascade()
+    {
+        var output = RenderHelp("libraries", "delete").Replace("\r\n", "\n");
+        Assert.Contains("Permission required:\n  admin", output);
+        Assert.Contains("cascade", output.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void LibrariesReorder_RequiresAdmin_AndHasInputStdin()
+    {
+        var output = RenderHelp("libraries", "reorder").Replace("\r\n", "\n");
+        Assert.Contains("Permission required:\n  admin", output);
+        Assert.Contains("--input", output);
+        Assert.Contains("--stdin", output);
+    }
+
+    [Fact]
+    public void BuildUpdateBody_OmitsUnsetIncludesSet()
+    {
+        var body = LibrariesCommand.BuildUpdateBodyForTesting("New", null, null, null, 2);
+        Assert.Equal("New", body.Name);
+        Assert.Null(body.MediaType);
+        Assert.Equal(2, body.DisplayOrder);
+    }
+```
+
+Delete the now-replaced `Libraries_HasListGetScan` test if it still exists (its assertion is superseded by `Libraries_HasAllSubcommands`).
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `dotnet test tests/AbsCli.Tests --filter LibrariesCommandTests`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `src/AbsCli/Commands/LibrariesCommand.cs`: add a logger field as the first line inside the class:
+
+```csharp
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+```
+
+Register the four subcommands in `Create()` after the `scan` registration:
+
+```csharp
+        command.Subcommands.Add(CreateCreateCommand());
+        command.Subcommands.Add(CreateUpdateCommand());
+        command.Subcommands.Add(CreateDeleteCommand());
+        command.Subcommands.Add(CreateReorderCommand());
+```
+
+Add these methods (confirm `AddPermissionRequired`/`AddHelpSection`/`AddExamples`/`AddResponseExample<T>`/`CommandHelper.BuildClient`/`ConsoleOutput.WriteJson`/`CommandHelper.ReadJsonInput` against `CollectionsCommand.cs`/`ItemsCommand.cs`):
+
+```csharp
+    private static Command CreateCreateCommand()
+    {
+        var nameOption = new Option<string>("--name") { Description = "Library name", Required = true };
+        var folderOption = new Option<string[]>("--folder") { Description = "Server-side folder path (repeatable; created if missing)", AllowMultipleArgumentsPerToken = true };
+        var mediaTypeOption = new Option<string?>("--media-type") { Description = "book | podcast (default book)" };
+        var providerOption = new Option<string?>("--provider") { Description = "Metadata provider (default google)" };
+        var iconOption = new Option<string?>("--icon") { Description = "Library icon (default database)" };
+        var command = new Command("create", "Create a new library")
+        { nameOption, folderOption, mediaTypeOption, providerOption, iconOption };
+        command.AddPermissionRequired("admin");
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "Folder paths are SERVER-SIDE and are created on the server if missing.",
+            "At least one --folder is required. Library settings are not",
+            "configurable here.");
+        command.AddExamples(
+            "abs-cli libraries create --name \"Audiobooks\" --folder /audiobooks",
+            "abs-cli libraries create --name \"Pods\" --folder /pods --media-type podcast");
+        command.AddResponseExample<Library>();
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var name = parseResult.GetValue(nameOption)!;
+            var folders = parseResult.GetValue(folderOption) ?? Array.Empty<string>();
+            var mediaType = parseResult.GetValue(mediaTypeOption);
+            var provider = parseResult.GetValue(providerOption);
+            var icon = parseResult.GetValue(iconOption);
+            if (folders.Length == 0)
+            {
+                _logger.Error("At least one --folder is required.");
+                Environment.Exit(1);
+                return 1;
+            }
+            var body = new LibraryCreateRequest
+            {
+                Name = name,
+                Folders = folders.Select(f => new LibraryFolderRequest { FullPath = f }).ToList(),
+                MediaType = string.IsNullOrEmpty(mediaType) ? null : mediaType,
+                Provider = string.IsNullOrEmpty(provider) ? null : provider,
+                Icon = string.IsNullOrEmpty(icon) ? null : icon
+            };
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new LibrariesService(client);
+            var result = await service.CreateAsync(body);
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.Library);
+            return 0;
+        });
+        return command;
+    }
+
+    private static Command CreateUpdateCommand()
+    {
+        var idOption = new Option<string>("--id") { Description = "Library ID", Required = true };
+        var nameOption = new Option<string?>("--name") { Description = "New name" };
+        var mediaTypeOption = new Option<string?>("--media-type") { Description = "New media type (book | podcast)" };
+        var providerOption = new Option<string?>("--provider") { Description = "New metadata provider" };
+        var iconOption = new Option<string?>("--icon") { Description = "New icon" };
+        var displayOrderOption = new Option<int?>("--display-order") { Description = "New display order (number)" };
+        var command = new Command("update", "Edit a library's name, media type, provider, icon, or display order")
+        { idOption, nameOption, mediaTypeOption, providerOption, iconOption, displayOrderOption };
+        command.AddPermissionRequired("admin");
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "Folders are NOT editable here. Empty --name is rejected. At least",
+            "one edit flag is required.");
+        command.AddExamples(
+            "abs-cli libraries update --id \"lib_1\" --name \"Renamed\"",
+            "abs-cli libraries update --id \"lib_1\" --display-order 2");
+        command.AddResponseExample<Library>();
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var id = parseResult.GetValue(idOption)!;
+            var name = parseResult.GetValue(nameOption);
+            var mediaType = parseResult.GetValue(mediaTypeOption);
+            var provider = parseResult.GetValue(providerOption);
+            var icon = parseResult.GetValue(iconOption);
+            var displayOrder = parseResult.GetValue(displayOrderOption);
+            if (name is not null && string.IsNullOrEmpty(name))
+            {
+                _logger.Error("--name cannot be empty");
+                Environment.Exit(1);
+                return 1;
+            }
+            var body = BuildUpdateBodyForTesting(name, mediaType, provider, icon, displayOrder);
+            if (body.Name == null && body.MediaType == null && body.Provider == null && body.Icon == null && body.DisplayOrder == null)
+            {
+                _logger.Error("Specify at least one of --name, --media-type, --provider, --icon, --display-order");
+                Environment.Exit(1);
+                return 1;
+            }
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new LibrariesService(client);
+            var result = await service.UpdateAsync(id, body);
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.Library);
+            return 0;
+        });
+        return command;
+    }
+
+    /// <summary>
+    /// Build the PATCH body from the flags, coercing empty strings to null so
+    /// they are omitted. Exposed internally for unit testing.
+    /// </summary>
+    internal static LibraryUpdateRequest BuildUpdateBodyForTesting(string? name, string? mediaType, string? provider, string? icon, int? displayOrder)
+    {
+        return new LibraryUpdateRequest
+        {
+            Name = string.IsNullOrEmpty(name) ? null : name,
+            MediaType = string.IsNullOrEmpty(mediaType) ? null : mediaType,
+            Provider = string.IsNullOrEmpty(provider) ? null : provider,
+            Icon = string.IsNullOrEmpty(icon) ? null : icon,
+            DisplayOrder = displayOrder
+        };
+    }
+
+    private static Command CreateDeleteCommand()
+    {
+        var idOption = new Option<string>("--id") { Description = "Library ID", Required = true };
+        var command = new Command("delete", "Delete a library and ALL its contents") { idOption };
+        command.AddPermissionRequired("admin");
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "DESTRUCTIVE CASCADE: permanently deletes the library AND every item",
+            "in it, all collections for the library, and removes it from playlists",
+            "and playback sessions. No confirmation prompt. Returns the deleted",
+            "library.");
+        command.AddExamples(
+            "abs-cli libraries delete --id \"lib_1\"");
+        command.AddResponseExample<Library>();
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var id = parseResult.GetValue(idOption)!;
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new LibrariesService(client);
+            var result = await service.DeleteAsync(id);
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.Library);
+            return 0;
+        });
+        return command;
+    }
+
+    private static Command CreateReorderCommand()
+    {
+        var inputOption = new Option<string?>("--input") { Description = "JSON file with an array of {id, newOrder}" };
+        var stdinOption = new Option<bool>("--stdin") { Description = "Read the reorder JSON array from stdin" };
+        var command = new Command("reorder", "Reorder libraries by display order")
+        { inputOption, stdinOption };
+        command.AddPermissionRequired("admin");
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "Body is a JSON array of objects: [{\"id\":\"lib_1\",\"newOrder\":1}, ...].");
+        command.AddExamples(
+            "abs-cli libraries reorder --input order.json",
+            "echo '[{\"id\":\"lib_1\",\"newOrder\":1}]' | abs-cli libraries reorder --stdin");
+        command.AddResponseExample<LibraryListResponse>();
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var input = parseResult.GetValue(inputOption);
+            var stdin = parseResult.GetValue(stdinOption);
+            if (stdin && input != null)
+            {
+                _logger.Error("Provide --input or --stdin, not both.");
+                Environment.Exit(1);
+                return 1;
+            }
+            string orderJson;
+            if (stdin) orderJson = await Console.In.ReadToEndAsync(cancellationToken);
+            else if (input != null) orderJson = CommandHelper.ReadJsonInput(input);
+            else
+            {
+                _logger.Error("Provide --input <file> or --stdin.");
+                Environment.Exit(1);
+                return 1;
+            }
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new LibrariesService(client);
+            var result = await service.ReorderAsync(orderJson);
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.LibraryListResponse);
+            return 0;
+        });
+        return command;
+    }
+```
+
+Verify `LibrariesCommand.cs` has `using System.CommandLine; using AbsCli.Models; using AbsCli.Output; using AbsCli.Services;` (add any missing). `Library`/`LibraryListResponse`/`LibraryCreateRequest`/`LibraryUpdateRequest`/`LibraryFolderRequest` are all in `AbsCli.Models`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet test tests/AbsCli.Tests --filter LibrariesCommandTests`
+Expected: PASS.
+
+- [ ] **Step 5: Confirm wiring**
+
+Run: `dotnet run --project src/AbsCli -- libraries --help`
+Expected: lists create/update/delete/reorder.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+dotnet format AbsCli.sln
+git add src/AbsCli/Commands/LibrariesCommand.cs tests/AbsCli.Tests/Commands/LibrariesCommandTests.cs
+git status --short   # if ResponseExamples.g.cs shows modified, revert: git checkout src/AbsCli/Commands/ResponseExamples.g.cs
+git commit -m "feat: add libraries create, update, delete, reorder commands"
+```
+
+---
+
+## Task 5: Docs — README + coverage map
+
+**Files:** Modify `README.md`, `docs/abs-api-coverage.md`.
+
+- [ ] **Step 1: README Commands table**
+
+Add four rows near the other `libraries …` rows (after `libraries scan`):
+
+```markdown
+| `libraries create --name <n> --folder <path>... [--media-type] [--provider] [--icon]` | Create a library (admin; folders are server-side, created if missing) |
+| `libraries update --id <id> [--name] [--media-type] [--provider] [--icon] [--display-order]` | Edit library fields (admin; folders not editable) |
+| `libraries delete --id <id>` | Delete a library and ALL its contents (admin; destructive cascade) |
+| `libraries reorder {--input <file> \| --stdin}` | Reorder libraries by display order (admin) |
+```
+
+- [ ] **Step 2: Coverage doc**
+
+In `docs/abs-api-coverage.md`, find the four rows and update last column to the mapped command with ✅, and set the permission column to `admin` where it is blank or `?`:
+- `POST /api/libraries` → `admin`, `` `libraries create` ✅ ``
+- `PATCH /api/libraries/:id` → `admin`, `` `libraries update` ✅ ``
+- `DELETE /api/libraries/:id` → `admin`, `` `libraries delete` ✅ ``
+- `POST /api/libraries/order` → **fix permission `?` → `admin`**, `` `libraries reorder` ✅ ``
+
+Run to confirm:
+```bash
+rg -n "POST \| .api/libraries|PATCH \| .api/libraries/:id|DELETE \| .api/libraries/:id|libraries/order" docs/abs-api-coverage.md
+rg -n "libraries create|libraries reorder" README.md
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md docs/abs-api-coverage.md
+git commit -m "docs: document library CRUD commands and fix reorder permission"
+```
+
+---
+
+## Task 6: Smoke test
+
+**Files:** Modify `docker/smoke-test.sh`. No `seed.sh` change (the section creates + deletes its own throwaway library).
+
+- [ ] **Step 1: Help-example enumeration**
+
+Add to the leaf-command loop (backslash-continued):
+```bash
+           "libraries create" "libraries update" "libraries delete" "libraries reorder" \
+```
+
+- [ ] **Step 2: Add a "Library CRUD" section**
+
+Place it in the main root-authenticated body (root is admin), AFTER the existing "Libraries" section. It creates a throwaway library, updates it, reorders it, then deletes it (self-cleaning so the stack returns to 1 library):
+
+```bash
+# ============================================================
+echo ""
+echo "=== Library CRUD (admin) ==="
+# ============================================================
+
+# create a throwaway library (server creates /tmp/smoke-crud-lib)
+output=$($CLI libraries create --name "Smoke CRUD Lib" --folder /tmp/smoke-crud-lib --media-type book 2>&1)
+assert_json_key "libraries create returns id" "id" "$output"
+NEW_LIB_ID=$(json_get "$output" "['id']")
+assert_json_expr "libraries create set name" "d['name']=='Smoke CRUD Lib'" "$output"
+
+# update its name
+output=$($CLI libraries update --id "$NEW_LIB_ID" --name "Smoke CRUD Renamed" 2>&1)
+assert_json_expr "libraries update changed name" "d['name']=='Smoke CRUD Renamed'" "$output"
+
+# reorder (send the new lib to a high display order)
+output=$(echo "[{\"id\":\"$NEW_LIB_ID\",\"newOrder\":99}]" | $CLI libraries reorder --stdin 2>&1)
+assert_json_key "libraries reorder returns libraries" "libraries" "$output"
+
+# delete it (returns the deleted library)
+output=$($CLI libraries delete --id "$NEW_LIB_ID" 2>&1)
+assert_json_expr "libraries delete returns deleted id" "d['id']=='$NEW_LIB_ID'" "$output"
+
+# confirm it's gone from the list
+output=$($CLI libraries list 2>&1)
+assert_json_expr "libraries list no longer has the deleted lib" "'$NEW_LIB_ID' not in [l['id'] for l in d['libraries']]" "$output"
+```
+
+- [ ] **Step 3: 403 assertions**
+
+Add to the `testuser` (non-admin) admin-denial group:
+```bash
+error_output=$($CLI libraries create --name "Nope" --folder /tmp/nope 2>&1 || true)
+if echo "$error_output" | grep -qi "permission denied\|admin"; then
+    pass "libraries create as testuser shows admin permission denied"
+else
+    fail "libraries create as testuser shows admin permission denied" "got: ${error_output:0:200}"
+fi
+```
+(If the section runs after root context switched away, ensure the create/update/delete happy-path block ran earlier under root; the 403 block does its own `abs_login testuser testpass` and the section restores `abs_login root root` afterward — match the existing pattern.)
+
+- [ ] **Step 4: Run the smoke test**
+
+```bash
+cd docker && docker compose up -d
+IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+ABS_URL=http://$IP:80 bash docker/seed.sh
+ABS_URL=http://$IP:80 bash docker/smoke-test.sh
+```
+Expected: all pass, exit 0. If a field name or the reorder response differs, inspect a live response and adjust. Only mark "smoke passed" after seeing it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/smoke-test.sh
+git commit -m "test: add library CRUD smoke assertions and 403 coverage"
+```
+
+---
+
+## Task 7: Full verification
+
+- [ ] **Step 1: Full unit run** — `dotnet test AbsCli.sln` → all pass (incl. `ResponseExamplesDriftTest`).
+- [ ] **Step 2: Format check** — `dotnet format AbsCli.sln --verify-no-changes` → clean (else format + commit `chore: fix formatting`).
+- [ ] **Step 3: Wiring** — `dotnet run --project src/AbsCli -- libraries --help` shows create/update/delete/reorder.
+- [ ] **Step 4: Smoke gate** — confirm Task 6's smoke passed. Gates the PR checkbox.
+
+---
+
+## Self-Review Notes (author checklist — completed during planning)
+
+- **Spec coverage:** create (flags + repeatable --folder, ≥1 required, settings dropped), update (scalar flags, empty-name rejected, at-least-one required, folders-not-editable help), delete (admin, cascade warning, no prompt, returns deleted Library), reorder (--input/--stdin raw array), coverage-doc fixes incl. order `?`→admin, smoke incl. self-cleaning create→update→reorder→delete + 403.
+- **Reuse:** responses reuse existing `Library`/`LibraryListResponse` (no new response models). New request types registered + generator-excluded (Task 2), like the tag/genre/narrator request types.
+- **Delete returns the deleted library** (verified: `res.json(libraryJson)`), so the command prints the `Library` — not `{success:true}`.
+- **Existing test update:** Task 4 replaces the `Libraries_HasListGetScan` assertion with the full subcommand set (adding 4 verbs changes it) — called out to avoid a surprise red.
+- **Permission hint** `"admin permission"` (per CLAUDE.md), consistent with the recent tags/genres/narrators work; note the pre-existing `ScanAsync` uses the older `"'admin' access"` string — left untouched.
+- **Type consistency:** `LibraryCreateRequest`/`LibraryUpdateRequest`/`LibraryFolderRequest` fields match service serialization + tests; `BuildUpdateBodyForTesting` signature matches its test and call site.
+- **CHANGELOG untouched.**

--- a/docs/specs/2026-07-14-library-crud-design.md
+++ b/docs/specs/2026-07-14-library-crud-design.md
@@ -1,0 +1,74 @@
+# Library CRUD — Design
+
+Date: 2026-07-14
+Status: Approved (brainstorm)
+
+## Goal
+
+Add the four admin library-management endpoints to the existing `libraries`
+command: create, update, delete, reorder. Thin 1:1 pass-through.
+
+## API reference (verified against ABS v2.35.1 — LibraryController)
+
+All four require **admin** (`isAdminOrUp`).
+
+| Endpoint | Body | Response | Notes |
+|---|---|---|---|
+| `POST /api/libraries` | `{ name*, folders* [{fullPath}], mediaType=book, provider=google, icon=database, settings{} }` | created `Library` | Server **creates the folder dirs** if missing (server-side paths). `folders` is a required non-empty array. |
+| `PATCH /api/libraries/:id` | `{ name?, provider?, mediaType?, icon?, displayOrder?, settings? }` | updated `Library` | **Folders are NOT updatable here.** |
+| `DELETE /api/libraries/:id` | — | the deleted `Library` (`res.json(libraryJson)`) | **Destructive cascade:** deletes the library and all its items, collections, and removes it from playlists + playback sessions. |
+| `POST /api/libraries/order` | array of `{ id, newOrder }` | `{ libraries: [...] }` | Reorder by display order. |
+
+## Command layout (precedent-driven)
+
+Chosen to introduce no new patterns. Precedents surveyed:
+- Scalar edits → flags (`authors/series/collections update`).
+- Body carrying an array → `--input`/`--stdin` (`collections reorder`, `items batch-*`).
+- Repeatable path list → repeatable flag (`upload --files`).
+- Delete → no confirmation prompt anywhere in the CLI.
+
+### `libraries create` (POST /api/libraries)
+- `--name` (required), `--folder <path>` (repeatable via `Option<string[]>{ AllowMultipleArgumentsPerToken = true }`, ≥1 required), `--media-type`, `--provider`, `--icon`.
+- Body `{ name, folders:[{fullPath}], mediaType?, provider?, icon? }` — omitted optional flags are not sent (server applies defaults book/google/database).
+- **Settings dropped (YAGNI)** — the nested settings object would require a new `--settings-json` pattern; out of scope. Can be added later.
+- `--help`: folders are server-side and created if missing; ≥1 required.
+- Response: reuse existing `Library` model.
+
+### `libraries update` (PATCH /api/libraries/:id)
+- `--id` (required), `--name`, `--media-type`, `--provider`, `--icon`, `--display-order`.
+- Empty `--name` rejected client-side; at least one edit flag required (mirrors `authors`/`series`/`collections update`).
+- `--help`: folders not editable here.
+- Response: `Library`.
+
+### `libraries delete` (DELETE /api/libraries/:id)
+- `--id` (required). **No confirmation prompt** (consistent with every other delete). `--help` warns loudly about the destructive cascade.
+- Response: the deleted `Library`.
+
+### `libraries reorder` (POST /api/libraries/order)
+- `--input <file>` / `--stdin` for the JSON array `[{ "id": "...", "newOrder": N }]` (mirrors `collections reorder`); the raw body is passed straight through.
+- Response: reuse existing `LibraryListResponse` (`{ libraries:[...] }`).
+
+## Implementation
+
+- New request models (`src/AbsCli/Models/LibraryRequests.cs`): `LibraryFolderRequest { fullPath }`, `LibraryCreateRequest { name, folders, mediaType?, provider?, icon? }`, `LibraryUpdateRequest { name?, mediaType?, provider?, icon?, displayOrder? }`. Optional fields use `[JsonIgnore(Condition = WhenWritingNull)]` (the context has no global `DefaultIgnoreCondition`). Registered in `JsonContext` and **excluded from the response-example generator** (like the tag/genre/narrator request types). Reorder needs no request model (raw pass-through).
+- Responses reuse `Library` / `LibraryListResponse` — no new response models.
+- `ApiEndpoints`: `Libraries` and `Library(id)` already exist; add `LibrariesOrder = "api/libraries/order"`.
+- Extend `LibrariesService` (`CreateAsync`/`UpdateAsync`/`DeleteAsync`/`ReorderAsync`, hint `"admin permission"`) and `LibrariesCommand` (4 subcommands + logger field).
+
+## Docs
+- README Commands table: 4 new `libraries …` rows.
+- Coverage doc: mark the four rows ✅ and **fix `POST /api/libraries/order` permission `?` → `admin`**; set the create/update/delete permission columns to `admin` where blank.
+
+## Testing
+- Unit: request round-trip tests (folders + omitted-null optionals); `ApiEndpoints.LibrariesOrder`; command help/structure (flags, `admin` tags, caveats, repeatable `--folder`, at-least-one/empty-name on update via `BuildUpdateBodyForTesting`). Note: the existing `Libraries_HasListGetScan` assertion must be updated to the full subcommand set.
+- Smoke (self-cleaning): create a throwaway library at a server `/tmp` path → assert id/name; update its name; reorder; delete it → assert the returned deleted-library id, then confirm it's gone from `libraries list`. Plus a 403: `libraries create` as non-admin `testuser`.
+
+## Out of scope (YAGNI)
+- Library `settings` object (create/update).
+- Folder edits via update (ABS doesn't support).
+- Delete confirmation prompt.
+
+## Notes
+- `DELETE` returns the deleted library JSON (not an empty 200), so the command prints the `Library`.
+- Permission hint `"admin permission"` per CLAUDE.md; the pre-existing `ScanAsync` uses the older `"'admin' access"` string — left untouched.
+- Do NOT edit `CHANGELOG.md`.

--- a/docs/specs/2026-07-14-library-crud-design.md
+++ b/docs/specs/2026-07-14-library-crud-design.md
@@ -41,8 +41,9 @@ Chosen to introduce no new patterns. Precedents surveyed:
 - Response: `Library`.
 
 ### `libraries delete` (DELETE /api/libraries/:id)
-- `--id` (required). **No confirmation prompt** (consistent with every other delete). `--help` warns loudly about the destructive cascade.
+- `--id` (required). **Confirmation-gated** (unlike every other delete — the blast radius is far larger). The command first `GET`s the library (a deliberate pre-fetch), prints a warning showing the library's name + id + cascade, and requires the operator to type the library's **exact name** on stdin to proceed. Non-matching input aborts (exit 1). **No `--yes` bypass** — a flag is not a real gate against an agent, whereas requiring the typed name is; in a non-interactive context nothing is typed, so it aborts.
 - Response: the deleted `Library`.
+- `ConfirmationMatches(input, name)` (trimmed, case-sensitive, null-safe) is extracted for unit testing.
 
 ### `libraries reorder` (POST /api/libraries/order)
 - `--input <file>` / `--stdin` for the JSON array `[{ "id": "...", "newOrder": N }]` (mirrors `collections reorder`); the raw body is passed straight through.
@@ -66,7 +67,6 @@ Chosen to introduce no new patterns. Precedents surveyed:
 ## Out of scope (YAGNI)
 - Library `settings` object (create/update).
 - Folder edits via update (ABS doesn't support).
-- Delete confirmation prompt.
 
 ## Notes
 - `DELETE` returns the deleted library JSON (not an empty 200), so the command prints the `Library`.

--- a/src/AbsCli/Api/ApiEndpoints.cs
+++ b/src/AbsCli/Api/ApiEndpoints.cs
@@ -6,6 +6,7 @@ public static class ApiEndpoints
     public const string AuthRefresh = "auth/refresh";
 
     public const string Libraries = "api/libraries";
+    public const string LibrariesOrder = "api/libraries/order";
     public static string Library(string id) => $"api/libraries/{id}";
     public static string LibraryItems(string libraryId) => $"api/libraries/{libraryId}/items";
     public static string LibrarySeries(string libraryId) => $"api/libraries/{libraryId}/series";

--- a/src/AbsCli/Commands/AuthorsCommand.cs
+++ b/src/AbsCli/Commands/AuthorsCommand.cs
@@ -191,7 +191,7 @@ public static class AuthorsCommand
                 _logger.Error("--name cannot be empty");
                 Environment.Exit(1);
             }
-            var body = BuildUpdateBodyForTesting(name, description, asin);
+            var body = BuildUpdateBody(name, description, asin);
             if (body.Count == 0)
             {
                 _logger.Error("Specify at least one of --name, --description, --asin");
@@ -211,7 +211,7 @@ public static class AuthorsCommand
     /// absent (omit from JSON), empty string = clear (send JSON null),
     /// non-empty = set value. Exposed internally for unit testing.
     /// </summary>
-    internal static Dictionary<string, string> BuildUpdateBodyForTesting(string? name, string? description, string? asin)
+    internal static Dictionary<string, string> BuildUpdateBody(string? name, string? description, string? asin)
     {
         var body = new Dictionary<string, string>();
         if (!string.IsNullOrEmpty(name))

--- a/src/AbsCli/Commands/CollectionsCommand.cs
+++ b/src/AbsCli/Commands/CollectionsCommand.cs
@@ -182,7 +182,7 @@ public static class CollectionsCommand
                 Environment.Exit(1);
                 return 1;
             }
-            var body = BuildUpdateBodyForTesting(name, description);
+            var body = BuildUpdateBody(name, description);
             if (body.Count == 0)
             {
                 _logger.Error("Specify at least one of --name, --description");
@@ -383,9 +383,9 @@ public static class CollectionsCommand
     /// Build the PATCH body honouring tri-state semantics: null = field
     /// absent (omit from JSON), empty string = clear (send JSON null),
     /// non-empty = set value. Exposed internally for unit testing.
-    /// Mirrors <c>AuthorsCommand.BuildUpdateBodyForTesting</c>.
+    /// Mirrors <c>AuthorsCommand.BuildUpdateBody</c>.
     /// </summary>
-    internal static Dictionary<string, string> BuildUpdateBodyForTesting(string? name, string? description)
+    internal static Dictionary<string, string> BuildUpdateBody(string? name, string? description)
     {
         var body = new Dictionary<string, string>();
         if (!string.IsNullOrEmpty(name))

--- a/src/AbsCli/Commands/LibrariesCommand.cs
+++ b/src/AbsCli/Commands/LibrariesCommand.cs
@@ -149,8 +149,7 @@ public static class LibrariesCommand
         { idOption, nameOption, mediaTypeOption, providerOption, iconOption, displayOrderOption };
         command.AddPermissionRequired("admin");
         command.AddHelpSection("Notes", HelpSectionPosition.Top,
-            "Folders are NOT editable here. Empty --name is rejected. At least",
-            "one edit flag is required.");
+            "Empty --name is rejected. At least one edit flag is required.");
         command.AddExamples(
             "abs-cli libraries update --id \"lib_1\" --name \"Renamed\"",
             "abs-cli libraries update --id \"lib_1\" --display-order 2");
@@ -169,7 +168,7 @@ public static class LibrariesCommand
                 Environment.Exit(1);
                 return 1;
             }
-            var body = BuildUpdateBodyForTesting(name, mediaType, provider, icon, displayOrder);
+            var body = BuildUpdateBody(name, mediaType, provider, icon, displayOrder);
             if (body.Name == null && body.MediaType == null && body.Provider == null && body.Icon == null && body.DisplayOrder == null)
             {
                 _logger.Error("Specify at least one of --name, --media-type, --provider, --icon, --display-order");
@@ -187,9 +186,10 @@ public static class LibrariesCommand
 
     /// <summary>
     /// Build the PATCH body from the flags, coercing empty strings to null so
-    /// they are omitted. Exposed internally for unit testing.
+    /// they are omitted. The production body builder for `update`; exposed
+    /// <c>internal</c> so it can be unit-tested directly.
     /// </summary>
-    internal static LibraryUpdateRequest BuildUpdateBodyForTesting(string? name, string? mediaType, string? provider, string? icon, int? displayOrder)
+    internal static LibraryUpdateRequest BuildUpdateBody(string? name, string? mediaType, string? provider, string? icon, int? displayOrder)
     {
         return new LibraryUpdateRequest
         {
@@ -218,10 +218,8 @@ public static class LibrariesCommand
             "in it, all collections for the library, and removes it from playlists",
             "and playback sessions. Cannot be undone. Returns the deleted library.",
             "",
-            "Guarded: the target library is fetched and you must type its exact",
-            "name to confirm (the name is shown in the prompt). There is no --yes",
-            "bypass, so an agent cannot delete a library without deliberately",
-            "supplying the name on stdin. Non-matching input aborts (exit 1).");
+            "Guarded: you must type the library's exact name to confirm (the",
+            "name is shown in the prompt). Non-matching input aborts (exit 1).");
         command.AddExamples(
             "abs-cli libraries delete --id \"lib_1\"");
         command.AddResponseExample<Library>();

--- a/src/AbsCli/Commands/LibrariesCommand.cs
+++ b/src/AbsCli/Commands/LibrariesCommand.cs
@@ -7,12 +7,18 @@ namespace AbsCli.Commands;
 
 public static class LibrariesCommand
 {
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+
     public static Command Create()
     {
         var command = new Command("libraries", "Manage libraries");
         command.Subcommands.Add(CreateListCommand());
         command.Subcommands.Add(CreateGetCommand());
         command.Subcommands.Add(CreateScanCommand());
+        command.Subcommands.Add(CreateCreateCommand());
+        command.Subcommands.Add(CreateUpdateCommand());
+        command.Subcommands.Add(CreateDeleteCommand());
+        command.Subcommands.Add(CreateReorderCommand());
         return command;
     }
 
@@ -78,6 +84,184 @@ public static class LibrariesCommand
             var libraryId = CommandHelper.RequireLibrary(config);
             var service = new LibrariesService(client);
             await service.ScanAsync(libraryId, force);
+            return 0;
+        });
+        return command;
+    }
+
+    private static Command CreateCreateCommand()
+    {
+        var nameOption = new Option<string>("--name") { Description = "Library name", Required = true };
+        var folderOption = new Option<string[]>("--folder") { Description = "Server-side folder path (repeatable; created if missing)", AllowMultipleArgumentsPerToken = true };
+        var mediaTypeOption = new Option<string?>("--media-type") { Description = "book | podcast (default book)" };
+        var providerOption = new Option<string?>("--provider") { Description = "Metadata provider (default google)" };
+        var iconOption = new Option<string?>("--icon") { Description = "Library icon (default database)" };
+        var command = new Command("create", "Create a new library")
+        { nameOption, folderOption, mediaTypeOption, providerOption, iconOption };
+        command.AddPermissionRequired("admin");
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "Folder paths are SERVER-SIDE and are created on the server if missing.",
+            "At least one --folder is required. Library settings are not",
+            "configurable here.");
+        command.AddExamples(
+            "abs-cli libraries create --name \"Audiobooks\" --folder /audiobooks",
+            "abs-cli libraries create --name \"Pods\" --folder /pods --media-type podcast");
+        command.AddResponseExample<Library>();
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var name = parseResult.GetValue(nameOption)!;
+            var folders = parseResult.GetValue(folderOption) ?? Array.Empty<string>();
+            var mediaType = parseResult.GetValue(mediaTypeOption);
+            var provider = parseResult.GetValue(providerOption);
+            var icon = parseResult.GetValue(iconOption);
+            if (folders.Length == 0)
+            {
+                _logger.Error("At least one --folder is required.");
+                Environment.Exit(1);
+                return 1;
+            }
+            var body = new LibraryCreateRequest
+            {
+                Name = name,
+                Folders = folders.Select(f => new LibraryFolderRequest { FullPath = f }).ToList(),
+                MediaType = string.IsNullOrEmpty(mediaType) ? null : mediaType,
+                Provider = string.IsNullOrEmpty(provider) ? null : provider,
+                Icon = string.IsNullOrEmpty(icon) ? null : icon
+            };
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new LibrariesService(client);
+            var result = await service.CreateAsync(body);
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.Library);
+            return 0;
+        });
+        return command;
+    }
+
+    private static Command CreateUpdateCommand()
+    {
+        var idOption = new Option<string>("--id") { Description = "Library ID", Required = true };
+        var nameOption = new Option<string?>("--name") { Description = "New name" };
+        var mediaTypeOption = new Option<string?>("--media-type") { Description = "New media type (book | podcast)" };
+        var providerOption = new Option<string?>("--provider") { Description = "New metadata provider" };
+        var iconOption = new Option<string?>("--icon") { Description = "New icon" };
+        var displayOrderOption = new Option<int?>("--display-order") { Description = "New display order (number)" };
+        var command = new Command("update", "Edit a library's name, media type, provider, icon, or display order")
+        { idOption, nameOption, mediaTypeOption, providerOption, iconOption, displayOrderOption };
+        command.AddPermissionRequired("admin");
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "Folders are NOT editable here. Empty --name is rejected. At least",
+            "one edit flag is required.");
+        command.AddExamples(
+            "abs-cli libraries update --id \"lib_1\" --name \"Renamed\"",
+            "abs-cli libraries update --id \"lib_1\" --display-order 2");
+        command.AddResponseExample<Library>();
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var id = parseResult.GetValue(idOption)!;
+            var name = parseResult.GetValue(nameOption);
+            var mediaType = parseResult.GetValue(mediaTypeOption);
+            var provider = parseResult.GetValue(providerOption);
+            var icon = parseResult.GetValue(iconOption);
+            var displayOrder = parseResult.GetValue(displayOrderOption);
+            if (name is not null && string.IsNullOrEmpty(name))
+            {
+                _logger.Error("--name cannot be empty");
+                Environment.Exit(1);
+                return 1;
+            }
+            var body = BuildUpdateBodyForTesting(name, mediaType, provider, icon, displayOrder);
+            if (body.Name == null && body.MediaType == null && body.Provider == null && body.Icon == null && body.DisplayOrder == null)
+            {
+                _logger.Error("Specify at least one of --name, --media-type, --provider, --icon, --display-order");
+                Environment.Exit(1);
+                return 1;
+            }
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new LibrariesService(client);
+            var result = await service.UpdateAsync(id, body);
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.Library);
+            return 0;
+        });
+        return command;
+    }
+
+    /// <summary>
+    /// Build the PATCH body from the flags, coercing empty strings to null so
+    /// they are omitted. Exposed internally for unit testing.
+    /// </summary>
+    internal static LibraryUpdateRequest BuildUpdateBodyForTesting(string? name, string? mediaType, string? provider, string? icon, int? displayOrder)
+    {
+        return new LibraryUpdateRequest
+        {
+            Name = string.IsNullOrEmpty(name) ? null : name,
+            MediaType = string.IsNullOrEmpty(mediaType) ? null : mediaType,
+            Provider = string.IsNullOrEmpty(provider) ? null : provider,
+            Icon = string.IsNullOrEmpty(icon) ? null : icon,
+            DisplayOrder = displayOrder
+        };
+    }
+
+    private static Command CreateDeleteCommand()
+    {
+        var idOption = new Option<string>("--id") { Description = "Library ID", Required = true };
+        var command = new Command("delete", "Delete a library and ALL its contents") { idOption };
+        command.AddPermissionRequired("admin");
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "DESTRUCTIVE CASCADE: permanently deletes the library AND every item",
+            "in it, all collections for the library, and removes it from playlists",
+            "and playback sessions. No confirmation prompt. Returns the deleted",
+            "library.");
+        command.AddExamples(
+            "abs-cli libraries delete --id \"lib_1\"");
+        command.AddResponseExample<Library>();
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var id = parseResult.GetValue(idOption)!;
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new LibrariesService(client);
+            var result = await service.DeleteAsync(id);
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.Library);
+            return 0;
+        });
+        return command;
+    }
+
+    private static Command CreateReorderCommand()
+    {
+        var inputOption = new Option<string?>("--input") { Description = "JSON file with an array of {id, newOrder}" };
+        var stdinOption = new Option<bool>("--stdin") { Description = "Read the reorder JSON array from stdin" };
+        var command = new Command("reorder", "Reorder libraries by display order")
+        { inputOption, stdinOption };
+        command.AddPermissionRequired("admin");
+        command.AddHelpSection("Notes", HelpSectionPosition.Top,
+            "Body is a JSON array of objects: [{\"id\":\"lib_1\",\"newOrder\":1}, ...].");
+        command.AddExamples(
+            "abs-cli libraries reorder --input order.json",
+            "echo '[{\"id\":\"lib_1\",\"newOrder\":1}]' | abs-cli libraries reorder --stdin");
+        command.AddResponseExample<LibraryListResponse>();
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var input = parseResult.GetValue(inputOption);
+            var stdin = parseResult.GetValue(stdinOption);
+            if (stdin && input != null)
+            {
+                _logger.Error("Provide --input or --stdin, not both.");
+                Environment.Exit(1);
+                return 1;
+            }
+            string orderJson;
+            if (stdin) orderJson = await Console.In.ReadToEndAsync(cancellationToken);
+            else if (input != null) orderJson = CommandHelper.ReadJsonInput(input);
+            else
+            {
+                _logger.Error("Provide --input <file> or --stdin.");
+                Environment.Exit(1);
+                return 1;
+            }
+            var (client, _) = CommandHelper.BuildClient();
+            var service = new LibrariesService(client);
+            var result = await service.ReorderAsync(orderJson);
+            ConsoleOutput.WriteJson(result, AppJsonContext.Default.LibraryListResponse);
             return 0;
         });
         return command;

--- a/src/AbsCli/Commands/LibrariesCommand.cs
+++ b/src/AbsCli/Commands/LibrariesCommand.cs
@@ -201,6 +201,13 @@ public static class LibrariesCommand
         };
     }
 
+    /// <summary>
+    /// True when the typed confirmation (trimmed) exactly matches the library
+    /// name. Case-sensitive; null/empty never matches. Exposed for testing.
+    /// </summary>
+    internal static bool ConfirmationMatches(string? input, string libraryName)
+        => input?.Trim() == libraryName;
+
     private static Command CreateDeleteCommand()
     {
         var idOption = new Option<string>("--id") { Description = "Library ID", Required = true };
@@ -209,8 +216,12 @@ public static class LibrariesCommand
         command.AddHelpSection("Notes", HelpSectionPosition.Top,
             "DESTRUCTIVE CASCADE: permanently deletes the library AND every item",
             "in it, all collections for the library, and removes it from playlists",
-            "and playback sessions. No confirmation prompt. Returns the deleted",
-            "library.");
+            "and playback sessions. Cannot be undone. Returns the deleted library.",
+            "",
+            "Guarded: the target library is fetched and you must type its exact",
+            "name to confirm (the name is shown in the prompt). There is no --yes",
+            "bypass, so an agent cannot delete a library without deliberately",
+            "supplying the name on stdin. Non-matching input aborts (exit 1).");
         command.AddExamples(
             "abs-cli libraries delete --id \"lib_1\"");
         command.AddResponseExample<Library>();
@@ -219,6 +230,20 @@ public static class LibrariesCommand
             var id = parseResult.GetValue(idOption)!;
             var (client, _) = CommandHelper.BuildClient();
             var service = new LibrariesService(client);
+            // Fetch first so the confirmation prompt can show what will be
+            // destroyed (a deliberate pre-fetch — the safety gate needs the name).
+            var library = await service.GetAsync(id);
+            Console.Error.WriteLine(
+                $"WARNING: this permanently deletes library \"{library.Name}\" ({library.Id}) and ALL its " +
+                "contents (items, collections, playlist/session references). This cannot be undone.");
+            Console.Error.Write("Type the library name to confirm: ");
+            var confirmation = Console.In.ReadLine();
+            if (!ConfirmationMatches(confirmation, library.Name))
+            {
+                _logger.Error("Confirmation did not match the library name. Aborted.");
+                Environment.Exit(1);
+                return 1;
+            }
             var result = await service.DeleteAsync(id);
             ConsoleOutput.WriteJson(result, AppJsonContext.Default.Library);
             return 0;

--- a/src/AbsCli/Commands/SeriesCommand.cs
+++ b/src/AbsCli/Commands/SeriesCommand.cs
@@ -102,7 +102,7 @@ public static class SeriesCommand
                 _logger.Error("--name cannot be empty");
                 Environment.Exit(1);
             }
-            var body = BuildUpdateBodyForTesting(name, description);
+            var body = BuildUpdateBody(name, description);
             if (body.Count == 0)
             {
                 _logger.Error("Specify at least one of --name, --description");
@@ -122,7 +122,7 @@ public static class SeriesCommand
     /// rejected upstream); description is included whenever supplied, so an
     /// empty string clears it server-side. Exposed internally for unit testing.
     /// </summary>
-    internal static Dictionary<string, string> BuildUpdateBodyForTesting(string? name, string? description)
+    internal static Dictionary<string, string> BuildUpdateBody(string? name, string? description)
     {
         var body = new Dictionary<string, string>();
         if (!string.IsNullOrEmpty(name))

--- a/src/AbsCli/Models/JsonContext.cs
+++ b/src/AbsCli/Models/JsonContext.cs
@@ -77,6 +77,9 @@ namespace AbsCli.Models;
 [JsonSerializable(typeof(ProgressUpdateRequest))]
 [JsonSerializable(typeof(Me))]
 [JsonSerializable(typeof(UserPermissions))]
+[JsonSerializable(typeof(LibraryFolderRequest))]
+[JsonSerializable(typeof(LibraryCreateRequest))]
+[JsonSerializable(typeof(LibraryUpdateRequest))]
 [JsonSourceGenerationOptions(WriteIndented = true)]
 public partial class AppJsonContext : JsonSerializerContext;
 

--- a/src/AbsCli/Models/LibraryRequests.cs
+++ b/src/AbsCli/Models/LibraryRequests.cs
@@ -1,0 +1,56 @@
+using System.Text.Json.Serialization;
+
+namespace AbsCli.Models;
+
+/// <summary>Folder entry for POST /api/libraries (server-side path).</summary>
+public class LibraryFolderRequest
+{
+    [JsonPropertyName("fullPath")]
+    public string FullPath { get; set; } = "";
+}
+
+/// <summary>Request body for POST /api/libraries. Null optionals are omitted (server defaults apply).</summary>
+public class LibraryCreateRequest
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("folders")]
+    public List<LibraryFolderRequest> Folders { get; set; } = new();
+
+    [JsonPropertyName("mediaType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MediaType { get; set; }
+
+    [JsonPropertyName("provider")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Provider { get; set; }
+
+    [JsonPropertyName("icon")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Icon { get; set; }
+}
+
+/// <summary>Request body for PATCH /api/libraries/:id. Null fields are omitted.</summary>
+public class LibraryUpdateRequest
+{
+    [JsonPropertyName("name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("mediaType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MediaType { get; set; }
+
+    [JsonPropertyName("provider")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Provider { get; set; }
+
+    [JsonPropertyName("icon")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Icon { get; set; }
+
+    [JsonPropertyName("displayOrder")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? DisplayOrder { get; set; }
+}

--- a/src/AbsCli/Services/LibrariesService.cs
+++ b/src/AbsCli/Services/LibrariesService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using AbsCli.Api;
 using AbsCli.Models;
 
@@ -27,5 +28,27 @@ public class LibrariesService
         var url = ApiEndpoints.LibraryScan(libraryId);
         if (force) url += "?force=1";
         await _client.PostEmptyAsync(url, "'admin' access");
+    }
+
+    public async Task<Library> CreateAsync(LibraryCreateRequest body)
+    {
+        var json = JsonSerializer.Serialize(body, AppJsonContext.Default.LibraryCreateRequest);
+        return await _client.PostAsync(ApiEndpoints.Libraries, json, AppJsonContext.Default.Library, "admin permission");
+    }
+
+    public async Task<Library> UpdateAsync(string id, LibraryUpdateRequest body)
+    {
+        var json = JsonSerializer.Serialize(body, AppJsonContext.Default.LibraryUpdateRequest);
+        return await _client.PatchAsync(ApiEndpoints.Library(id), json, AppJsonContext.Default.Library, "admin permission");
+    }
+
+    public async Task<Library> DeleteAsync(string id)
+    {
+        return await _client.DeleteAsync(ApiEndpoints.Library(id), AppJsonContext.Default.Library, "admin permission");
+    }
+
+    public async Task<LibraryListResponse> ReorderAsync(string orderJson)
+    {
+        return await _client.PostAsync(ApiEndpoints.LibrariesOrder, orderJson, AppJsonContext.Default.LibraryListResponse, "admin permission");
     }
 }

--- a/tests/AbsCli.Tests/Api/ApiEndpointsTests.cs
+++ b/tests/AbsCli.Tests/Api/ApiEndpointsTests.cs
@@ -64,4 +64,10 @@ public class ApiEndpointsTests
     {
         Assert.Equal("api/items/li_1/ffprobe/12345", ApiEndpoints.ItemFfprobe("li_1", "12345"));
     }
+
+    [Fact]
+    public void LibrariesOrder_IsStable()
+    {
+        Assert.Equal("api/libraries/order", ApiEndpoints.LibrariesOrder);
+    }
 }

--- a/tests/AbsCli.Tests/Commands/AuthorsCommandTests.cs
+++ b/tests/AbsCli.Tests/Commands/AuthorsCommandTests.cs
@@ -114,7 +114,7 @@ public class AuthorsCommandTests
     [InlineData("Foo", "", "", "{\"name\": \"Foo\",\"description\": null,\"asin\": null}")]
     public void AuthorsUpdate_BuildBody_TriState(string? name, string? description, string? asin, string expected)
     {
-        var body = AuthorsCommand.BuildUpdateBodyForTesting(name, description, asin);
+        var body = AuthorsCommand.BuildUpdateBody(name, description, asin);
         var json = System.Text.Json.JsonSerializer.Serialize(
             body, AbsCli.Models.AppJsonContext.Default.DictionaryStringString);
         var expectedFragments = expected.Trim('{', '}').Split(',')

--- a/tests/AbsCli.Tests/Commands/CollectionsCommandTests.cs
+++ b/tests/AbsCli.Tests/Commands/CollectionsCommandTests.cs
@@ -98,7 +98,7 @@ public class CollectionsCommandTests
     [Fact]
     public void CollectionsUpdate_BuildBody_OmitsNullKeys()
     {
-        var body = CollectionsCommand.BuildUpdateBodyForTesting(name: "X", description: null);
+        var body = CollectionsCommand.BuildUpdateBody(name: "X", description: null);
         Assert.Single(body);
         Assert.Equal("X", body["name"]);
     }
@@ -106,7 +106,7 @@ public class CollectionsCommandTests
     [Fact]
     public void CollectionsUpdate_BuildBody_ClearsOnEmptyString()
     {
-        var body = CollectionsCommand.BuildUpdateBodyForTesting(name: null, description: "");
+        var body = CollectionsCommand.BuildUpdateBody(name: null, description: "");
         Assert.Single(body);
         Assert.Null(body["description"]); // null = JSON null on the wire
     }
@@ -114,7 +114,7 @@ public class CollectionsCommandTests
     [Fact]
     public void CollectionsUpdate_BuildBody_SetsBothWhenProvided()
     {
-        var body = CollectionsCommand.BuildUpdateBodyForTesting(name: "n", description: "d");
+        var body = CollectionsCommand.BuildUpdateBody(name: "n", description: "d");
         Assert.Equal(2, body.Count);
         Assert.Equal("n", body["name"]);
         Assert.Equal("d", body["description"]);

--- a/tests/AbsCli.Tests/Commands/LibrariesCommandTests.cs
+++ b/tests/AbsCli.Tests/Commands/LibrariesCommandTests.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using AbsCli.Commands;
+using AbsCli.Models;
 using Xunit;
 
 namespace AbsCli.Tests.Commands;
@@ -19,10 +20,55 @@ public class LibrariesCommandTests
     }
 
     [Fact]
-    public void Libraries_HasListGetScan()
+    public void Libraries_HasAllSubcommands()
     {
         var verbs = LibrariesCommand.Create().Subcommands.Select(c => c.Name).ToList();
-        Assert.Equal(new[] { "list", "get", "scan" }, verbs);
+        Assert.Equal(new[] { "list", "get", "scan", "create", "update", "delete", "reorder" }, verbs);
+    }
+
+    [Fact]
+    public void LibrariesCreate_RequiresAdmin_AndHasFolderAndNameOptions()
+    {
+        var output = RenderHelp("libraries", "create").Replace("\r\n", "\n");
+        Assert.Contains("Permission required:\n  admin", output);
+        Assert.Contains("--name", output);
+        Assert.Contains("--folder", output);
+        Assert.Contains("--media-type", output);
+    }
+
+    [Fact]
+    public void LibrariesUpdate_RequiresAdmin()
+    {
+        var output = RenderHelp("libraries", "update").Replace("\r\n", "\n");
+        Assert.Contains("Permission required:\n  admin", output);
+        Assert.Contains("--id", output);
+        Assert.Contains("--display-order", output);
+    }
+
+    [Fact]
+    public void LibrariesDelete_RequiresAdmin_AndWarnsCascade()
+    {
+        var output = RenderHelp("libraries", "delete").Replace("\r\n", "\n");
+        Assert.Contains("Permission required:\n  admin", output);
+        Assert.Contains("cascade", output.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void LibrariesReorder_RequiresAdmin_AndHasInputStdin()
+    {
+        var output = RenderHelp("libraries", "reorder").Replace("\r\n", "\n");
+        Assert.Contains("Permission required:\n  admin", output);
+        Assert.Contains("--input", output);
+        Assert.Contains("--stdin", output);
+    }
+
+    [Fact]
+    public void BuildUpdateBody_OmitsUnsetIncludesSet()
+    {
+        var body = LibrariesCommand.BuildUpdateBodyForTesting("New", null, null, null, 2);
+        Assert.Equal("New", body.Name);
+        Assert.Null(body.MediaType);
+        Assert.Equal(2, body.DisplayOrder);
     }
 
     [Fact]

--- a/tests/AbsCli.Tests/Commands/LibrariesCommandTests.cs
+++ b/tests/AbsCli.Tests/Commands/LibrariesCommandTests.cs
@@ -78,7 +78,7 @@ public class LibrariesCommandTests
     [Fact]
     public void BuildUpdateBody_OmitsUnsetIncludesSet()
     {
-        var body = LibrariesCommand.BuildUpdateBodyForTesting("New", null, null, null, 2);
+        var body = LibrariesCommand.BuildUpdateBody("New", null, null, null, 2);
         Assert.Equal("New", body.Name);
         Assert.Null(body.MediaType);
         Assert.Equal(2, body.DisplayOrder);

--- a/tests/AbsCli.Tests/Commands/LibrariesCommandTests.cs
+++ b/tests/AbsCli.Tests/Commands/LibrariesCommandTests.cs
@@ -51,6 +51,19 @@ public class LibrariesCommandTests
         var output = RenderHelp("libraries", "delete").Replace("\r\n", "\n");
         Assert.Contains("Permission required:\n  admin", output);
         Assert.Contains("cascade", output.ToLowerInvariant());
+        Assert.Contains("confirm", output.ToLowerInvariant());
+    }
+
+    [Theory]
+    [InlineData("My Library", "My Library", true)]
+    [InlineData("  My Library  ", "My Library", true)]
+    [InlineData("my library", "My Library", false)]
+    [InlineData("Wrong", "My Library", false)]
+    [InlineData("", "My Library", false)]
+    [InlineData(null, "My Library", false)]
+    public void ConfirmationMatches_RequiresExactTrimmedName(string? input, string name, bool expected)
+    {
+        Assert.Equal(expected, LibrariesCommand.ConfirmationMatches(input, name));
     }
 
     [Fact]

--- a/tests/AbsCli.Tests/Commands/SeriesCommandTests.cs
+++ b/tests/AbsCli.Tests/Commands/SeriesCommandTests.cs
@@ -71,7 +71,7 @@ public class SeriesCommandTests
     [Fact]
     public void BuildUpdateBody_OmitsUnsetKeys()
     {
-        var body = SeriesCommand.BuildUpdateBodyForTesting("New Name", null);
+        var body = SeriesCommand.BuildUpdateBody("New Name", null);
         Assert.True(body.ContainsKey("name"));
         Assert.False(body.ContainsKey("description"));
         Assert.Equal("New Name", body["name"]);
@@ -80,7 +80,7 @@ public class SeriesCommandTests
     [Fact]
     public void BuildUpdateBody_IncludesEmptyDescription()
     {
-        var body = SeriesCommand.BuildUpdateBodyForTesting(null, "");
+        var body = SeriesCommand.BuildUpdateBody(null, "");
         Assert.True(body.ContainsKey("description"));
         Assert.Equal("", body["description"]);
         Assert.False(body.ContainsKey("name"));

--- a/tests/AbsCli.Tests/Services/LibrariesServiceTests.cs
+++ b/tests/AbsCli.Tests/Services/LibrariesServiceTests.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+using AbsCli.Models;
+using Xunit;
+
+namespace AbsCli.Tests.Services;
+
+public class LibrariesServiceTests
+{
+    [Fact]
+    public void LibraryCreateRequest_SerializesFoldersAndName()
+    {
+        var req = new LibraryCreateRequest
+        {
+            Name = "Audiobooks",
+            Folders = new List<LibraryFolderRequest> { new() { FullPath = "/audiobooks" } }
+        };
+        var json = JsonSerializer.Serialize(req, AppJsonContext.Default.LibraryCreateRequest);
+        Assert.Contains("\"name\": \"Audiobooks\"", json);
+        Assert.Contains("\"fullPath\": \"/audiobooks\"", json);
+        Assert.DoesNotContain("mediaType", json);
+        Assert.DoesNotContain("provider", json);
+        Assert.DoesNotContain("icon", json);
+    }
+
+    [Fact]
+    public void LibraryCreateRequest_IncludesOptionalsWhenSet()
+    {
+        var req = new LibraryCreateRequest
+        {
+            Name = "Pods",
+            Folders = new List<LibraryFolderRequest> { new() { FullPath = "/pods" } },
+            MediaType = "podcast",
+            Provider = "itunes",
+            Icon = "podcast"
+        };
+        var json = JsonSerializer.Serialize(req, AppJsonContext.Default.LibraryCreateRequest);
+        Assert.Contains("\"mediaType\": \"podcast\"", json);
+        Assert.Contains("\"provider\": \"itunes\"", json);
+        Assert.Contains("\"icon\": \"podcast\"", json);
+    }
+
+    [Fact]
+    public void LibraryUpdateRequest_OmitsNullFields()
+    {
+        var req = new LibraryUpdateRequest { Name = "Renamed" };
+        var json = JsonSerializer.Serialize(req, AppJsonContext.Default.LibraryUpdateRequest);
+        Assert.Contains("\"name\": \"Renamed\"", json);
+        Assert.DoesNotContain("mediaType", json);
+        Assert.DoesNotContain("displayOrder", json);
+    }
+
+    [Fact]
+    public void LibraryUpdateRequest_IncludesDisplayOrder()
+    {
+        var req = new LibraryUpdateRequest { DisplayOrder = 3 };
+        var json = JsonSerializer.Serialize(req, AppJsonContext.Default.LibraryUpdateRequest);
+        Assert.Contains("\"displayOrder\": 3", json);
+        Assert.DoesNotContain("\"name\"", json);
+    }
+}

--- a/tools/GenerateResponseExamples/Program.cs
+++ b/tools/GenerateResponseExamples/Program.cs
@@ -116,6 +116,9 @@ internal static class Program
             typeof(TagRenameRequest),
             typeof(GenreRenameRequest),
             typeof(NarratorRenameRequest),
+            typeof(LibraryFolderRequest),
+            typeof(LibraryCreateRequest),
+            typeof(LibraryUpdateRequest),
         };
 
         // JsonSerializableAttribute.Type is not a public property in .NET 8 —


### PR DESCRIPTION
## Summary

Adds the four admin library-management endpoints to the `libraries` command:

- **`libraries create --name <n> --folder <path>… [--media-type] [--provider] [--icon]`** — `POST /api/libraries`. Repeatable `--folder` (like `upload --files`); folders are **server-side** paths (ABS creates them if missing). ≥1 folder required.
- **`libraries update --id <id> [--name] [--media-type] [--provider] [--icon] [--display-order]`** — `PATCH /api/libraries/:id`. Scalar edits only (folders **not** editable here); empty `--name` rejected; at least one flag required.
- **`libraries delete --id <id>`** — `DELETE /api/libraries/:id`. **Destructive cascade** (library + all items, collections, playlist/session refs). **Confirmation-gated:** fetches the library, shows its name, and requires the operator to type the exact name on stdin to proceed. **No `--yes` bypass** (a flag isn't a real gate against an agent; the typed name is). Non-matching input aborts. This is the only gated command in the CLI — deliberate, given the blast radius.
- **`libraries reorder {--input <file> | --stdin}`** — `POST /api/libraries/order`. JSON array of `{id, newOrder}`, mirroring `collections reorder`.

All four are `admin`. Settings object dropped (YAGNI).

## Changes

- New request models (`LibraryCreateRequest`/`LibraryFolderRequest`/`LibraryUpdateRequest`, null-omitting); registered in `JsonContext` and excluded from the response-example generator. Responses reuse existing `Library`/`LibraryListResponse`.
- Fix: `docs/abs-api-coverage.md` — `POST /api/libraries/order` permission `?` → `admin`; the four rows marked ✅ (PATCH/DELETE corrected to `admin`, matching their `isAdminOrUp` checks).
- README Commands table updated.

## Test Plan

- [x] 377/377 unit tests (model round-trips, endpoint, command help/structure, `ConfirmationMatches` gate logic); `dotnet format --verify-no-changes` clean
- [x] Smoke test passed against local docker-compose stack (313 passed, 0 failed): self-cleaning create → update → reorder → gated delete (wrong-name aborts, correct-name deletes) → list-confirm, plus 403 as non-admin `testuser`
- [ ] Reviewer sanity check