### PR TITLE
fix: harden config.json read and write

### DIFF
--- a/src/AbsCli/Api/AbsApiClient.cs
+++ b/src/AbsCli/Api/AbsApiClient.cs
@@ -295,7 +295,7 @@ public class AbsApiClient
         }
     }
 
-    private async Task RefreshTokenAsync()
+    internal async Task RefreshTokenAsync()
     {
         if (_config.RefreshToken == null)
         {
@@ -319,7 +319,10 @@ public class AbsApiClient
 
         _config.AccessToken = loginResponse.User.AccessToken;
         _config.RefreshToken = loginResponse.User.RefreshToken;
-        _configManager.Save(_config);
+        // Patch the file rather than Save(_config): _config is resolved, so a
+        // whole-object save would leak ABS_TOKEN/ABS_SERVER/ABS_LIBRARY from the
+        // environment into a config the operator deliberately kept them out of.
+        _configManager.UpdateTokens(_config.AccessToken, _config.RefreshToken);
 
         _http.DefaultRequestHeaders.Authorization =
             new AuthenticationHeaderValue("Bearer", _config.AccessToken);

--- a/src/AbsCli/Configuration/ConfigManager.cs
+++ b/src/AbsCli/Configuration/ConfigManager.cs
@@ -72,6 +72,19 @@ public class ConfigManager
         Save(onDisk);
     }
 
+    /// <summary>
+    /// Persist rotated tokens by rewriting only the on-disk config. Same reason
+    /// as <see cref="UpdateVersionCheck"/>: saving a resolved <see cref="AppConfig"/>
+    /// would write an ABS_TOKEN or ABS_LIBRARY the operator kept out of the file.
+    /// </summary>
+    public void UpdateTokens(string? accessToken, string? refreshToken)
+    {
+        var onDisk = Load();
+        onDisk.AccessToken = accessToken;
+        onDisk.RefreshToken = refreshToken;
+        Save(onDisk);
+    }
+
     public AppConfig Resolve(
         string? flagServer = null,
         string? flagToken = null,

--- a/src/AbsCli/Configuration/ConfigManager.cs
+++ b/src/AbsCli/Configuration/ConfigManager.cs
@@ -26,7 +26,18 @@ public class ConfigManager
             return new AppConfig();
 
         var json = File.ReadAllText(_configPath);
-        return JsonSerializer.Deserialize(json, AppJsonContext.Default.AppConfig) ?? new AppConfig();
+        try
+        {
+            return JsonSerializer.Deserialize(json, AppJsonContext.Default.AppConfig) ?? new AppConfig();
+        }
+        catch (JsonException ex)
+        {
+            // Every command loads the config, so a raw parser message here is the
+            // only thing the operator ever sees. Name the file and the way out.
+            throw new InvalidOperationException(
+                $"Config file is not valid JSON: {_configPath} — delete it and run 'abs-cli login'. ({ex.Message})",
+                ex);
+        }
     }
 
     public void Save(AppConfig config)
@@ -36,7 +47,14 @@ public class ConfigManager
             Directory.CreateDirectory(dir);
 
         var json = JsonSerializer.Serialize(config, AppJsonContext.Default.AppConfig);
-        File.WriteAllText(_configPath, json);
+        // Write-then-rename. A truncated config.json costs a re-login: it holds the
+        // only copy of the refresh token, and the server rotates the old one away
+        // as soon as it is used.
+        var tmpPath = _configPath + ".tmp";
+        File.WriteAllText(tmpPath, json);
+        if (!OperatingSystem.IsWindows() && File.Exists(_configPath))
+            File.SetUnixFileMode(tmpPath, File.GetUnixFileMode(_configPath));
+        File.Move(tmpPath, _configPath, overwrite: true);
     }
 
     /// <summary>

--- a/src/AbsCli/Program.cs
+++ b/src/AbsCli/Program.cs
@@ -53,9 +53,13 @@ var debugEnabled = parseResult.GetValue(debugOption)
 var logJson = parseResult.GetValue(logJsonOption);
 LogSetup.Configure(debugEnabled, logJson);
 
+// Without this, System.CommandLine's own handler catches everything a command
+// throws, dumps a stack trace to stderr and returns 1 — the catch below never
+// runs. Off, so one exception surfaces as one logged error line.
+var invocation = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
 try
 {
-    return await parseResult.InvokeAsync();
+    return await parseResult.InvokeAsync(invocation);
 }
 catch (Exception ex)
 {

--- a/tests/AbsCli.Tests/Api/RefreshTokenPersistenceTests.cs
+++ b/tests/AbsCli.Tests/Api/RefreshTokenPersistenceTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using AbsCli.Api;
+using AbsCli.Configuration;
+using Xunit;
+
+namespace AbsCli.Tests.Api;
+
+[Collection("NLog")]
+public class RefreshTokenPersistenceTests : IDisposable
+{
+    private readonly HttpListener _listener = new();
+    private readonly string _server;
+    private readonly string _tempDir;
+
+    public RefreshTokenPersistenceTests()
+    {
+        _server = $"http://127.0.0.1:{FreePort()}/";
+        _listener.Prefixes.Add(_server);
+        _listener.Start();
+        _tempDir = Path.Combine(Path.GetTempPath(), $"abs-cli-refresh-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    private static int FreePort()
+    {
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+        return port;
+    }
+
+    private async Task ServeOneRefreshAsync()
+    {
+        var context = await _listener.GetContextAsync();
+        var body = Encoding.UTF8.GetBytes(
+            """{"user":{"id":"u1","username":"tester","accessToken":"new-access","refreshToken":"new-refresh"}}""");
+        context.Response.StatusCode = 200;
+        context.Response.ContentType = "application/json";
+        context.Response.ContentLength64 = body.Length;
+        await context.Response.OutputStream.WriteAsync(body);
+        context.Response.Close();
+    }
+
+    [Fact]
+    public async Task RefreshToken_PersistsRotatedTokens_WithoutWritingEnvValues()
+    {
+        var configPath = Path.Combine(_tempDir, "config.json");
+        var manager = new ConfigManager(configPath);
+        manager.Save(new AppConfig { Server = _server, AccessToken = "old-access", RefreshToken = "old-refresh" });
+        // Resolve() merges env into memory. A refresh must persist only the rotated
+        // tokens, never the env-supplied values that the operator kept out of the file.
+        var resolved = manager.Resolve(envLookup: key => key == "ABS_LIBRARY" ? "env-lib" : null);
+        Assert.Equal("env-lib", resolved.DefaultLibrary);
+
+        var serving = ServeOneRefreshAsync();
+        await new AbsApiClient(resolved, manager).RefreshTokenAsync();
+        await serving;
+
+        var onDisk = manager.Load();
+        Assert.Equal("new-access", onDisk.AccessToken);
+        Assert.Equal("new-refresh", onDisk.RefreshToken);
+        Assert.Null(onDisk.DefaultLibrary);
+        Assert.Equal(_server, onDisk.Server);
+    }
+
+    [Fact]
+    public async Task RefreshToken_UpdatesInMemoryConfig_SoTheSameProcessUsesTheNewToken()
+    {
+        var configPath = Path.Combine(_tempDir, "config.json");
+        var manager = new ConfigManager(configPath);
+        manager.Save(new AppConfig { Server = _server, AccessToken = "old-access", RefreshToken = "old-refresh" });
+        var config = manager.Resolve(envLookup: _ => null);
+
+        var serving = ServeOneRefreshAsync();
+        await new AbsApiClient(config, manager).RefreshTokenAsync();
+        await serving;
+
+        Assert.Equal("new-access", config.AccessToken);
+        Assert.Equal("new-refresh", config.RefreshToken);
+    }
+
+    public void Dispose()
+    {
+        _listener.Close();
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+}

--- a/tests/AbsCli.Tests/Configuration/ConfigManagerTests.cs
+++ b/tests/AbsCli.Tests/Configuration/ConfigManagerTests.cs
@@ -216,6 +216,40 @@ public class ConfigManagerTests
     }
 
     [Fact]
+    public void UpdateTokens_DoesNotPersistEnvValues()
+    {
+        var configPath = Path.Combine(_tempDir, "config.json");
+        var manager = new ConfigManager(configPath);
+        manager.Save(new AppConfig { Server = "https://file.example.com" });
+        var resolved = manager.Resolve(envLookup: key => key switch
+        {
+            "ABS_TOKEN" => "env-secret",
+            "ABS_LIBRARY" => "env-lib",
+            _ => null
+        });
+        Assert.Equal("env-secret", resolved.AccessToken);
+        manager.UpdateTokens("rotated-access", "rotated-refresh");
+        var reloaded = manager.Load();
+        Assert.Equal("rotated-access", reloaded.AccessToken);
+        Assert.Equal("rotated-refresh", reloaded.RefreshToken);
+        Assert.Null(reloaded.DefaultLibrary);
+        Assert.Equal("https://file.example.com", reloaded.Server);
+    }
+
+    [Fact]
+    public void UpdateTokens_PreservesVersionCheckState()
+    {
+        var configPath = Path.Combine(_tempDir, "config.json");
+        var manager = new ConfigManager(configPath);
+        var checkedAt = new DateTimeOffset(2026, 8, 12, 10, 0, 0, TimeSpan.Zero);
+        manager.UpdateVersionCheck("2.36.0", checkedAt);
+        manager.UpdateTokens("rotated-access", "rotated-refresh");
+        var reloaded = manager.Load();
+        Assert.Equal("2.36.0", reloaded.LastServerVersion);
+        Assert.Equal(checkedAt, reloaded.LastVersionCheck);
+    }
+
+    [Fact]
     public void Resolve_CarriesVersionCheckStateFromFile()
     {
         var configPath = Path.Combine(_tempDir, "config.json");

--- a/tests/AbsCli.Tests/Configuration/ConfigManagerTests.cs
+++ b/tests/AbsCli.Tests/Configuration/ConfigManagerTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using AbsCli.Configuration;
 
 namespace AbsCli.Tests.Configuration;
@@ -47,6 +48,58 @@ public class ConfigManagerTests
         Assert.Equal("access123", loaded.AccessToken);
         Assert.Equal("refresh456", loaded.RefreshToken);
         Assert.Equal("lib-id-1", loaded.DefaultLibrary);
+    }
+
+    [Fact]
+    public void Load_ThrowsActionableError_WhenFileIsNotJson()
+    {
+        var configPath = Path.Combine(_tempDir, "config.json");
+        File.WriteAllText(configPath, "not json{");
+        var manager = new ConfigManager(configPath);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => manager.Load());
+
+        Assert.Contains(configPath, ex.Message);
+        Assert.Contains("abs-cli login", ex.Message);
+        Assert.IsType<JsonException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void Save_ReplacesAtomically_SoAnOpenReaderStillSeesWholeOldFile()
+    {
+        var configPath = Path.Combine(_tempDir, "config.json");
+        var manager = new ConfigManager(configPath);
+        manager.Save(new AppConfig { Server = "https://old.example.com", RefreshToken = "old-refresh" });
+        var before = File.ReadAllText(configPath);
+        // A handle opened before the write must still read the complete old
+        // document: an atomic replace swaps the directory entry, it never
+        // truncates the bytes under someone else's handle.
+        using var reader = new FileStream(
+            configPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        manager.Save(new AppConfig { Server = "https://new.example.com", RefreshToken = "new-refresh" });
+        Assert.Equal(before, new StreamReader(reader).ReadToEnd());
+        Assert.Equal("https://new.example.com", manager.Load().Server);
+    }
+
+    [Fact]
+    public void Save_LeavesNoTempFileBehind()
+    {
+        var configPath = Path.Combine(_tempDir, "config.json");
+        var manager = new ConfigManager(configPath);
+        manager.Save(new AppConfig { Server = "https://example.com" });
+        Assert.Equal(new[] { "config.json" }, Directory.GetFiles(_tempDir).Select(Path.GetFileName).Order());
+    }
+
+    [Fact]
+    public void Save_PreservesRestrictiveFileMode()
+    {
+        if (OperatingSystem.IsWindows()) return;
+        var configPath = Path.Combine(_tempDir, "config.json");
+        var manager = new ConfigManager(configPath);
+        manager.Save(new AppConfig { Server = "https://example.com" });
+        File.SetUnixFileMode(configPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        manager.Save(new AppConfig { Server = "https://example.com", RefreshToken = "secret" });
+        Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(configPath));
     }
 
     [Fact]


### PR DESCRIPTION
Three related config-file defects, all on the path every command takes.

## 1. A corrupt `config.json` killed every command with a stack trace

`ConfigManager.Load` threw a raw `JsonException`. System.CommandLine's default exception handler caught it before `Program.cs`'s `catch` could, dumped 22 stack frames to stderr and returned 1 — so there was no actionable message, and `config get` was broken too, leaving no in-CLI way to recover.

- `ConfigManager.Load` now catches `JsonException` and names the file plus the way out.
- `Program.cs` sets `EnableDefaultExceptionHandler = false`, so *any* command exception surfaces as one logged error line via the existing handler. Exit code for thrown exceptions moves 1 → 2.

```
Unhandled exception: System.Text.Json.JsonException: 'not json{' is an invalid...
   at ... 22 stack frames ...                                            EXIT=1
→
ERROR Config file is not valid JSON: ~/.abs-cli/config.json — delete it
      and run 'abs-cli login'. ('not json{' is an invalid JSON literal...)   EXIT=2
```

## 2. `ConfigManager.Save` was a non-atomic `File.WriteAllText`

An interrupted write truncated the file holding the only copy of the refresh token — unrecoverable once the server has rotated the old one away, costing a re-login. Now writes to `config.json.tmp` and renames over the target. The existing file mode is carried onto the temp file, so a config chmod'd to 600 stays 600 rather than being reset to the umask default by the rename.

The 24h version-check cadence writes this file on a schedule, which is what widened the window onto that token.

## 3. Token refresh wrote env values into the file

`RefreshTokenAsync` saved the *resolved* `AppConfig`, so running with `ABS_TOKEN`, `ABS_SERVER` or `ABS_LIBRARY` set persisted those env values into a config the operator had deliberately kept them out of — the leak `UpdateVersionCheck`'s doc comment already warned about. Replaced with a new `ConfigManager.UpdateTokens`, load-then-patch, mirroring `UpdateVersionCheck`. `LoginCommand` already did this correctly and is unchanged.

## Tests

Six new tests, each watched fail first:

- `Load_ThrowsActionableError_WhenFileIsNotJson`
- `Save_ReplacesAtomically_SoAnOpenReaderStillSeesWholeOldFile` — a handle opened before the write must still read the complete old document. This is the real atomicity assertion, no filesystem seam required.
- `Save_LeavesNoTempFileBehind`, `Save_PreservesRestrictiveFileMode` — guards; these pass pre-fix by design and exist to pin what the rename must not break.
- `UpdateTokens_DoesNotPersistEnvValues`, `UpdateTokens_PreservesVersionCheckState`
- New `RefreshTokenPersistenceTests.cs` drives the real refresh path over a loopback `HttpListener` and asserts on what lands on disk — this is what proved the leak (`Expected: null / Actual: "env-lib"`) rather than just the unit-level shape.

`RefreshTokenAsync` went `private` → `internal` for the integration test. `InternalsVisibleTo AbsCli.Tests` already exists and `RecordServerVersion` is internal for the same reason.

## Verification

- [x] 429 unit tests pass
- [x] `dotnet format AbsCli.sln` clean
- [x] `docker/smoke-test.sh`: **338 passed, 0 failed** against a recreated + freshly seeded stack (run after the final commit)

Smoke matters here because the S.CL change alters every command's error path. Nothing depended on the old exit code: smoke has exactly one exit-code assertion and it checks `= 0`; every other failure case greps stderr text.

## Known limitation, deliberately not fixed

`UpdateVersionCheck` and `UpdateTokens` are unlocked read-modify-writes, so two concurrent invocations can clobber each other's fields. Neither can truncate the file any more, and in practice the version check writes once per day, so parallel CLI calls would have to collide within that first write to matter. A real fix needs a lock file; not worth it for this.