### PR TITLE
fix: tolerate numeric ebookLocation in mediaProgress (#65)

### DIFF
--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -1072,6 +1072,30 @@ else
     fail "progress get after remove surfaces 404" "got: ${output:0:200}"
 fi
 
+# 8b. Regression (issue #65): a numeric ebookLocation must not crash `me`.
+# ABS types ebookLocation as STRING but stores/echoes bare numbers written to
+# it (SQLite type affinity). The CLI only ever SENDS strings, so the numeric
+# shape is injected here via the raw API to exercise the tolerant read path.
+ABS_TOKEN=$(curl -fsS -X POST "$ABS_URL/login" -H 'Content-Type: application/json' \
+    -d '{"username":"root","password":"root"}' 2>/dev/null \
+    | python3 -c "import sys,json; u=json.load(sys.stdin).get('user',{}); print(u.get('accessToken') or u.get('token') or '')")
+if [ -z "$ABS_TOKEN" ]; then
+    fail "issue #65: obtained API token for raw numeric-ebookLocation PATCH" "login returned no token"
+else
+    curl -fsS -X PATCH "$ABS_URL/api/me/progress/$PROGRESS_LID" \
+        -H "Authorization: Bearer $ABS_TOKEN" -H 'Content-Type: application/json' \
+        -d '{"ebookLocation": 24, "ebookProgress": 0.1}' >/dev/null 2>&1
+    if output=$($CLI me 2>/dev/null); then
+        assert_json_key "issue #65: me survives numeric ebookLocation" "username" "$output"
+    else
+        fail "issue #65: me survives numeric ebookLocation" "me exited non-zero (deserialize crash)"
+    fi
+    output=$($CLI items progress get --library-item "$PROGRESS_LID" 2>/dev/null)
+    assert_json_expr "issue #65: numeric ebookLocation surfaced as string" \
+        "d.get('ebookLocation')=='24'" "$output"
+    $CLI items progress remove --library-item "$PROGRESS_LID" >/dev/null 2>&1 || true
+fi
+
 # 9. progress set with no body flags → exit 1
 output=$($CLI items progress set --library-item "$PROGRESS_LID" 2>&1 || true)
 if echo "$output" | grep -qi "Specify at least one"; then

--- a/src/AbsCli/Models/MediaProgress.cs
+++ b/src/AbsCli/Models/MediaProgress.cs
@@ -45,6 +45,7 @@ public class MediaProgress
     public bool HideFromContinueListening { get; set; }
 
     [JsonPropertyName("ebookLocation")]
+    [JsonConverter(typeof(TolerantStringConverter))]
     public string? EbookLocation { get; set; }
 
     [JsonPropertyName("ebookProgress")]

--- a/src/AbsCli/Models/TolerantStringConverter.cs
+++ b/src/AbsCli/Models/TolerantStringConverter.cs
@@ -1,0 +1,34 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AbsCli.Models;
+
+/// <summary>
+/// Reads a JSON value that ABS declares as a string but may emit as a bare
+/// number. ABS types some columns (e.g. <c>mediaProgress.ebookLocation</c>) as
+/// <c>STRING</c>, but SQLite's loose type affinity lets legacy numeric values
+/// leak through as JSON numbers, crashing a plain <c>string</c> deserialize
+/// (issue #65). String tokens pass through unchanged; number tokens surface as
+/// their raw text (e.g. <c>24</c> → <c>"24"</c>); null stays null. Writes
+/// normally as a string.
+/// </summary>
+public class TolerantStringConverter : JsonConverter<string?>
+{
+    public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => reader.TokenType switch
+        {
+            JsonTokenType.Null => null,
+            JsonTokenType.String => reader.GetString(),
+            // Raw numeric text (e.g. 24 -> "24"). ValueSpan is complete because
+            // the CLI always deserializes from a fully-read response string.
+            JsonTokenType.Number => Encoding.UTF8.GetString(reader.ValueSpan),
+            _ => throw new JsonException($"Unexpected token {reader.TokenType} for string field")
+        };
+
+    public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
+    {
+        if (value is null) writer.WriteNullValue();
+        else writer.WriteStringValue(value);
+    }
+}

--- a/tests/AbsCli.Tests/Services/MeServiceTests.cs
+++ b/tests/AbsCli.Tests/Services/MeServiceTests.cs
@@ -57,6 +57,52 @@ public class MeServiceTests
     }
 
     [Fact]
+    public void MediaProgress_Deserializes_NumericEbookLocation()
+    {
+        // ABS declares ebookLocation as STRING but SQLite type affinity lets
+        // legacy numeric values leak through as bare JSON numbers (issue #65).
+        // The model must tolerate them, surfacing the raw number as a string.
+        var json = """
+        {"id":"mp_3","userId":"u_1","libraryItemId":"li_y","mediaItemId":"b_y",
+         "mediaItemType":"book","duration":0,"progress":0,"currentTime":0,
+         "isFinished":false,"hideFromContinueListening":false,
+         "ebookLocation":24,"ebookProgress":0,
+         "lastUpdate":0,"startedAt":0,"finishedAt":null}
+        """;
+        var back = JsonSerializer.Deserialize(json, AppJsonContext.Default.MediaProgress)!;
+        Assert.Equal("24", back.EbookLocation);
+    }
+
+    [Fact]
+    public void MediaProgress_Deserializes_StringEbookLocation_Unchanged()
+    {
+        // The common case — a locator/CFI string — must still pass through verbatim.
+        var json = """
+        {"id":"mp_4","userId":"u_1","libraryItemId":"li_z","mediaItemId":"b_z",
+         "mediaItemType":"book","duration":0,"progress":0,"currentTime":0,
+         "isFinished":false,"hideFromContinueListening":false,
+         "ebookLocation":"{\"href\":\"x.jpeg\"}","ebookProgress":0,
+         "lastUpdate":0,"startedAt":0,"finishedAt":null}
+        """;
+        var back = JsonSerializer.Deserialize(json, AppJsonContext.Default.MediaProgress)!;
+        Assert.Equal("{\"href\":\"x.jpeg\"}", back.EbookLocation);
+    }
+
+    [Fact]
+    public void MediaProgress_Deserializes_NullEbookLocation()
+    {
+        var json = """
+        {"id":"mp_5","userId":"u_1","libraryItemId":"li_n","mediaItemId":"b_n",
+         "mediaItemType":"book","duration":0,"progress":0,"currentTime":0,
+         "isFinished":false,"hideFromContinueListening":false,
+         "ebookLocation":null,"ebookProgress":0,
+         "lastUpdate":0,"startedAt":0,"finishedAt":null}
+        """;
+        var back = JsonSerializer.Deserialize(json, AppJsonContext.Default.MediaProgress)!;
+        Assert.Null(back.EbookLocation);
+    }
+
+    [Fact]
     public void ProgressUpdateRequest_OmitsUnsetFields()
     {
         // Only is-finished set; CurrentTime/EbookLocation/etc. should be absent from JSON.


### PR DESCRIPTION
Fixes #65.

## Problem
`abs-cli me` (and any command deserializing `mediaProgress[]`) crashes when a `mediaProgress.ebookLocation` comes back as a bare JSON number. ABS declares the column `STRING`, but SQLite's loose type affinity lets legacy numeric values leak through as numbers, which a plain `string?` deserialize can't read.

## Fix
- Add `TolerantStringConverter : JsonConverter<string?>` — `null`→null, `String`→passthrough, `Number`→raw text (`24`→`"24"`). AOT/source-gen-safe.
- Apply it to `MediaProgress.EbookLocation` only (the one field ABS actually emits this way). The write path is unchanged — the CLI still only sends strings.

## Verification
- Unit tests: numeric, string, and null `ebookLocation` deserialize correctly.
- Confirmed empirically against live ABS that an API-written numeric `ebookLocation` echoes back as a JSON number, and that the fixed **AOT** binary reads it as `"24"` without crashing (self-test 68/68).
- Smoke regression: injects a numeric `ebookLocation` via the raw API (the CLI can't emit one) and asserts `me` + `items progress get` survive. Full smoke 333/0.