### PR TITLE
fix: version parsing and base64url token decoding (#71)

### DIFF
--- a/docs/input-output.md
+++ b/docs/input-output.md
@@ -2,10 +2,20 @@
 
 ## Output
 
-- All commands write JSON to stdout
+- Commands that return API data write JSON to stdout
 - JSON matches ABS API response structure exactly — no transformation
-- Errors go to stderr, never stdout
+- Errors, warnings and progress go to stderr, never stdout — stdout stays pipeable
 - List commands return the ABS pagination envelope: `{ "results": [...], "total": N, "limit": N, "page": N }`
+
+Exceptions to JSON-on-stdout:
+
+- `--output -` streams raw bytes to stdout (`items cover download`,
+  `items ebook download`, `authors image download`); with a file path, stdout
+  stays empty
+- Side-effect-only commands (`login`, `config set`) write a human
+  confirmation to stderr and nothing to stdout
+- `changelog` writes human-readable text to stdout; `self-test` writes its whole
+  report to stderr
 
 ## Exit Codes
 

--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -266,10 +266,17 @@ public class AbsApiClient
         }
     }
 
-    private static int CompareVersions(string a, string b)
+    /// <summary>
+    /// Compare two dotted version strings. Tolerant by design: a leading "v" is
+    /// dropped and each segment contributes only its leading digits, so
+    /// prerelease forms ("2.36.0-beta") and junk ("nightly") compare as 0 for
+    /// that segment instead of throwing. This runs on the login path — an
+    /// unparseable version must not take down an otherwise working command.
+    /// </summary>
+    internal static int CompareVersions(string a, string b)
     {
-        var aParts = a.Split('.').Select(int.Parse).ToArray();
-        var bParts = b.Split('.').Select(int.Parse).ToArray();
+        var aParts = ParseVersion(a);
+        var bParts = ParseVersion(b);
         var len = Math.Max(aParts.Length, bParts.Length);
         for (int i = 0; i < len; i++)
         {
@@ -279,6 +286,12 @@ public class AbsApiClient
         }
         return 0;
     }
+
+    private static int[] ParseVersion(string version) =>
+        version.TrimStart('v', 'V')
+            .Split('.')
+            .Select(p => int.TryParse(new string(p.TakeWhile(char.IsDigit).ToArray()), out var n) ? n : 0)
+            .ToArray();
 
     private async Task EnsureSuccessOrHandleAuthAsync(
         HttpResponseMessage response, HttpMethod method, string endpoint,

--- a/src/AbsCli/Api/TokenHelper.cs
+++ b/src/AbsCli/Api/TokenHelper.cs
@@ -11,7 +11,10 @@ public static class TokenHelper
             var parts = token.Split('.');
             if (parts.Length != 3) return null;
 
-            var payload = parts[1];
+            // JWT payloads are base64url: map the alphabet back before padding,
+            // or any payload containing '-' or '_' (non-ASCII username) fails to
+            // decode and expiry is silently lost.
+            var payload = parts[1].Replace('-', '+').Replace('_', '/');
             // Fix base64 padding
             switch (payload.Length % 4)
             {

--- a/src/AbsCli/Commands/SelfTestCommand.cs
+++ b/src/AbsCli/Commands/SelfTestCommand.cs
@@ -497,6 +497,25 @@ public static class SelfTestCommand
                 Assert(TokenHelper.GetExpiration("not-a-jwt") == null, "should be null");
             });
 
+            Check("Base64url payload decodes", () =>
+            {
+                // Non-ASCII username puts '-' and '_' in the payload; exp = 1775928439
+                var token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJ0ZXN0IiwidXNlcm5hbWUiOiLQv9C-0LvRjNC30L7QstCw0YLQtdC70YwiLCJ0eXBlIjoiYWNjZXNzIiwiaWF0IjoxNzc1OTI0ODM5LCJleHAiOjE3NzU5Mjg0Mzl9.fakesig";
+                var exp = TokenHelper.GetExpiration(token);
+                Assert(exp != null, "exp should not be null");
+                Assert(exp!.Value.ToUnixTimeSeconds() == 1775928439, "wrong exp value");
+            });
+
+            Console.Error.WriteLine("");
+            Console.Error.WriteLine("=== Version Comparison ===");
+
+            Check("Non-numeric version does not throw", () =>
+            {
+                AbsApiClient.CheckServerVersion("2.36.0-beta");
+                AbsApiClient.CheckServerVersion("v2.36.0");
+                AbsApiClient.CheckServerVersion("nightly");
+            });
+
             Console.Error.WriteLine("");
             Console.Error.WriteLine("=== Console Output ===");
 

--- a/src/AbsCli/Program.cs
+++ b/src/AbsCli/Program.cs
@@ -39,7 +39,11 @@ rootCommand.Subcommands.Add(SelfTestCommand.Create());
 rootCommand.Subcommands.Add(ChangelogCommand.Create());
 
 rootCommand.AddHelpSection("Environment variables",
-    "ABS_DEBUG=1   Same as --debug. Enables debug-level logging to stderr.");
+    "ABS_SERVER    Server URL.",
+    "ABS_TOKEN     Access token. Refresh needs a stored refresh token from 'login'.",
+    "ABS_LIBRARY   Default library ID.",
+    "ABS_DEBUG=1   Same as --debug. Enables debug-level logging to stderr.",
+    "Precedence: flags > env > config file.");
 
 rootCommand.UseCustomHelpSections();
 

--- a/tests/AbsCli.Tests/Api/TokenHelperTests.cs
+++ b/tests/AbsCli.Tests/Api/TokenHelperTests.cs
@@ -10,6 +10,10 @@ public class TokenHelperTests
     // JWT without exp field (legacy token)
     private const string NoExpToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJ0ZXN0IiwiaWF0IjoxNzc1OTI0ODAyfQ.fakesig";
 
+    // Same exp as ExpiredToken, but a non-ASCII username puts '-' and '_' in the
+    // base64url payload — plain Convert.FromBase64String rejects those.
+    private const string Base64UrlToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJ0ZXN0IiwidXNlcm5hbWUiOiLQv9C-0LvRjNC30L7QstCw0YLQtdC70YwiLCJ0eXBlIjoiYWNjZXNzIiwiaWF0IjoxNzc1OTI0ODM5LCJleHAiOjE3NzU5Mjg0Mzl9.fakesig";
+
     [Fact]
     public void GetExpiration_ReturnsExpTime_WhenPresent()
     {
@@ -42,6 +46,15 @@ public class TokenHelperTests
         var result = TokenHelper.IsExpiringSoon(NoExpToken, thresholdSeconds: 60);
 
         Assert.False(result);
+    }
+
+    [Fact]
+    public void GetExpiration_DecodesBase64UrlPayload()
+    {
+        var exp = TokenHelper.GetExpiration(Base64UrlToken);
+
+        Assert.NotNull(exp);
+        Assert.Equal(1775928439, exp.Value.ToUnixTimeSeconds());
     }
 
     [Fact]

--- a/tests/AbsCli.Tests/Api/VersionComparisonTests.cs
+++ b/tests/AbsCli.Tests/Api/VersionComparisonTests.cs
@@ -1,0 +1,36 @@
+using AbsCli.Api;
+
+namespace AbsCli.Tests.Api;
+
+public class VersionComparisonTests
+{
+    [Theory]
+    [InlineData("2.36.0", "2.36.0", 0)]
+    [InlineData("2.36.1", "2.36.0", 1)]
+    [InlineData("2.35.0", "2.36.0", -1)]
+    [InlineData("2.36", "2.36.0", 0)]
+    [InlineData("2.36.0.1", "2.36.0", 1)]
+    public void CompareVersions_OrdersNumericVersions(string a, string b, int expected)
+    {
+        Assert.Equal(expected, Math.Sign(AbsApiClient.CompareVersions(a, b)));
+    }
+
+    [Theory]
+    [InlineData("2.36.0-beta", "2.36.0", 0)]
+    [InlineData("2.37.0-rc1", "2.36.0", 1)]
+    [InlineData("v2.36.0", "2.36.0", 0)]
+    [InlineData("V2.35.0", "2.36.0", -1)]
+    [InlineData("nightly", "2.36.0", -1)]
+    [InlineData("", "2.36.0", -1)]
+    public void CompareVersions_TreatsNonNumericSegmentsAsZero(string a, string b, int expected)
+    {
+        Assert.Equal(expected, Math.Sign(AbsApiClient.CompareVersions(a, b)));
+    }
+
+    [Fact]
+    public void CheckServerVersion_DoesNotThrow_OnNonNumericVersion()
+    {
+        AbsApiClient.CheckServerVersion("2.36.0-beta");
+        AbsApiClient.CheckServerVersion("nightly");
+    }
+}


### PR DESCRIPTION
Addresses items 1, 2, 5 and 6 of #71 (reported from a `grimoire-cli` audit). Items 3 and 4 are declined — see the issue comment.

## Fixes

**`CompareVersions` threw on non-numeric segments** (`AbsApiClient.cs`). `int.Parse` on each dotted segment meant `2.36.0-beta`, `2.37.0-rc1` or a `v` prefix threw `FormatException`. Nothing at the call site catches it, so it fell through to the top-level handler in `Program.cs` and exited 2 — a check that exists only to emit a warning was failing the login. Worse, `configManager.Save` runs before the check, so the tokens were persisted and the user still saw a cryptic failure. Segments now contribute only their leading digits; an unparseable segment counts as 0.

**`TokenHelper` didn't decode base64url** (`TokenHelper.cs`). The payload was padded but `-`/`_` were never mapped back to `+`/`/`, so `Convert.FromBase64String` threw and the surrounding catch returned null — expiry silently lost, proactive refresh disabled. Narrower trigger than it sounds: ABS payloads are `{userId, username, jti, type, iat, exp}`, all ASCII except the username, and for ASCII bytes those characters can only land on the 4th sextet of a triple. Measured: 0/2000 random ASCII usernames produce one; Cyrillic does; ~70% of CJK usernames do. Degradation was graceful (401 still triggers reactive refresh), so this was a correctness fix rather than an outage.

## Docs

**`ABS_*` in root help.** The `Environment variables` help section existed but listed only `ABS_DEBUG`, so `ABS_SERVER`/`ABS_TOKEN`/`ABS_LIBRARY` were in the README and `docs/configuration.md` but invisible to `--help`. Added, with the precedence order and the caveat that an env-supplied token can only be refreshed if `login` stored a refresh token.

**`docs/input-output.md`.** The issue's premise (missing exit codes / stream split) didn't hold — those were already documented. The real defect was "All commands write JSON to stdout", which is false for `--output -` binary streams, side-effect-only commands, and `self-test`. Corrected and enumerated.

## Tests

- `VersionComparisonTests` — numeric ordering plus prerelease, `v` prefix, junk and empty input (`CompareVersions` widened to `internal` for this)
- `TokenHelperTests.GetExpiration_DecodesBase64UrlPayload` — fixture token whose payload actually contains `-` and `_`
- `self-test` gained matching AOT-path checks for both

## Verification

- `dotnet test AbsCli.sln` — 405 passed, 0 failed
- `dotnet format --verify-no-changes` — clean
- `self-test` — 71 passed, 0 failed
- `docker/smoke-test.sh` against a freshly seeded 2.36.0 stack — **333 passed, 0 failed**