### PR TITLE
chore: install ponytail and answer-first skills in devcontainer

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -41,3 +41,7 @@ claude plugin install superpowers@superpowers-dev 2>/dev/null || true
 # --- Ponytail: general code-simplicity discipline (YAGNI, reuse, minimal diff) ---
 claude plugin marketplace add DietrichGebert/ponytail 2>/dev/null || true
 claude plugin install ponytail@ponytail 2>/dev/null || true
+
+# --- answer-first: output-style skill (lead with the answer, cut preamble) ---
+claude plugin marketplace add thomaslazar/answer-first 2>/dev/null || true
+claude plugin install answer-first@razal-skills 2>/dev/null || true

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -37,3 +37,7 @@ jq '. + {statusLine: {type: "command", command: "/home/vscode/.claude/statusline
 # Structured development workflow (brainstorming, planning, TDD, debugging, code review).
 claude plugin marketplace add obra/superpowers 2>/dev/null || true
 claude plugin install superpowers@superpowers-dev 2>/dev/null || true
+
+# --- Ponytail: general code-simplicity discipline (YAGNI, reuse, minimal diff) ---
+claude plugin marketplace add DietrichGebert/ponytail 2>/dev/null || true
+claude plugin install ponytail@ponytail 2>/dev/null || true


### PR DESCRIPTION
Wires two skill plugins into the devcontainer's `post-create.sh`, alongside superpowers, so they're available to anyone building the container:

- **ponytail** (`DietrichGebert/ponytail`, MIT) — general code-simplicity discipline (YAGNI, reuse, stdlib/native first, minimal diff) for work not covered by the abs-cli-specific rules in CLAUDE.md.
- **answer-first** (`thomaslazar/answer-first`, MIT) — output-style skill: lead with the answer, cut preamble/tangents/closers.

Both use `2>/dev/null || true`, so they no-op on rebuild if already present. No source vendored into the repo — installed via the same marketplace mechanism as superpowers.