### PR TITLE
feat: stamp PR builds with a build id in --version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,10 +90,29 @@ jobs:
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
+      # Stamps non-release builds so --version and the User-Agent say which build
+      # this is. Releases pass nothing, keeping the version bare.
+      - name: Compute build id
+        id: build
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          PR: ${{ github.event.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "$EVENT" = pull_request ]; then
+            echo "id=pr-$PR.$(echo "$PR_SHA" | cut -c1-7)" >> "$GITHUB_OUTPUT"
+          else
+            echo "id=" >> "$GITHUB_OUTPUT"
+          fi
       - name: Publish
-        run: >
-          dotnet publish src/AbsCli/AbsCli.csproj
-          -c Release -r ${{ matrix.rid }} --self-contained true /p:PublishAot=true
+        shell: bash
+        env:
+          BUILD_ID: ${{ steps.build.outputs.id }}
+        run: |
+          dotnet publish src/AbsCli/AbsCli.csproj \
+            -c Release -r ${{ matrix.rid }} --self-contained true /p:PublishAot=true \
+            ${BUILD_ID:+-p:BuildId=$BUILD_ID}
       - name: Run self-test (AOT integrity check)
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
           BUILD_ID: ${{ steps.build.outputs.id }}
         run: |
           dotnet publish src/AbsCli/AbsCli.csproj \
-            -c Release -r ${{ matrix.rid }} --self-contained true /p:PublishAot=true \
+            -c Release -r ${{ matrix.rid }} --self-contained true -p:PublishAot=true \
             ${BUILD_ID:+-p:BuildId=$BUILD_ID}
       - name: Run self-test (AOT integrity check)
         shell: bash

--- a/src/AbsCli/AbsCli.csproj
+++ b/src/AbsCli/AbsCli.csproj
@@ -10,7 +10,11 @@
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
     <Version>1.0.2</Version>
+    <!-- The SDK's source-link integration would otherwise append the git SHA to
+         every build. CI passes -p:BuildId=pr-1.a1b2c3d for non-release builds;
+         releases and local builds pass nothing and stay bare. -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+    <InformationalVersion Condition="'$(BuildId)' != ''">$(Version)+$(BuildId)</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Headers;
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
@@ -29,7 +30,7 @@ public class AbsApiClient
             // longer timeouts. Setting this to Infinite disables the global cap.
             Timeout = Timeout.InfiniteTimeSpan
         };
-        _http.DefaultRequestHeaders.UserAgent.ParseAdd($"abs-cli/{AssemblyVersion}");
+        _http.DefaultRequestHeaders.UserAgent.ParseAdd($"abs-cli/{ClientVersion}");
 
         if (config.AccessToken != null)
             _http.DefaultRequestHeaders.Authorization =
@@ -235,8 +236,15 @@ public class AbsApiClient
     private static readonly string MinSupportedVersion = "2.33.1";
     private static readonly string MaxTestedVersion = "2.36.0";
 
-    private static readonly string AssemblyVersion =
-        typeof(AbsApiClient).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
+    // The informational version carries CI's build stamp ("1.0.2+pr-1.a1b2c3d") so
+    // --version and server logs identify which build this is. It lives in an
+    // assembly-level attribute, which Native AOT can trim — self-test asserts it
+    // still resolves.
+    internal static readonly string ClientVersion =
+        typeof(AbsApiClient).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        ?? typeof(AbsApiClient).Assembly.GetName().Version?.ToString(3)
+        ?? "0.0.0";
 
     public static void CheckServerVersion(string? version)
     {

--- a/src/AbsCli/Commands/SelfTestCommand.cs
+++ b/src/AbsCli/Commands/SelfTestCommand.cs
@@ -888,6 +888,22 @@ public static class SelfTestCommand
             });
 
             Console.Error.WriteLine();
+            Console.Error.WriteLine("=== Build stamp ===");
+
+            Check("Informational version resolves", () =>
+            {
+                // --version and the User-Agent read an assembly-level attribute, which
+                // trimming can strip: it compiles fine and goes empty only in a
+                // published binary.
+                var version = AbsApiClient.ClientVersion;
+                var assemblyVersion = typeof(AbsApiClient).Assembly.GetName().Version?.ToString(3);
+                Assert(!string.IsNullOrWhiteSpace(version) && version != "0.0.0",
+                    "informational version did not resolve");
+                Assert(assemblyVersion == null || version.StartsWith(assemblyVersion, StringComparison.Ordinal),
+                    $"informational version '{version}' does not start with assembly version '{assemblyVersion}'");
+            });
+
+            Console.Error.WriteLine();
             Console.Error.WriteLine("=== Embedded resources ===");
 
             Check("CHANGELOG.md embedded and parseable", () =>


### PR DESCRIPTION
Ports grimoire-cli's build-stamping so a downloaded CI artifact says where it came from.

CI computes a build id for `pull_request` events (`pr-<num>.<sha7>`) and passes it as `-p:BuildId=...`. The csproj folds it into `InformationalVersion` as `1.0.2+pr-42.a1b2c3d`, which System.CommandLine's `--version` prints and the HTTP `User-Agent` carries. Release and local builds pass nothing and stay bare (`1.0.2`).

No main-branch stamping — this repo does not publish main binaries.

## Changes

- `AbsCli.csproj` — `InformationalVersion` conditional on `BuildId`
- `AbsApiClient.cs` — `AssemblyVersion` → `ClientVersion`, reads `AssemblyInformationalVersionAttribute` with fallback to the assembly version
- `build.yml` — "Compute build id" step; publish passes `${BUILD_ID:+-p:BuildId=$BUILD_ID}`
- `SelfTestCommand.cs` — asserts the attribute survives Native AOT trimming (it compiles fine and goes empty only in a published binary)

## Verification

- `dotnet test` — 392 passed
- `self-test` — 69 passed, 0 failed
- `docker/smoke-test.sh` against a freshly seeded local stack — 333 passed, 0 failed
- `-p:BuildId=pr-99.abc1234` → `--version` prints `1.0.2+pr-99.abc1234`; bare build prints `1.0.2`