### PR TITLE
test: make the encode-m4b already-processing assertion deterministic

### DIFF
--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -35,9 +35,13 @@ echo ""
 
 PASS=0
 FAIL=0
+SKIP=0
 
 pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1 — $2"; FAIL=$((FAIL + 1)); }
+# For assertions whose precondition could not be established — a timing-dependent
+# scenario that did not materialise is untested, not passed and not broken.
+skip() { echo "  SKIP: $1 — $2"; SKIP=$((SKIP + 1)); }
 
 assert_json_key() {
     local label="$1" key="$2" json="$3"
@@ -1505,9 +1509,13 @@ CANCEL_TEST_ITEM_ID=""
 encode_cleanup() { cleanup_items "${ENCODE_TMP:-}" "${ENCODE_ITEM_ID:-}" "${CANCEL_TEST_ITEM_ID:-}"; }
 trap encode_cleanup EXIT
 
-ffmpeg -y -f lavfi -i "sine=frequency=440:duration=30" -ac 2 -c:a libmp3lame -b:a 128k \
+# 180s each rather than a token few seconds: both the "already processing" and the
+# cancel assertions need the merge task to still be in flight when the next
+# request lands, and ABS clears the pending task as soon as it finishes. Six
+# minutes of audio keeps even a codec=copy remux observable.
+ffmpeg -y -f lavfi -i "sine=frequency=440:duration=180" -ac 2 -c:a libmp3lame -b:a 128k \
     "$ENCODE_TMP/track1.mp3" > /dev/null 2>&1
-ffmpeg -y -f lavfi -i "sine=frequency=523:duration=30" -ac 2 -c:a libmp3lame -b:a 128k \
+ffmpeg -y -f lavfi -i "sine=frequency=523:duration=180" -ac 2 -c:a libmp3lame -b:a 128k \
     "$ENCODE_TMP/track2.mp3" > /dev/null 2>&1
 
 if [ -s "$ENCODE_TMP/track1.mp3" ] && [ -s "$ENCODE_TMP/track2.mp3" ]; then
@@ -1551,12 +1559,38 @@ else
 fi
 
 # Already-processing 400: a second start before the task completes should fail.
-output=$($CLI items encode-m4b start --id "$ENCODE_ITEM_ID" --codec copy 2>&1 || true)
-if echo "$output" | grep -q "already processing"; then
-    pass "encode-m4b start: second start while pending returns 400"
+# ABS returns the 400 only while a pending task exists for the item
+# (AbMergeManager.getPendingTaskByLibraryItemId), so confirm the merge really is
+# still in flight before asserting on the guard. Without this check a merge that
+# finished first looks identical to a broken guard: the second start simply
+# succeeds and returns a normal receipt.
+encode_pending=0
+for i in $(seq 1 20); do
+    if $CLI tasks list 2>/dev/null | python3 -c "
+import sys, json
+tasks = json.load(sys.stdin).get('tasks', [])
+for t in tasks:
+    data = t.get('data') or {}
+    if t.get('action') == 'encode-m4b' and data.get('libraryItemId') == '$ENCODE_ITEM_ID' and not t.get('isFinished'):
+        raise SystemExit(0)
+raise SystemExit(1)
+" 2>/dev/null; then
+        encode_pending=1
+        break
+    fi
+    sleep 0.1
+done
+
+if [ "$encode_pending" = "1" ]; then
+    output=$($CLI items encode-m4b start --id "$ENCODE_ITEM_ID" --codec copy 2>&1 || true)
+    if echo "$output" | grep -q "already processing"; then
+        pass "encode-m4b start: second start while pending returns 400"
+    else
+        fail "encode-m4b start: second start while pending returns 400" "missing 'already processing'"
+        echo "    response: ${output:0:200}"
+    fi
 else
-    fail "encode-m4b start: second start while pending returns 400" "missing 'already processing'"
-    echo "    response: ${output:0:200}"
+    skip "encode-m4b start: second start while pending returns 400" "merge finished before a pending task could be observed"
 fi
 
 # Poll tasks list until all tasks are gone. The encode-m4b itself finishes
@@ -1619,7 +1653,7 @@ fi
 
 # Cancel happy path: upload a separate item, start an aac re-encode (slower
 # than copy/remux), cancel mid-flight, verify the item was NOT merged. The
-# 30s fixtures + aac@192k re-encoding gives enough headroom for the cancel to
+# 180s fixtures + aac@192k re-encoding gives enough headroom for the cancel to
 # arrive before the task finishes on typical hardware.
 output=$($CLI upload --library "$LIB_ID" --folder "$FOLDER_ID" \
     --title "ENCODE_M4B_CANCEL_TEST" --author "Smoke Author" \
@@ -2355,7 +2389,7 @@ rm -rf "$VC_HOME"
 # ============================================================
 echo ""
 echo "========================================"
-echo "Results: $PASS passed, $FAIL failed"
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
 echo "========================================"
 
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
Makes the `encode-m4b start: second start while pending returns 400` smoke assertion deterministic. It failed spuriously during the version-check work (PR #75) and cost a full misdiagnosis cycle — it read as a regression from that branch until a re-run on a fresh stack passed with identical code.

## The race

The assertion fires a second `encode-m4b start` immediately after the first and requires a 400. ABS returns that 400 only while a pending task exists for the item:

```js
// server/managers/AbMergeManager.js:32-34
getPendingTaskByLibraryItemId(libraryItemId) {
  return this.pendingTasks.find((t) => t.task.data.libraryItemId === libraryItemId)
}
```

With two 30-second fixtures and `--codec copy` — a stream copy, no transcode — the remux could finish before the second request landed. The second start was then perfectly legal and returned a normal receipt (`"started": true`). Nothing in the test synchronised the two, so a merge that won the race looked identical to a broken guard.

The script's own comment already hinted at this: *"The encode-m4b itself finishes quickly (especially with codec=copy)"*.

## Changes

**1. Longer fixtures — 30s → 180s each.** Six minutes of audio keeps even a copy remux observably in flight. This follows the idiom already used a few assertions later, where the cancel test deliberately picks `--codec aac --bitrate 192k` because it is "slower than copy/remux" for exactly this reason. The cancel assertion gets more headroom as a side benefit; its comment is updated so it still describes the real fixtures.

**2. Establish the precondition instead of assuming it.** Poll the tasks list for a pending `encode-m4b` task on that item (matching `action` and `data.libraryItemId`, ignoring finished tasks), then fire the second start. If no pending task is ever observed, the merge already completed and the scenario is untestable in that run — so it now **skips with a reason** rather than failing. A timing-dependent scenario that never materialised is untested, not broken.

Adds a `skip()` helper and a skipped count to the results summary. **Skips do not change the exit code**, so a skip cannot turn into the flake this PR removes.

## Verification

- `bash -n docker/smoke-test.sh` — syntax clean
- Full smoke against a freshly seeded 2.36.0 stack — **338 passed, 0 failed, 0 skipped**, exit 0. The assertion took the assert path, confirming the fixtures give real headroom.
- The **skip branch was exercised separately**, since the good run never reaches it: driving the same poll-and-skip logic against an item id with no pending task produced `SKIP` with `PASS=0 FAIL=0 SKIP=1` — it reports honestly rather than silently passing.

Shell-only change; no CLI code touched, so no verb or flag changes and the README Commands table is unaffected.
