### PR TITLE
chore: raise MaxTestedVersion to 2.36.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       audiobookshelf:
-        image: advplyr/audiobookshelf:2.35.1
+        image: advplyr/audiobookshelf:2.36.0
         # The smoke authenticates via `abs-cli login` at every section, which
         # exceeds ABS's default auth rate limit (40 logins / 10 min). Disable
         # it on this disposable CI instance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ test: add metadata update assertion to smoke tests
 - Expected location: `temp/audiobookshelf/` (gitignored). If missing, clone the currently supported version before referencing API code:
   ```bash
   # Supported version is set in src/AbsCli/Api/AbsApiClient.cs (MinSupportedVersion / MaxTestedVersion)
-  git clone --depth 1 --branch v2.35.1 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
+  git clone --depth 1 --branch v2.36.0 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
   ```
 - Replace the version tag with whatever `MaxTestedVersion` is currently set to.
 - Use this checkout to verify endpoints, controllers, request/response shapes, and permission checks before designing or changing CLI commands.

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Errors and warnings go to stderr by default with a timestamp + level prefix:
 
 ```
 2026-05-19T14:23:45.123Z ERROR Permission denied. This operation requires 'update' permission.
-2026-05-19T14:23:45.123Z WARN  ABS server version 2.36.0 has not been tested with this version of abs-cli.
+2026-05-19T14:23:45.123Z WARN  ABS server version 2.37.0 has not been tested with this version of abs-cli.
 ```
 
 Add `--debug` to any command (or set `ABS_DEBUG=1` in the environment) to also emit one stderr line per HTTP call (method + full URL + status code, plus the response body on non-2xx), token-refresh decisions, and version-check decisions.
@@ -358,7 +358,7 @@ See [docs/](docs/) for architecture, authentication, build targets, and more.
 
 ## Compatibility
 
-Tested against Audiobookshelf **2.33.1 — 2.35.1**. The CLI warns on login if the server version is outside the tested range. See [docs/abs-compatibility.md](docs/abs-compatibility.md) for the full compatibility matrix and policy.
+Tested against Audiobookshelf **2.33.1 — 2.36.0**. The CLI warns on login if the server version is outside the tested range. See [docs/abs-compatibility.md](docs/abs-compatibility.md) for the full compatibility matrix and policy.
 
 ## License
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   audiobookshelf:
-    image: advplyr/audiobookshelf:2.35.1
+    image: advplyr/audiobookshelf:2.36.0
     ports:
       - "13378:80"
     volumes:

--- a/docs/abs-api-coverage.md
+++ b/docs/abs-api-coverage.md
@@ -5,29 +5,29 @@ any) that implements it.
 
 - **Reference:** ABS server source at `temp/audiobookshelf/server/routers/`
   (routes) and `server/controllers/` (handlers). Tested range:
-  `2.33.1 – 2.35.1` (`AbsApiClient.cs`).
+  `2.33.1 – 2.36.0` (`AbsApiClient.cs`).
 - **Permission** column uses ABS's tokens (`admin` / `update` / `upload` /
   `download` / `delete`); blank = any authenticated user. `?` = not visible at
   the router layer.
 - ✅ = covered by a CLI command · — = not implemented · 🔒 = internal-only
-  (no user-facing verb).
+  (no user-facing verb); 🔒 rows never count as covered.
 
 ## Coverage summary
 
 | Resource | Covered / Total |
 |----------|-----------------|
-| Libraries | 4 / 27 |
-| Items | 13 / 26 |
-| Me (current user) | 5 / 18 |
+| Libraries | 16 / 28 |
+| Items | 16 / 26 |
+| Me (current user) | 5 / 23 |
 | Collections | 9 / 9 |
 | Authors | 7 / 7 |
-| Series | 1 / 2 |
+| Series | 2 / 2 |
 | Backup | 6 / 7 |
-| Search | 4 / 6 |
+| Search | 5 / 6 |
 | Cache | 2 / 2 |
 | Tools | 4 / 4 |
-| Misc | 3 / 16 |
-| Playlists | 0 / 10 |
+| Misc | 8 / 16 |
+| Playlists | 9 / 10 |
 | Podcasts | 0 / 13 |
 | Users | 0 / 9 |
 | Sessions | 0 / 9 |
@@ -39,6 +39,7 @@ any) that implements it.
 | Shares | 0 / 2 |
 | Stats | 0 / 2 |
 | Filesystem | 0 / 2 |
+| Auth (non-`/api`) | 1 / 2 |
 
 ## Libraries
 
@@ -56,7 +57,7 @@ any) that implements it.
 | GET | `/api/libraries/:id/series` | List series | | `series list` ✅ |
 | GET | `/api/libraries/:id/series/:seriesId` | Get series (library-scoped) | | — |
 | GET | `/api/libraries/:id/collections` | List collections | | `collections list` ✅ |
-| GET | `/api/libraries/:id/playlists` | List playlists | | — |
+| GET | `/api/libraries/:id/playlists` | List playlists | | `playlists list` ✅ |
 | GET | `/api/libraries/:id/personalized` | Personalized shelves | | — |
 | GET | `/api/libraries/:id/filterdata` | Valid filter values | | — |
 | GET | `/api/libraries/:id/search` | Search within library | | `search` ✅ |
@@ -109,14 +110,19 @@ any) that implements it.
 | Method | Path | Description | Perm | CLI |
 |--------|------|-------------|------|-----|
 | GET | `/api/me` | Current user profile | | `me` ✅ |
+| GET | `/api/me/sessions` | My auth sessions (paginated) | | — |
+| DELETE | `/api/me/sessions/:id` | Revoke one of my auth sessions | | — |
 | GET | `/api/me/listening-sessions` | My listening sessions | | — |
 | GET | `/api/me/item/listening-sessions/:id/:episodeId?` | Item listening sessions | | — |
 | GET | `/api/me/listening-stats` | My listening stats | | — |
+| GET | `/api/me/progress` | All my media progress | | — |
 | GET | `/api/me/progress/:id/remove-from-continue-listening` | Remove from continue listening | update | — |
 | GET | `/api/me/progress/:id/:episodeId?` | Get media progress | | `items progress get` ✅ |
 | PATCH | `/api/me/progress/batch/update` | Batch update progress | update | `items batch-update-progress` ✅ |
 | PATCH | `/api/me/progress/:libraryItemId/:episodeId?` | Set/create media progress | update | `items progress set` ✅ |
 | DELETE | `/api/me/progress/:id` | Delete media progress | delete | `items progress remove` ✅ |
+| GET | `/api/me/bookmarks` | All my bookmarks | | — |
+| GET | `/api/me/bookmarks/:libraryItemId` | My bookmarks for one item | | — |
 | POST | `/api/me/item/:id/bookmark` | Create bookmark | update | — |
 | PATCH | `/api/me/item/:id/bookmark` | Update bookmark | update | — |
 | DELETE | `/api/me/item/:id/bookmark/:time` | Delete bookmark | delete | — |
@@ -164,16 +170,16 @@ any) that implements it.
 
 | Method | Path | Description | Perm | CLI |
 |--------|------|-------------|------|-----|
-| POST | `/api/playlists` | Create playlist | | — |
+| POST | `/api/playlists` | Create playlist | | `playlists create` ✅ |
 | GET | `/api/playlists` | List my playlists | | — |
-| GET | `/api/playlists/:id` | Get playlist | | — |
-| PATCH | `/api/playlists/:id` | Update playlist | update | — |
-| DELETE | `/api/playlists/:id` | Delete playlist | delete | — |
-| POST | `/api/playlists/:id/item` | Add item | update | — |
-| DELETE | `/api/playlists/:id/item/:itemId/:episodeId?` | Remove item | update | — |
-| POST | `/api/playlists/:id/batch/add` | Batch add | update | — |
-| POST | `/api/playlists/:id/batch/remove` | Batch remove | update | — |
-| POST | `/api/playlists/collection/:collectionId` | Create from collection | | — |
+| GET | `/api/playlists/:id` | Get playlist | | `playlists get` ✅ |
+| PATCH | `/api/playlists/:id` | Update / reorder | update | `playlists update` / `reorder` ✅ |
+| DELETE | `/api/playlists/:id` | Delete playlist | delete | `playlists delete` ✅ |
+| POST | `/api/playlists/:id/item` | Add item | update | `playlists add` ✅ |
+| DELETE | `/api/playlists/:id/item/:itemId/:episodeId?` | Remove item | update | `playlists remove` ✅ |
+| POST | `/api/playlists/:id/batch/add` | Batch add | update | `playlists batch-add` ✅ |
+| POST | `/api/playlists/:id/batch/remove` | Batch remove | update | `playlists batch-remove` ✅ |
+| POST | `/api/playlists/collection/:collectionId` | Create from collection | | `playlists create-from-collection` ✅ |
 
 ## Podcasts
 
@@ -343,12 +349,12 @@ streaming routes are intentionally omitted — out of scope for a management CLI
 | PATCH | `/api/settings` | Update server settings | admin | — |
 | PATCH | `/api/sorting-prefixes` | Update sorting prefixes | admin | — |
 | POST | `/api/authorize` | Authorize user | | 🔒 (login) |
-| GET | `/api/tags` | List tags | admin | — |
-| POST | `/api/tags/rename` | Rename tag | admin | — |
-| DELETE | `/api/tags/:tag` | Delete tag | admin | — |
-| GET | `/api/genres` | List genres | admin | — |
-| POST | `/api/genres/rename` | Rename genre | admin | — |
-| DELETE | `/api/genres/:genre` | Delete genre | admin | — |
+| GET | `/api/tags` | List tags | admin | `tags list` ✅ |
+| POST | `/api/tags/rename` | Rename tag | admin | `tags rename` ✅ |
+| DELETE | `/api/tags/:tag` | Delete tag | admin | `tags delete` ✅ |
+| GET | `/api/genres` | List genres | admin | `genres list` ✅ |
+| POST | `/api/genres/rename` | Rename genre | admin | `genres rename` ✅ |
+| DELETE | `/api/genres/:genre` | Delete genre | admin | `genres delete` ✅ |
 | POST | `/api/validate-cron` | Validate cron expression | admin | — |
 | GET | `/api/auth-settings` | Get auth settings | | — |
 | PATCH | `/api/auth-settings` | Update auth settings | admin | — |

--- a/docs/abs-compatibility.md
+++ b/docs/abs-compatibility.md
@@ -9,7 +9,7 @@ the project README and checked at runtime.
 |----------------|--------------|-------|
 | 0.1.x — 0.2.4   | 2.33.1        | Initial release, baseline API |
 | 0.2.5 — 0.4.0   | 2.33.1 — 2.33.2 | No API surface changes in 2.33.2 (maintenance release; internal refactors, image-endpoint clamping, cross-library bulk-download guard) |
-| 0.5.0+          | 2.33.1 — 2.35.1 | v2.34 closes the upstream batch-update `canUpdate` gap (now returns 403 for users without update permission); v2.35 adds a 60s server-side refresh-token grace period (CLI behavior unchanged). v2.35.1 is a patch with internal-only fixes (BookAuthor dedup guard, case-insensitive user lookup) — no response-shape, endpoint, or permission changes for endpoints abs-cli consumes. DTO sweep confirmed no response-shape changes for endpoints abs-cli consumes. |
+| 0.5.0+          | 2.33.1 — 2.36.0 | v2.34 closes the upstream batch-update `canUpdate` gap (now returns 403 for users without update permission); v2.35 adds a 60s server-side refresh-token grace period (CLI behavior unchanged). v2.35.1 is a patch with internal-only fixes (BookAuthor dedup guard, case-insensitive user lookup). v2.36.0 adds five additive `/api/me/*` routes (auth sessions, bulk progress, bookmarks) that abs-cli does not consume; makes expanded item/book/podcast JSON a strict superset of minified, so expanded responses gain `numFiles`, `numTracks`, `numAudioFiles`, `numChapters`, `ebookFormat` and `numEpisodes` — all additive; the media-level fields pass through untyped, and the CLI now models the new top-level `numFiles` on its expanded-item DTO (it was previously dropped), emitting it only when the server sends it, so output against pre-2.36.0 servers is unchanged. `numEpisodes` stays unmodelled — the podcast DTO is a books-only placeholder; widens the refresh-token grace period to 10 minutes and makes it configurable; and stops accepting refresh tokens as bearer credentials (abs-cli only ever presents one at `POST /auth/refresh`, so unaffected). No response-shape removals, endpoint changes, or permission changes for endpoints abs-cli consumes. |
 
 This table grows as new ABS versions are tested. A single CLI version may support
 multiple ABS versions if the API surface hasn't changed.
@@ -19,7 +19,7 @@ multiple ABS versions if the API surface hasn't changed.
 On first API call, the CLI reads the ABS server version from the login response
 (`serverSettings.version`). If the version is outside the known-compatible range:
 
-- **Newer than tested:** Warning to stderr — e.g. against a hypothetical future release above the tested ceiling: `Warning: ABS server version 2.36.0 has not been tested with this version of abs-cli. Proceed with caution.`
+- **Newer than tested:** Warning to stderr — e.g. against a hypothetical future release above the tested ceiling: `Warning: ABS server version 2.37.0 has not been tested with this version of abs-cli. Proceed with caution.`
 - **Older than supported:** Warning to stderr: `Warning: ABS server version 2.30.0 is older than the minimum supported version (2.33.1). Some features may not work.`
 
 Warnings only — the CLI does not refuse to run. The user decides whether to proceed.
@@ -86,7 +86,8 @@ This directory is gitignored. Re-clone after a fresh checkout if needed. Pin to 
 specific tag to match your target ABS version:
 
 ```bash
-git clone --depth 1 --branch v2.33.1 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
+# Supported version is set in src/AbsCli/Api/AbsApiClient.cs (MinSupportedVersion / MaxTestedVersion)
+git clone --depth 1 --branch v2.36.0 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
 ```
 
 ### Building DTOs from Source

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -55,16 +55,25 @@ Login route is in `server/Auth.js`:
 
 ## Server-side notes
 
-- **v2.35 refresh-token grace period.** ABS 2.35 added 60 seconds of
-  server-side grace on the previous refresh token after a successful
-  rotation (new `lastRefreshToken` / `lastRefreshTokenExpiresAt` columns on
-  the session row; `rotateTokensForSession` keeps the old token usable for
-  one minute, and `POST /auth/refresh` accepts either the current or the
-  prior refresh token within the grace window). This guards against a race
-  between two concurrent refresh callers each issuing a fresh token. abs-cli
-  is single-process and never issues concurrent refreshes, so the grace
-  period is transparent — no CLI behavior change. Request and response
-  shapes are unchanged.
+- **Refresh-token grace period.** ABS 2.35 added 60 seconds of server-side
+  grace on the previous refresh token after a successful rotation (new
+  `lastRefreshToken` / `lastRefreshTokenExpiresAt` columns on the session
+  row, written by `rotateTokensForSession`; `POST /auth/refresh` accepts
+  either the current or the prior refresh token within the window). This
+  guards against a race between two concurrent refresh callers each issuing
+  a fresh token. ABS 2.36 widened the window to 10 minutes and made it
+  configurable (`TokenManager.RefreshTokenGracePeriod`,
+  `REFRESH_TOKEN_GRACE_PERIOD` env var). abs-cli is single-process and never
+  issues concurrent refreshes, so the grace period is transparent — no CLI
+  behavior change. Request and response shapes are unchanged.
+
+- **v2.36 bearer-token type check.** A refresh token is rejected when
+  presented as a `Bearer` credential
+  (`TokenManager.isBearerAccessTokenPayload` gates both the passport JWT
+  strategy and socket auth, rejecting payloads with `type === 'refresh'`).
+  abs-cli sends only its access token as `Bearer` and presents the refresh
+  token exclusively via the `X-Refresh-Token` header on
+  `POST /auth/refresh` — no change needed.
 
 - **Diagnostic logging.** Run any command with `--debug` (or set
   `ABS_DEBUG=1`) to emit token-refresh decisions to stderr. See

--- a/docs/plans/2026-07-30-abs-2.36.0-bump.md
+++ b/docs/plans/2026-07-30-abs-2.36.0-bump.md
@@ -1,0 +1,384 @@
+# ABS 2.36.0 Compatibility Bump Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the CLI's tested-version ceiling from ABS 2.35.1 to 2.36.0, with docs updated, `docs/abs-api-coverage.md` drift corrected, and live-smoke proof of compatibility.
+
+**Architecture:** Version-pin + docs change, plus one additive DTO field. The 2.35.1→2.36.0 server diff is additive-only for every surface abs-cli consumes (five new `/api/me/*` routes it does not call; expanded item JSON promoted to a strict superset of minified), so no CLI logic changes. Four tasks: (1) bump the three version pins + four doc files; (2) audit and correct `docs/abs-api-coverage.md`; (3) verify against a live 2.36.0 stack; (4) model the one new top-level key, `numFiles`, which Task 3 found the expanded DTO was dropping. Task 4 was **discovered during execution** — the original plan asserted no DTO change was needed, and Task 3 Step 5 is the check that disproved it.
+
+**Tech Stack:** C# / .NET 10, docker-compose ABS dev stack, `docker/smoke-test.sh`.
+
+---
+
+## Baseline & conventions
+
+- **Spec:** `docs/specs/2026-07-30-abs-2.36.0-bump-design.md`
+- **Branch:** `chore/abs-2.36.0-bump` — create it before the first commit. Commit the spec, this plan, and the code together on it (per `CLAUDE.md`: docs and delivery reviewed as one unit).
+- The reference checkout `temp/audiobookshelf` is already at `v2.36.0`.
+- No unit test pins the version string (verified: `grep -rn "2\.35\.1\|MaxTested" tests/` is empty), so the bump breaks no tests. Task 3 Step 1 re-verifies.
+- Run `dotnet format AbsCli.sln` before committing (CI enforces `--verify-no-changes`).
+- Out of scope: CLI `<Version>` bump and CHANGELOG (release-owned); `MinSupportedVersion` stays `2.33.1`; no new CLI verbs.
+
+## File structure
+
+- Modify: `src/AbsCli/Api/AbsApiClient.cs` — `MaxTestedVersion` constant.
+- Modify: `docker/docker-compose.yml`, `.github/workflows/build.yml` — ABS image tag.
+- Modify: `README.md`, `CLAUDE.md`, `docs/abs-compatibility.md`, `docs/authentication.md` — docs.
+- Modify: `docs/abs-api-coverage.md` — tested range, five new Me rows, drift audit.
+- Modify: `src/AbsCli/Models/LibraryItemExpanded.cs` — `int? NumFiles` (added by Task 4, discovered mid-execution).
+- Modify: `tests/AbsCli.Tests/Commands/ItemsGetExpandedCommandTests.cs` — stale comment only, no assertion change.
+- Add: `docs/specs/2026-07-30-abs-2.36.0-bump-design.md`, `docs/plans/2026-07-30-abs-2.36.0-bump.md` (already written, committed on the branch).
+
+---
+
+## Task 1: Bump version pins and docs
+
+**Files:**
+- `src/AbsCli/Api/AbsApiClient.cs`
+- `docker/docker-compose.yml`
+- `.github/workflows/build.yml`
+- `README.md`
+- `CLAUDE.md`
+- `docs/abs-compatibility.md`
+- `docs/authentication.md`
+
+- [ ] **Step 1: Bump `MaxTestedVersion`**
+
+In `src/AbsCli/Api/AbsApiClient.cs` (~line 236), change:
+```csharp
+    private static readonly string MaxTestedVersion = "2.35.1";
+```
+to:
+```csharp
+    private static readonly string MaxTestedVersion = "2.36.0";
+```
+(Leave `MinSupportedVersion = "2.33.1"` unchanged.)
+
+- [ ] **Step 2: Bump the docker-compose image**
+
+In `docker/docker-compose.yml` (~line 3), change:
+```yaml
+    image: advplyr/audiobookshelf:2.35.1
+```
+to:
+```yaml
+    image: advplyr/audiobookshelf:2.36.0
+```
+
+- [ ] **Step 3: Bump the CI smoke-test service image**
+
+In `.github/workflows/build.yml` (~line 30), change:
+```yaml
+        image: advplyr/audiobookshelf:2.35.1
+```
+to:
+```yaml
+        image: advplyr/audiobookshelf:2.36.0
+```
+
+- [ ] **Step 4: Update the README tested range**
+
+In `README.md` (~line 361), change `2.33.1 — 2.35.1` to `2.33.1 — 2.36.0`. The surrounding sentence and the link to `docs/abs-compatibility.md` stay as-is.
+
+- [ ] **Step 5: Fix the README warning example**
+
+`README.md` (~line 298) illustrates the "not been tested" warning using `2.36.0`, which is now *inside* the tested range. Change the example version to `2.37.0`:
+```
+2026-05-19T14:23:45.123Z WARN  ABS server version 2.37.0 has not been tested with this version of abs-cli.
+```
+Leave the timestamp alone — it is illustrative, not a date claim about this change.
+
+- [ ] **Step 6: Update the CLAUDE.md reference-clone tag**
+
+In `CLAUDE.md` (~line 80), change:
+```bash
+  git clone --depth 1 --branch v2.35.1 https://github.com/advplyr/audiobookshelf.git temp/audiobookshelf
+```
+to `--branch v2.36.0`.
+
+Do **not** touch `CLAUDE.md:36` — that is a historical note about the 2.35.0 bump landing in PR #43, not a version pin.
+
+- [ ] **Step 7: Extend the compatibility matrix**
+
+In `docs/abs-compatibility.md` (~line 12), the `0.5.0+` row: change the ABS range to `2.33.1 — 2.36.0` and append a 2.36.0 note to the existing Notes text. Keep the existing 2.34 / 2.35 / 2.35.1 sentences — the row is cumulative history. Append:
+
+> v2.36.0 adds five additive `/api/me/*` routes (auth sessions, bulk progress, bookmarks) that abs-cli does not consume; makes expanded item/book/podcast JSON a strict superset of minified, so expanded responses gain `numFiles`, `numTracks`, `numAudioFiles`, `numChapters`, `ebookFormat` and `numEpisodes` — all additive; the media-level fields pass through untyped, and the CLI now models the new top-level `numFiles` on its expanded-item DTO (it was previously dropped), emitting it only when the server sends it, so output against pre-2.36.0 servers is unchanged. `numEpisodes` stays unmodelled — the podcast DTO is a books-only placeholder; widens the refresh-token grace period to 10 minutes and makes it configurable; and stops accepting refresh tokens as bearer credentials (abs-cli only ever presents one at `POST /auth/refresh`, so unaffected). No response-shape removals, endpoint changes, or permission changes for endpoints abs-cli consumes.
+
+The row also ends with a fourth, version-unscoped sentence: "DTO sweep confirmed no response-shape changes for endpoints abs-cli consumes." That claim is now false as written — 2.36.0 *did* add response fields (additively). Keep it only by scoping it to a version; otherwise delete it, since the new text closes with the accurate scoped form ("No response-shape *removals* ..."). Do not leave two contradictory claims about response shapes in the same row.
+
+- [ ] **Step 8: Fix the compatibility-doc warning example**
+
+Same defect as Step 5. In `docs/abs-compatibility.md` (~line 22), change the example version `2.36.0` → `2.37.0` in the "Newer than tested" bullet. Leave the "Older than supported" bullet (`2.30.0`) untouched.
+
+- [ ] **Step 9: Update the authentication grace-period note**
+
+In `docs/authentication.md` (~line 58), the "**v2.35 refresh-token grace period.**" bullet hardcodes 60 seconds / "one minute", which 2.36.0 makes wrong. Rewrite the bullet to:
+
+- keep the 2.35 origin (60 seconds, new `lastRefreshToken` / `lastRefreshTokenExpiresAt` session columns, `POST /auth/refresh` accepting either the current or prior token within the window);
+- state that **2.36 widened the window to 10 minutes and made it configurable** via the server-side `REFRESH_TOKEN_GRACE_PERIOD` env var (`TokenManager.RefreshTokenGracePeriod`);
+- keep the existing conclusion verbatim in substance: abs-cli is single-process, never issues concurrent refreshes, so the grace period is transparent — no CLI behavior change, request and response shapes unchanged.
+
+Then add a **new sibling bullet** under `## Server-side notes`:
+
+> - **v2.36 bearer-token type check.** As of ABS 2.36, a refresh token is rejected when presented as a `Bearer` credential (`TokenManager.isBearerAccessTokenPayload` gates both the passport JWT strategy and socket auth, rejecting payloads with `type === 'refresh'`). abs-cli sends only its access token as `Bearer` and presents the refresh token exclusively via the `X-Refresh-Token` header on `POST /auth/refresh`, so it is correct by construction — no change needed.
+
+- [ ] **Step 10: Confirm no historical reference was rewritten**
+
+```bash
+cd /workspaces/abs-cli
+grep -rn "2\.35\.1" --include=*.cs --include=*.md --include=*.yml . | grep -v temp/ | grep -v 'docs/plans/' | grep -v 'docs/specs/' | grep -v CHANGELOG
+```
+Expected: **exactly two hits**, both legitimate — `docs/abs-api-coverage.md:8` (Task 2 owns that file) and the cumulative-history sentence in `docs/abs-compatibility.md:12` that describes the 2.35.1 patch, which Step 7 explicitly preserves. Any *other* hit is a pin that Steps 1–9 missed.
+
+(Note: do not anchor the `grep -v` patterns with `^\./` — this environment's `grep -r .` emits paths without a `./` prefix, so anchored patterns silently filter nothing.)
+
+Then confirm the deliberate survivors are intact:
+```bash
+grep -n "2\.35\.0" CLAUDE.md docs/roadmap.md
+```
+Expected: `CLAUDE.md:36` (PR #43 retro note) and `docs/roadmap.md:129-130` (v0.5.0 milestone history) still present and unmodified.
+
+---
+
+## Task 2: Audit and correct `docs/abs-api-coverage.md`
+
+Two kinds of edit: the bump's own (tested range, five new Me routes) and the folded-in drift fix. Do them in one pass so the counts are recomputed once, at the end.
+
+**Files:** `docs/abs-api-coverage.md`
+
+- [ ] **Step 1: Update the tested range**
+
+Line ~8: `2.33.1 – 2.35.1` → `2.33.1 – 2.36.0`. (Note the en-dash `–` here, unlike the README's em-dash `—`. Preserve whichever character the file already uses.)
+
+- [ ] **Step 2: State the counting convention in the legend**
+
+The legend (~line 11-13) explains ✅ / — / 🔒 but not how 🔒 rows count. The existing `Misc 3 / 16` counted the 🔒 `POST /api/authorize` row as covered while every other summary row counts only ✅. Settle it toward ✅-only by appending a clause to the 🔒 legend line:
+
+> 🔒 = internal-only (no user-facing verb); 🔒 rows never count as covered.
+
+Word it as "never count as covered", **not** "excluded from the counts": 🔒 rows are excluded from the numerator only — they stay in the denominator (`Misc` remains `/ 16` including `POST /api/authorize`, `Auth` remains `/ 2` including `POST /auth/refresh`). The recount script in Step 6 bakes in that same asymmetry, so it cannot catch a wrong wording here.
+
+- [ ] **Step 3: Add the five new 2.36.0 Me routes**
+
+In `## Me (current user)`, add five rows marked `—`. Place `GET /api/me/sessions` and `DELETE /api/me/sessions/:id` after the `GET /api/me` row, and the progress/bookmarks rows next to their existing thematic neighbours (progress rows near the other `/progress` entries, bookmarks rows near the existing `/item/:id/bookmark` entries) — the section is loosely grouped by theme, so match it rather than appending blindly.
+
+All five take a **blank Perm column**: none carries permission middleware at the router layer, and the handlers gate only on `isGuest` / per-item access, not on a `user.permissions` flag.
+
+| Method | Path | Description | Perm | CLI |
+|--------|------|-------------|------|-----|
+| GET | `/api/me/sessions` | My auth sessions (paginated) | | — |
+| DELETE | `/api/me/sessions/:id` | Revoke one of my auth sessions | | — |
+| GET | `/api/me/progress` | All my media progress | | — |
+| GET | `/api/me/bookmarks` | All my bookmarks | | — |
+| GET | `/api/me/bookmarks/:libraryItemId` | My bookmarks for one item | | — |
+
+- [ ] **Step 4: Fix the seven mis-marked rows outside Playlists**
+
+Change the CLI column from `—` to the shipped verb:
+
+| Section | Row | New CLI cell |
+|---------|-----|--------------|
+| Libraries | `GET /api/libraries/:id/playlists` | `playlists list` ✅ |
+| Misc | `GET /api/tags` | `tags list` ✅ |
+| Misc | `POST /api/tags/rename` | `tags rename` ✅ |
+| Misc | `DELETE /api/tags/:tag` | `tags delete` ✅ |
+| Misc | `GET /api/genres` | `genres list` ✅ |
+| Misc | `POST /api/genres/rename` | `genres rename` ✅ |
+| Misc | `DELETE /api/genres/:genre` | `genres delete` ✅ |
+
+Leave each row's Perm column as-is (the tags/genres routes are correctly marked `admin`).
+
+- [ ] **Step 5: Fix the Playlists section — 9 of 10 rows**
+
+| Route | New CLI cell |
+|-------|--------------|
+| `POST /api/playlists` | `playlists create` ✅ |
+| `GET /api/playlists` | **leave `—`** |
+| `GET /api/playlists/:id` | `playlists get` ✅ |
+| `PATCH /api/playlists/:id` | `playlists update` / `reorder` ✅ |
+| `DELETE /api/playlists/:id` | `playlists delete` ✅ |
+| `POST /api/playlists/:id/item` | `playlists add` ✅ |
+| `DELETE /api/playlists/:id/item/:itemId/:episodeId?` | `playlists remove` ✅ |
+| `POST /api/playlists/:id/batch/add` | `playlists batch-add` ✅ |
+| `POST /api/playlists/:id/batch/remove` | `playlists batch-remove` ✅ |
+| `POST /api/playlists/collection/:collectionId` | `playlists create-from-collection` ✅ |
+
+`GET /api/playlists` (all playlists across every library) stays uncovered: `PlaylistsService.cs:29` lists via `ApiEndpoints.LibraryPlaylists(libraryId)` → `/api/libraries/:id/playlists`, never the unscoped route. Do not mark it ✅ to make a count look tidier.
+
+- [ ] **Step 6: Recompute the Coverage summary**
+
+Do not hand-edit these numbers from the spec — recount mechanically so the edit is self-verifying:
+
+```bash
+cd /workspaces/abs-cli && python3 - <<'EOF'
+import re
+lines = open('docs/abs-api-coverage.md').read().split('\n')
+sec = None; counts = {}
+for l in lines:
+    if l.startswith('## '):
+        sec = l[3:].strip()
+        if sec == 'Coverage summary': sec = None
+        elif sec: counts.setdefault(sec, [0, 0])
+    elif sec and l.startswith('|') and not re.match(r'\|\s*[-: ]+\|', l) and not l.startswith('| Method'):
+        counts[sec][0] += 1
+        if '✅' in l: counts[sec][1] += 1
+for k, (total, cov) in counts.items():
+    print(f"| {k} | {cov} / {total} |")
+EOF
+```
+
+Set each `## Coverage summary` row to the printed value. Expected output after Steps 3–5:
+
+| Resource | Was | Becomes |
+|----------|-----|---------|
+| Libraries | 4 / 27 | **16 / 28** |
+| Items | 13 / 26 | **16 / 26** |
+| Me (current user) | 5 / 18 | **5 / 23** |
+| Series | 1 / 2 | **2 / 2** |
+| Search | 4 / 6 | **5 / 6** |
+| Misc | 3 / 16 | **8 / 16** |
+| Playlists | 0 / 10 | **9 / 10** |
+
+All other rows (`Collections 9/9`, `Authors 7/7`, `Backup 6/7`, `Cache 2/2`, `Tools 4/4`, `Podcasts 0/13`, `Users 0/9`, `Sessions 0/9`, `Notifications 0/8`, `Email 0/5`, `RSS feeds 0/5`, `API keys 0/4`, `Custom metadata providers 0/3`, `Shares 0/2`, `Stats 0/2`, `Filesystem 0/2`) must come back unchanged. If the script disagrees with this table, **the script wins** — investigate the mismatch before editing, because it means a row edit in Steps 3–5 landed differently than intended.
+
+Note the summary uses `Sessions` where the section heading is `Sessions (playback)`; the script keys off the heading. Match rows by meaning, not string equality.
+
+- [ ] **Step 7: Add the missing Auth summary row**
+
+The summary omits the `## Auth (non-/api)` section. Append `| Auth (non-\`/api\`) | 1 / 2 |` so every section is represented (`POST /login` ✅; `POST /auth/refresh` is 🔒, excluded per Step 2's convention).
+
+- [ ] **Step 8: Re-run the recount as a check**
+
+Re-run the Step 6 script and diff its output against the summary table by eye. Every section must match. This is the spec's stated success criterion for this task.
+
+---
+
+## Task 3: Verify against a live 2.36.0 stack
+
+- [ ] **Step 1: Unit tests and format gate**
+
+```bash
+cd /workspaces/abs-cli
+dotnet format AbsCli.sln
+dotnet test AbsCli.sln
+dotnet format AbsCli.sln --verify-no-changes
+```
+Expected: all tests pass; `--verify-no-changes` exits 0. If a test asserts the tested-range string or `MaxTestedVersion`, update it to `2.36.0` (none is expected — see Baseline).
+
+- [ ] **Step 2: Bring up a fresh 2.36.0 stack and seed it**
+
+```bash
+cd /workspaces/abs-cli/docker && docker compose down -v && docker compose up -d
+IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+for i in $(seq 1 60); do curl -sf http://$IP:80/healthcheck >/dev/null 2>&1 && break; sleep 1; done
+docker inspect docker-audiobookshelf-1 -f '{{.Config.Image}}'
+ABS_URL=http://$IP:80 bash /workspaces/abs-cli/docker/seed.sh
+```
+Expected: image prints `advplyr/audiobookshelf:2.36.0`; seed ends with `Items: 16`.
+
+`down -v` is required — a volume carried over from the 2.35.1 image is not a clean upgrade-target test. (seed.sh's first scan-wait loop occasionally throws a transient `KeyError: 'total'`; if seeding fails, `docker compose down -v && up -d`, wait for health, and re-run seed.)
+
+**`smoke-test.sh` is not idempotent — it needs a freshly seeded stack for every run.** It creates and deletes library items, so a second run against the same stack fails on item-count assertions (`items list has 16 items`, pagination totals) and on the multi-ebook fixture's primary/supplementary state. Those failures are artifacts of the dirty stack, not regressions. If you need to re-run the smoke (e.g. after a late code change), repeat this whole step — `down -v`, `up -d`, wait for health, re-seed — before running it again.
+
+- [ ] **Step 3: Run the full smoke against 2.36.0**
+
+```bash
+IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+ABS_URL=http://$IP:80 bash /workspaces/abs-cli/docker/smoke-test.sh | tee /tmp/smoke-2360.txt
+```
+Expected: `0 failed`. Record the actual passed count in the PR description — there is no documented baseline from the 2.35.1 era that still applies (the suite has grown through the tags/genres, playlists, libraries-CRUD, and item-file-management features since), so the count is established here, not asserted against.
+
+Any FAIL is a real finding. Before attributing it to 2.36.0, re-run the same smoke against 2.35.1 (`docker compose down -v`, temporarily pin the image back, seed, run) to distinguish a genuine 2.36.0 regression from pre-existing flake. Do **not** mark the smoke passed in the PR unless it actually did — per `CLAUDE.md`, the checkbox is never copied forward unverified.
+
+- [ ] **Step 4: Confirm no version-warning regression**
+
+```bash
+grep -i "has not been tested" /tmp/smoke-2360.txt || echo "no untested-version warning (correct)"
+```
+Expected: prints the "correct" line. A warning here means Step 1 of Task 1 did not take effect.
+
+- [ ] **Step 5: Spot-check the newly populated expanded fields**
+
+The one behavioral difference 2.36.0 produces for abs-cli. Confirm the count fields now arrive populated and land on the existing DTO properties rather than being dropped:
+
+```bash
+IP=$(docker inspect docker-audiobookshelf-1 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+cd /workspaces/abs-cli
+ITEM=$(dotnet run --project src/AbsCli -- items list --limit 1 | python3 -c 'import sys,json; print(json.load(sys.stdin)["results"][0]["id"])')
+dotnet run --project src/AbsCli -- items get --id "$ITEM" --expanded | python3 -c 'import sys,json; d=json.load(sys.stdin); print("numFiles",d.get("numFiles")); m=d.get("media",{}); print({k:m.get(k) for k in ("numTracks","numAudioFiles","numChapters","ebookFormat")})'
+```
+Expected: `numFiles` ≥ 1 and `numTracks` / `numAudioFiles` ≥ 1 for a seeded audiobook — non-zero where the old server sent nothing. `ebookFormat` may legitimately be `null` (the seeded items are audio-only); that is not a failure.
+
+If these come back `0`, the fields are being dropped somewhere in the CLI's deserialization path and the spec's "no DTO change needed" conclusion is wrong — stop and re-open the analysis rather than shipping.
+
+**This step fired.** Result on the live 2.36.0 stack: media-level fields surfaced correctly (`numTracks: 1`, `numAudioFiles: 1`) because `LibraryItemExpanded.Media` is an untyped `JsonElement?` passthrough — but top-level `numFiles` was **absent** from `items get --expanded` while the server sent `numFiles: 1`. Cause: `items get --expanded` deserializes into `LibraryItemExpanded`, which has no `numFiles` property (the minified `LibraryItemMinified` does). A full server-vs-DTO key diff on both paths confirmed `numFiles` is the only 2.36.0 addition the CLI drops. See the revised spec section for the corrected analysis; Task 4 below closes the gap.
+
+- [ ] **Step 7: Re-run the spot-check after Task 4**
+
+Once `NumFiles` is on the expanded DTO, re-run Step 5's command. Expected: `numFiles` ≥ 1 rather than absent.
+
+---
+
+## Task 4: Surface `numFiles` on the expanded item DTO
+
+Discovered by Task 3 Step 5, not present in the original plan. Scoped to exactly one field — do not type the `media` passthrough (that is a separate spec, as `LibraryItemExpanded`'s own doc comment says).
+
+**Files:** `src/AbsCli/Models/LibraryItemExpanded.cs`, `src/AbsCli/Commands/ResponseExamples.g.cs` (generated).
+
+- [ ] **Step 1: Add the property**
+
+In `src/AbsCli/Models/LibraryItemExpanded.cs`, add to the `LibraryItemExpanded` class:
+```csharp
+    [JsonPropertyName("numFiles")]
+    public int NumFiles { get; set; }
+```
+Place it to mirror the server's own key order and the minified DTO's precedent — immediately before `Size`. Match the file's existing property style (no doc comment unless the field is non-obvious; `numFiles` is not).
+
+- [ ] **Step 2: Regenerate the response examples**
+
+`ResponseExamples.g.cs` is generated from the DTOs and a drift test (`tests/AbsCli.Tests/Commands/ResponseExamplesDriftTest.cs`) fails if it is stale. Do not hand-edit it:
+```bash
+cd /workspaces/abs-cli
+dotnet run --project tools/GenerateResponseExamples -- src/AbsCli/Commands/ResponseExamples.g.cs
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+dotnet format AbsCli.sln
+dotnet test AbsCli.sln
+dotnet format AbsCli.sln --verify-no-changes
+```
+All green, including the drift and JSON-validity tests. Then re-run Task 3 Step 5's spot-check against the live stack.
+
+Note the help-text response shape for `items get --expanded` gains a `numFiles` line as a consequence. That is the intended outcome, not a side effect to suppress.
+
+- [ ] **Step 8: Commit and open the PR**
+
+Commit spec + plan + code together on `chore/abs-2.36.0-bump`:
+
+```
+chore: raise MaxTestedVersion to 2.36.0
+
+ABS 2.36.0 is additive-only for every surface abs-cli consumes: five new
+/api/me/* routes the CLI does not call, and expanded item/book/podcast JSON
+promoted to a strict superset of minified. Live verification showed the one
+new top-level key, numFiles, was silently dropped by LibraryItemExpanded, so
+it is now modeled — nullable and omitted when absent, so output against the
+2.33.1-2.35.1 servers that never send it is unchanged.
+
+Also corrects accumulated drift in docs/abs-api-coverage.md, where shipped
+tags/genres and playlists verbs were still marked unimplemented and the
+coverage summary counts had not been recomputed.
+```
+
+Then `gh pr create`, present the PR URL as a clickable link on its own line, and watch CI to a terminal state per `CLAUDE.md`'s post-PR verification rules.
+
+---
+
+## Self-Review (completed)
+
+- **Spec coverage:** `MaxTestedVersion` (T1 S1) ✓; docker-compose image (T1 S2) ✓; CI image (T1 S3) ✓; README range + warning example (T1 S4–5) ✓; CLAUDE.md clone tag (T1 S6) ✓; compatibility matrix + warning example (T1 S7–8) ✓; authentication.md grace period + new bearer-check note (T1 S9) ✓; historical-reference guard (T1 S10) ✓; coverage-doc tested range, legend convention, five Me rows, seven mis-marked rows, Playlists section, summary recount, missing Auth row, recount check (T2 S1–8) ✓; unit + format (T3 S1) ✓; live smoke on a clean volume (T3 S2–4) ✓; expanded-field spot-check (T3 S5) ✓; `numFiles` on the expanded DTO, nullable so no `0` is fabricated on older servers, with the stale test comment reworded (T4 S1–3) ✓; post-fix spot-check re-run (T3 S7) ✓; commit + PR (T3 S8) ✓. Out-of-scope items (CLI `<Version>`, CHANGELOG, `MinSupportedVersion`, new verbs, coverage-count linter) excluded ✓.
+- **Placeholder scan:** none — every edit shows exact before/after or an explicit rule. The one number not asserted (smoke passed-count) is deliberate and justified in place.
+- **Consistency:** `2.36.0` used uniformly for pins; `2.37.0` uniformly for the two out-of-range examples; `MinSupportedVersion` untouched everywhere; coverage numbers in T2 S6 match the spec's audit table and are subordinated to the script's live output.
+- **Ambiguity check:** T2 S6 names the script as the authority over the expected-value table, so a mismatch escalates rather than getting papered over. T3 S3 distinguishes a 2.36.0 regression from pre-existing flake instead of assuming either.

--- a/docs/specs/2026-07-30-abs-2.36.0-bump-design.md
+++ b/docs/specs/2026-07-30-abs-2.36.0-bump-design.md
@@ -1,0 +1,355 @@
+# ABS 2.36.0 compatibility bump — design
+
+**Date:** 2026-07-30
+**Scope:** Extend the tested-version ceiling from ABS 2.35.1 to 2.36.0. No CLI
+behavior change; one additive DTO field (`numFiles`) — verified additive-only
+release. Work is
+version-pin bumps + docs + a live smoke run that proves compatibility, plus a
+folded-in accuracy audit of `docs/abs-api-coverage.md` (pre-existing drift, not
+caused by this release).
+
+## Background
+
+Latest ABS release is **v2.36.0** (2026-07-27), a minor over the 2.35.1 the CLI
+currently tests against. The reference checkout at `temp/audiobookshelf` has
+already been updated to v2.36.0.
+
+The 2.35.1 → 2.36.0 server diff touches 23 files under `server/`. Full review
+below, grouped by whether abs-cli consumes the affected surface.
+
+### Additive endpoints — none consumed by abs-cli
+
+Five new routes on `ApiRouter.js`, all handled by `MeController`:
+
+| Route | Handler note |
+|-------|--------------|
+| `GET /api/me/sessions` | Paginated auth sessions (`page`, `itemsPerPage`); returns `{ total, numPages, page, itemsPerPage, sessions[] }`. Guests get an empty page. |
+| `DELETE /api/me/sessions/:id` | Deletes one of the caller's own sessions. 400 on non-UUID, 404 if not the caller's, 403 for guests. |
+| `GET /api/me/progress` | `{ mediaProgress[] }` — all progress for the caller. |
+| `GET /api/me/bookmarks` | `{ bookmarks[] }` — all bookmarks for the caller. |
+| `GET /api/me/bookmarks/:libraryItemId` | Bookmarks filtered to one item; 404 unknown item, 403 no access. |
+
+Purely additive. No existing route changed shape. Wiring CLI verbs to these is
+feature work, explicitly out of scope (see below).
+
+### Response-shape change — additive; one field was unmodeled
+
+`toOldJSONExpanded()` on `LibraryItem`, `Book`, and `Podcast` was refactored to
+spread `toOldJSONMinified()` and then add expanded-only fields, with a documented
+invariant that expanded must be a strict superset of minified. Net effect on the
+wire: expanded responses gain the count fields that minified always carried.
+
+| Model | Keys gained by expanded |
+|-------|------------------------|
+| `LibraryItem` | `numFiles` |
+| `Book` | `numTracks`, `numAudioFiles`, `numChapters`, `ebookFormat` |
+| `Podcast` | `numEpisodes` |
+
+**No key was removed or renamed.** The one plausible regression was checked and
+does not exist: `Podcast.toOldJSONExpanded()` no longer sets `metadata`
+explicitly, but `Podcast.toOldJSONMinified()` already used
+`oldMetadataToJSONExpanded()` (with an upstream comment saying minified and
+expanded metadata are identical), so podcast expanded metadata is unchanged.
+`Book.toOldJSONExpanded()` still overrides `metadata` with the expanded form, and
+`LibraryItem.toOldJSONExpanded()` still overrides `media` with the expanded form.
+
+**No DTO change is required for compatibility, but one field is dropped.**
+Verified empirically against a live 2.36.0 stack rather than by inspection — the
+first draft of this spec reasoned from the wrong DTOs and got the mechanism wrong.
+The actual picture, per path:
+
+- **`items get --expanded`** deserializes into `LibraryItemExpanded`, a *separate*
+  DTO from the minified `LibraryItemMinified` (`src/AbsCli/Models/LibraryItem.cs`).
+  Its `media` property is a `JsonElement?` **untyped passthrough**
+  (`LibraryItemExpanded.cs:128`), so every media-level gain — `numTracks`,
+  `numAudioFiles`, `numChapters`, `ebookFormat`, `numEpisodes` — surfaces verbatim
+  with no DTO involvement at all. `BookMedia` / `PodcastMedia` are not on this path.
+- **`LibraryItemExpanded` has no `numFiles` property**, so the one top-level field
+  2.36.0 adds to expanded item JSON is silently dropped. Confirmed both ways: the
+  server sends `numFiles: 1`, and `items get --expanded` omits the key entirely
+  (absent, not `0` — it was never modeled).
+- A full key-diff of server response vs. DTO on both paths shows `numFiles` is the
+  **only** 2.36.0 addition the CLI drops. (`LibraryItemMinified` deliberately
+  models a subset of the non-expanded response — `lastScan`, `libraryFiles`,
+  `oldLibraryItemId`, `scanVersion` are omitted by design, unrelated to 2.36.0.)
+
+So the compatibility claim holds — nothing breaks, no version-conditional code,
+and no prior behavior changes, because pre-2.36 servers never sent `numFiles` in
+expanded either. But "no DTO change needed" is a statement about *compatibility*,
+not about *fidelity*: the CLI's expanded output is now strictly less complete than
+the server's response, which sits awkwardly against the thin-pass-through
+principle.
+
+**Resolution: add `NumFiles` to `LibraryItemExpanded`.** One property plus a
+a `ResponseExamples.g.cs` regeneration check (the generator derives samples from
+these DTOs and a drift test enforces freshness). Deliberately scoped to that one
+field — the untyped `media` passthrough needs nothing, and typing `media` remains
+a separate spec as its own doc comment already notes.
+
+**Older-server behavior drove the property's type.** abs-cli still supports
+2.33.1 — 2.35.1, and those servers omit `numFiles` from the expanded response. A
+non-nullable `int` would therefore emit a fabricated `"numFiles": 0` for an item
+that genuinely has files — a real output regression on supported versions, since
+the key was previously absent. So the property is `int?` with
+`[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`: real value on
+2.36.0+, key absent on older servers exactly as before. Verified both directions
+by round-tripping a real 2.36.0 payload and a copy with the key deleted.
+
+The minified sibling `LibraryItemMinified` keeps its non-nullable `int NumFiles`
+— minified has carried the key on every supported version, so it has no absent
+case. The asymmetry is correct, not an oversight.
+
+**Consequence for help text.** The sample generator skips properties marked
+write-ignored-when-null, so `numFiles` does not appear in the `items get
+--expanded` response-shape sample, and `ResponseExamples.g.cs` ends up unchanged
+by this branch. The sample therefore *understates* 2.36.0 output by one key.
+Accepted: an incomplete example is better than one that fabricates a value which
+would be wrong on any pre-2.36.0 server.
+
+### Auth internals — reviewed, abs-cli unaffected
+
+- **Refresh tokens rejected as bearer credentials.** New
+  `TokenManager.isBearerAccessTokenPayload()` gates both `validateAccessToken()`
+  and the passport JWT strategy, rejecting any payload with `type === 'refresh'`.
+  abs-cli sends `AccessToken` as the `Bearer` header
+  (`AbsApiClient.cs:36`, `:231`) and only ever presents the refresh token via the
+  `X-Refresh-Token` header on `auth/refresh` (`AbsApiClient.cs:213`). Correct by
+  construction; no change needed.
+- **Refresh-token grace period 60s → 10 minutes**, now configurable via the
+  server-side `REFRESH_TOKEN_GRACE_PERIOD` env var. Widening only; abs-cli is
+  single-process and never issues concurrent refreshes, so still transparent.
+  `docs/authentication.md:58` hardcodes "60 seconds" and becomes stale — must be
+  updated.
+- **`POST /auth/logout?allDevices=1`** destroys every session for the caller.
+  abs-cli has no logout verb (`ApiEndpoints.cs` has no logout constant), so no
+  impact.
+- **`invalidateJwtSessionsForUser()`** now returns `{ accessToken, refreshToken }`
+  instead of a bare access token, honors `x-refresh-token`, and matches
+  `lastRefreshToken`. Only reached from `PATCH /api/users/:id` and
+  `PATCH /api/me/password`, neither of which abs-cli calls.
+- **Cookie `secure` flag** now derived from the new `isRequestSecure()` helper.
+  Cookie-path only; abs-cli is header-based.
+
+### Other changes — not consumed by abs-cli
+
+- `PATCH /api/users/:id` — password change now invalidates JWT sessions and no
+  longer returns rotated tokens in the response body. No CLI `users` command.
+- `DELETE /api/users/:id` — root-user deletion now 403 (was 400), plus a
+  `beforeDestroy` model hook. No CLI `users` command.
+- `PATCH` podcast episode — accepts an `enclosure` object (or `null` to clear),
+  mapping to `enclosureURL` / `enclosureType` / `enclosureSize`. No CLI podcast
+  commands.
+- `GET /api/library/:id/download` (`downloadMultiple`) — now loads expanded items
+  and 403s if the user cannot access any one of them. The CLI's only download
+  endpoints are `api/items/:id/file/:ino/download` and
+  `api/backups/:id/download`; it does not call the multi-item library download.
+- Scanner (`BookScanner`, `LibraryItemScanner`, `LibraryScan`, `ScanLogger`) —
+  new `author_added` and `authors_num_books_updated` **socket** emissions and a
+  `BookAuthor.getCountsForAuthors()` helper. abs-cli is HTTP-only and has no
+  socket client.
+- `serverSettings.timeZone` added to `toJSONForBrowser()`. Additive; the CLI reads
+  only `serverSettings.version` from the login response.
+- `Server.js` — `req.originalHostPrefix` now built via `getRequestOrigin()`, and
+  file-upload parsing skipped for `/internal-api` routes. Internal; the CLI's
+  `POST /api/upload` path is unaffected.
+- `OidcAuthStrategy`, `notifications.js`, new `parseUserAgent.js` /
+  `requestUtils.js` utils — no abs-cli surface.
+
+**Conclusion: no endpoint, response shape, or permission check that abs-cli
+consumes changed in 2.36.0.**
+
+## Changes
+
+### Functional (3 version pins + 1 DTO field)
+
+- `src/AbsCli/Api/AbsApiClient.cs:236` — `MaxTestedVersion` `"2.35.1"` → `"2.36.0"`.
+  `MinSupportedVersion` stays `"2.33.1"` (no support dropped).
+- `docker/docker-compose.yml:3` — `image: advplyr/audiobookshelf:2.35.1` → `:2.36.0`.
+- `.github/workflows/build.yml:30` — smoke-test service image `:2.35.1` → `:2.36.0`.
+- `src/AbsCli/Models/LibraryItemExpanded.cs` — add `int? NumFiles` with
+  `[JsonPropertyName("numFiles")]` and
+  `[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`, so the one
+  top-level field 2.36.0 adds to expanded item JSON stops being dropped without
+  fabricating a `0` on older servers (see the analysis above).
+- `tests/AbsCli.Tests/Commands/ItemsGetExpandedCommandTests.cs` — a comment
+  distinguishing the minified and expanded shapes by `numFiles` is stale now that
+  both carry it; reword to key off `libraryFiles`. No assertion changes.
+
+### Docs (5 files)
+
+- `README.md:361` — tested range `2.33.1 — 2.35.1` → `2.33.1 — 2.36.0`.
+- `README.md:298` — the illustrative "not been tested" warning names `2.36.0`,
+  which is now *inside* the range. Change the example version to `2.37.0` so it
+  stays accurate.
+- `CLAUDE.md:80` — reference-clone instruction `v2.35.1` → `v2.36.0`.
+- `docs/authentication.md:58` — rewrite the grace-period note: ABS 2.35
+  introduced 60 seconds; 2.36 widened it to 10 minutes and made it configurable
+  via the server-side `REFRESH_TOKEN_GRACE_PERIOD` env var. Keep the existing
+  conclusion (transparent to abs-cli, request/response shapes unchanged). Also
+  note that as of 2.36 a refresh token is rejected as a bearer credential —
+  abs-cli already only presents it at `POST /auth/refresh`.
+- `docs/abs-compatibility.md`:
+  - Matrix (line 12): extend the `0.5.0+` row's ABS range to `2.36.0` and append
+    a 2.36.0 note — five additive `/api/me/*` routes (sessions, progress,
+    bookmarks) that abs-cli does not yet consume; expanded item/book/podcast JSON
+    now a strict superset of minified (gains `numFiles`, `numTracks`,
+    `numAudioFiles`, `numChapters`, `ebookFormat`, `numEpisodes` — additive only;
+    the media-level fields pass through untyped, `numFiles` is newly modeled by
+    this change, and `numEpisodes` stays unmodelled in the books-only podcast
+    placeholder); refresh-token grace period widened to 10
+    minutes and made configurable; refresh tokens no longer accepted as bearer
+    credentials (abs-cli unaffected). No response-shape removals, endpoint
+    changes, or permission changes for endpoints abs-cli consumes.
+  - Runtime-check example (line 22): same `2.36.0` → `2.37.0` fix as
+    `README.md:298`.
+  - `### Setting Up the Reference` clone block (~line 90): the pinned tag still
+    said `v2.33.1`, three minor versions behind the ceiling, contradicting
+    `CLAUDE.md:80` and misdirecting anyone verifying API behavior. Bump to
+    `v2.36.0` and add the same "supported version is set in `AbsApiClient.cs`"
+    comment `CLAUDE.md` carries. (A `v<MaxTestedVersion>` placeholder was tried
+    and rejected — it stops the literal going stale but is not copy-pasteable.)
+- `docs/abs-api-coverage.md` — see the dedicated section below.
+
+### `docs/abs-api-coverage.md` — bump edits plus a drift audit
+
+Two kinds of change land here. The bump owns the first; the second is
+pre-existing drift, folded into this round at the user's request.
+
+**Bump-owned:**
+
+- Line 8 — tested range `2.33.1 – 2.35.1` → `2.33.1 – 2.36.0`.
+- `## Me (current user)` section — add the five new 2.36.0 routes as uncovered
+  (`—`): `GET /api/me/sessions`, `DELETE /api/me/sessions/:id`,
+  `GET /api/me/progress`, `GET /api/me/bookmarks`,
+  `GET /api/me/bookmarks/:libraryItemId`. All five get a **blank Perm column**:
+  none carries a permission middleware at the router layer, and the handlers gate
+  only on `isGuest` / per-item access, not on a `user.permissions` flag.
+
+**Drift audit.** The per-section route tables and the `## Coverage summary`
+counts have both fallen behind shipped features. Audited by counting rows and ✅
+marks per section against `src/AbsCli/Api/ApiEndpoints.cs` and the README
+Commands table. Two distinct defects:
+
+*(a) Section rows still marked `—` for verbs that ship today (7 rows):*
+
+| Section | Row | Correct CLI |
+|---------|-----|-------------|
+| Libraries | `GET /api/libraries/:id/playlists` | `playlists list` ✅ |
+| Misc | `GET /api/tags` | `tags list` ✅ |
+| Misc | `POST /api/tags/rename` | `tags rename` ✅ |
+| Misc | `DELETE /api/tags/:tag` | `tags delete` ✅ |
+| Misc | `GET /api/genres` | `genres list` ✅ |
+| Misc | `POST /api/genres/rename` | `genres rename` ✅ |
+| Misc | `DELETE /api/genres/:genre` | `genres delete` ✅ |
+
+Plus the whole `## Playlists` section: 9 of its 10 rows ship. Verified against
+`PlaylistsService.cs`:
+
+| Route | CLI |
+|-------|-----|
+| `POST /api/playlists` | `playlists create` ✅ |
+| `GET /api/playlists` | **stays `—`** — the CLI lists per-library via `/api/libraries/:id/playlists`, never this route |
+| `GET /api/playlists/:id` | `playlists get` ✅ |
+| `PATCH /api/playlists/:id` | `playlists update` / `reorder` ✅ |
+| `DELETE /api/playlists/:id` | `playlists delete` ✅ |
+| `POST /api/playlists/:id/item` | `playlists add` ✅ |
+| `DELETE /api/playlists/:id/item/:itemId/:episodeId?` | `playlists remove` ✅ |
+| `POST /api/playlists/:id/batch/add` | `playlists batch-add` ✅ |
+| `POST /api/playlists/:id/batch/remove` | `playlists batch-remove` ✅ |
+| `POST /api/playlists/collection/:collectionId` | `playlists create-from-collection` ✅ |
+
+*(b) `## Coverage summary` counts never recomputed.* Corrected values, derived by
+counting `✅` marks and total rows per section **after** the (a) fixes and the
+five new Me rows land:
+
+| Resource | Current | Corrected | Why |
+|----------|---------|-----------|-----|
+| Libraries | 4 / 27 | **16 / 28** | count never updated through libraries CRUD, narrators, series/authors/collections list; total was short one row |
+| Items | 13 / 26 | **16 / 26** | count never updated through file management / cover verbs |
+| Me (current user) | 5 / 18 | **5 / 23** | five new 2.36.0 routes, none covered |
+| Series | 1 / 2 | **2 / 2** | `series update` ships |
+| Search | 4 / 6 | **5 / 6** | `metadata chapters` search ships |
+| Misc | 3 / 16 | **8 / 16** | six tags/genres verbs ship; see convention note below |
+| Playlists | 0 / 10 | **9 / 10** | whole section shipped |
+
+All other summary rows (`Collections 9/9`, `Authors 7/7`, `Backup 6/7`,
+`Cache 2/2`, `Tools 4/4`, `Podcasts 0/13`, `Users 0/9`, `Sessions 0/9`,
+`Notifications 0/8`, `Email 0/5`, `RSS feeds 0/5`, `API keys 0/4`,
+`Custom metadata providers 0/3`, `Shares 0/2`, `Stats 0/2`,
+`Filesystem 0/2`) already match their sections — leave them alone.
+
+**Counting convention.** The `Misc 3 / 16` figure counted the 🔒 `POST
+/api/authorize` row as covered, while every other row counts only ✅. Settle it:
+**counts include ✅ only**, and the legend gains a clause saying 🔒 rows never
+count as covered. This is what drops Misc's 🔒 credit while the six tags/genres
+verbs add five net (`3 → 8`). Note the precise wording matters: 🔒 rows leave the
+numerator but stay in the denominator, so "excluded from the counts" would be
+false — `Misc` remains `/ 16`, `Auth` remains `/ 2`.
+
+**Missing summary row.** The summary omits the `## Auth (non-/api)` section.
+Add `Auth (non-/api) | 1 / 2` so the summary covers every section (`POST /login`
+✅; `POST /auth/refresh` is 🔒, excluded per the convention above).
+
+### Leave unchanged (historical references, not version pins)
+
+- `CLAUDE.md:36` — retro note about the 2.35.0 bump landing in PR #43.
+- `docs/roadmap.md:129-130` — v0.5.0 milestone history naming the
+  `2.33.1 — 2.35.0` widening.
+- `CHANGELOG.md:559` — historical `MaxTestedVersion` 2.33.2 entry.
+- Earlier matrix rows in `docs/abs-compatibility.md` (`0.1.x — 0.2.4`,
+  `0.2.5 — 0.4.0`).
+
+## Out of scope
+
+- **CLI verbs for the new `/api/me/*` endpoints** (sessions list/revoke, bulk
+  progress, bookmarks). Feature work; roadmap candidates, not compatibility work.
+- **Surfacing `numEpisodes` / podcast DTOs.** The CLI targets book libraries.
+- **Making the count fields nullable** to distinguish "old server omitted it"
+  from a real zero. Pre-existing behavior, not a 2.36.0 regression.
+- **CLI `<Version>` bump (`AbsCli.csproj`) and the CHANGELOG entry** —
+  release-owned, land on a `release/v{version}` branch.
+- **`MinSupportedVersion`** — unchanged at `2.33.1`.
+- **New CLI verbs to close any coverage gap the audit reveals.** The audit
+  corrects what the doc *claims*; it does not implement anything. `GET
+  /api/playlists` (all playlists across libraries) stays uncovered, as do the
+  `Podcasts` / `Users` / `Sessions` / `Notifications` / `Email` / `RSS feeds` /
+  `API keys` sections.
+- **A script or test to keep the summary counts honest.** The drift is real and
+  will recur, but a coverage-count linter is its own design discussion, not part
+  of a version bump. Worth raising as a roadmap item.
+
+## Verification
+
+- `dotnet test AbsCli.sln` — exercises the version-compare / range-warning logic
+  in `AbsApiClient`. If a test asserts the tested-range string or
+  `MaxTestedVersion`, update it to `2.36.0`.
+- `dotnet format AbsCli.sln --verify-no-changes` — CI style gate.
+- **`docker/smoke-test.sh` against a fresh 2.36.0 stack** — the definitive
+  compatibility proof (live HTTP paths). Per `CLAUDE.md`: bring the compose stack
+  up on the new image, resolve the container IP, seed with `docker/seed.sh`, and
+  run the smoke against `http://<container-ip>:80`. Expect the same all-green
+  result as on 2.35.1.
+- Spot-check `items get --expanded` against the 2.36.0 stack to confirm the
+  media-level count fields pass through and the newly added `NumFiles` property is
+  populated. Also round-trip a payload with `numFiles` deleted to prove no `0` is
+  fabricated for older servers.
+- Note `docker/smoke-test.sh` is **not idempotent** — it mutates seeded data, so
+  every run needs a freshly seeded stack (`down -v` → `up -d` → `seed.sh`).
+- **Coverage-count recount.** After editing `docs/abs-api-coverage.md`, recount ✅
+  marks and rows per section mechanically and confirm every `## Coverage summary`
+  row matches its section. Every corrected number in this spec came from such a
+  count; the edit is only correct if the recount reproduces it.
+
+## Success criteria
+
+- `MaxTestedVersion` is `2.36.0`; logging into a 2.36.0 server emits **no**
+  "not been tested" warning.
+- Unit tests green; `dotnet format` clean; smoke test green against the 2.36.0
+  image.
+- Docs, matrix, and coverage counts reflect the new ceiling; no doc still claims
+  `2.36.0` is an out-of-range example version.
+- Every `## Coverage summary` row in `docs/abs-api-coverage.md` equals a
+  mechanical recount of its section, and no shipped verb is still marked `—`.
+- `items get --expanded` against a 2.36.0 server emits a populated `numFiles`, and
+  a server-response-vs-DTO key diff shows no 2.36.0 field silently dropped on
+  either the minified or expanded path.

--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -233,7 +233,7 @@ public class AbsApiClient
     }
 
     private static readonly string MinSupportedVersion = "2.33.1";
-    private static readonly string MaxTestedVersion = "2.35.1";
+    private static readonly string MaxTestedVersion = "2.36.0";
 
     private static readonly string AssemblyVersion =
         typeof(AbsApiClient).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";

--- a/src/AbsCli/Models/LibraryItemExpanded.cs
+++ b/src/AbsCli/Models/LibraryItemExpanded.cs
@@ -130,6 +130,14 @@ public class LibraryItemExpanded
     [JsonPropertyName("libraryFiles")]
     public List<LibraryFile> LibraryFiles { get; set; } = new();
 
+    /// <summary>
+    /// Present from ABS 2.36.0 on; older supported servers (2.33.1 — 2.35.1)
+    /// omit it from the expanded shape, so it stays null and is not emitted.
+    /// </summary>
+    [JsonPropertyName("numFiles")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? NumFiles { get; set; }
+
     [JsonPropertyName("size")]
     public long Size { get; set; }
 

--- a/tests/AbsCli.Tests/Commands/ItemsGetExpandedCommandTests.cs
+++ b/tests/AbsCli.Tests/Commands/ItemsGetExpandedCommandTests.cs
@@ -30,7 +30,7 @@ public class ItemsGetExpandedCommandTests
     public void ItemsGet_Help_ShowsBothResponseShapes()
     {
         var output = RenderHelp("items", "get");
-        // Default (minified) — has `numFiles`, no `libraryFiles`.
+        // Default (minified) — no `libraryFiles`.
         Assert.Contains("Response shape:", output);
         Assert.Contains("\"numFiles\"", output);
         // Expanded — has `libraryFiles`, `lastScan`, `scanVersion`.


### PR DESCRIPTION
Extends the tested-version ceiling from ABS 2.35.1 to **2.36.0** (released 2026-07-27). `MinSupportedVersion` stays `2.33.1` — no support dropped.

## Compatibility review

Full review of the 2.35.1 → 2.36.0 server diff (23 files under `server/`). Nothing abs-cli consumes changed incompatibly:

- **Five new additive `/api/me/*` routes** — auth sessions (list/revoke), bulk progress, bookmarks. None consumed by the CLI; added to the coverage map as uncovered.
- **Expanded JSON is now a strict superset of minified** — `toOldJSONExpanded()` spreads `toOldJSONMinified()`, so expanded item/book/podcast responses gain `numFiles`, `numTracks`, `numAudioFiles`, `numChapters`, `ebookFormat`, `numEpisodes`. No key removed or renamed (checked the one plausible regression: podcast expanded metadata is unchanged, because minified already used the expanded form).
- **Auth internals** — refresh tokens are no longer accepted as `Bearer` credentials, and the refresh-token grace period widened from 60s to 10 min (now configurable via `REFRESH_TOKEN_GRACE_PERIOD`). abs-cli sends only its access token as `Bearer` and presents the refresh token exclusively via `X-Refresh-Token` on `POST /auth/refresh`, so it is unaffected. Both documented in `docs/authentication.md`.
- **Not consumed by the CLI:** `PATCH /users/:id` token-return change, root-delete 400→403, podcast episode `enclosure` updates, `GET /library/:id/download` access check, new scanner socket events, `serverSettings.timeZone`.

## One code change

The spec originally concluded no DTO change was needed. **Live verification disproved that** — the server sends `numFiles: 1` on `items get --expanded` while `LibraryItemExpanded` had no such property, so the CLI silently dropped it. A server-response-vs-DTO key diff on both paths confirmed it is the *only* 2.36.0 addition being dropped (the media-level fields surface because `Media` is an untyped `JsonElement?` passthrough).

Modeled as `int? NumFiles` with `[JsonIgnore(WhenWritingNull)]` rather than a plain `int`: on the still-supported 2.33.1 — 2.35.1 servers the key is absent, and a non-nullable `int` would have emitted a fabricated `"numFiles": 0` for items that have files. Verified both directions by round-tripping a real 2.36.0 payload and a copy with the key deleted.

Side effect worth knowing: the generator skips write-ignored nullable properties, so `numFiles` does not appear in the `--expanded` help sample and `ResponseExamples.g.cs` is unchanged. An incomplete sample beats one that would be wrong on any pre-2.36 server.

## Folded-in coverage-doc audit

`docs/abs-api-coverage.md` had drifted independently of this release. Corrected in the same change:

- **16 rows** marked "not implemented" for verbs that ship — 6 tags/genres, `GET /api/libraries/:id/playlists`, and 9 of 10 Playlists rows.
- **6 summary counts** never recomputed: Libraries `4/27` → `16/28`, Items `13/26` → `16/26`, Series `1/2` → `2/2`, Search `4/6` → `5/6`, Misc `3/16` → `8/16`, Playlists `0/10` → `9/10`.
- A latent counting inconsistency (Misc counted a 🔒 row as covered; no other row did) settled and written into the legend, plus the missing `Auth (non-/api)` summary row.

Counts are generated by a recount script over the section tables, not hand-edited. `GET /api/playlists` deliberately stays uncovered — the CLI lists per-library via `/api/libraries/:id/playlists` and never calls the unscoped route.

## Verification

- `dotnet test AbsCli.sln` — **392 passed, 0 failed**
- `dotnet format AbsCli.sln --verify-no-changes` — clean
- `docker/smoke-test.sh` against a freshly seeded **2.36.0** stack — **333 passed, 0 failed**, and no "has not been tested" warning. Re-run on the final code state after the nullability change.
- Live spot-check: `items get --expanded` returns `numFiles: 1` matching `libraryFiles.length`.

Note for future bumps: `smoke-test.sh` is not idempotent — it mutates seeded data, so each run needs a fresh `down -v` → `up -d` → `seed.sh`. Now documented in the plan.

## Deliberately out of scope

CLI verbs for the new `/api/me/*` endpoints; typing the `media` passthrough; CLI `<Version>` and CHANGELOG (release-owned); a linter to keep the coverage counts honest (worth a roadmap item). One reviewer proposal is also deferred for your call: restructuring the `docs/abs-compatibility.md` matrix into per-version sections, since its cumulative Notes cell is now the longest in the doc at ~940 characters.