### PR TITLE
test: survive ABS's backup-apply crash and diagnose the help flake

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,15 @@ services:
     volumes:
       - abs-config:/config
       - abs-metadata:/metadata
+    # ABS can kill itself during `backup apply`: BackupManager.requestApplyBackup
+    # disconnects the database, then spends seconds extracting the sqlite file and
+    # the metadata-items/ + metadata-authors/ folders before reconnecting. Writing
+    # into /metadata wakes ABS's own folder watcher, whose handler queries the DB
+    # (library.findByPk) while it is disconnected — "ConnectionManager.getConnection
+    # was called after the connection manager was closed" — and the unhandled
+    # rejection exits the process. Without a restart policy that one upstream race
+    # takes the whole smoke suite down with it.
+    restart: unless-stopped
     environment:
       - PORT=80
       # The smoke test authenticates via `abs-cli login` at every section

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -143,9 +143,19 @@ for cmd in "login" "config get" "config set" \
            "tasks list" \
            "search"; do
     label="help+examples: abs-cli $cmd"
-    output=$($CLI $cmd --help 2>&1) || true
+    output=$($CLI $cmd --help 2>&1) && rc=0 || rc=$?
     if ! echo "$output" | grep -q "Description:\|Usage:"; then
-        fail "$label" "no help text"
+        # Seen once (2026-08-14) with no captured evidence, because this branch used
+        # to discard the output. `--help` touches no network and 650 consecutive
+        # invocations — including under four concurrent builds — never reproduced it,
+        # so retry once and report either way rather than guessing: a genuine break
+        # fails twice, and a transient one leaves a visible note instead of red.
+        retry=$($CLI $cmd --help 2>&1) && retry_rc=0 || retry_rc=$?
+        if echo "$retry" | grep -q "Description:\|Usage:"; then
+            pass "$label (passed on retry; first attempt rc=$rc, output=[${output:0:80}])"
+            continue
+        fi
+        fail "$label" "no help text after retry (rc=$rc then $retry_rc, output=[${output:0:200}])"
         continue
     fi
     example_count=$(echo "$output" | grep -c "abs-cli " || true)
@@ -698,8 +708,34 @@ output=$($CLI backup upload --file "$BACKUP_DL" 2>/dev/null)
 assert_json_key "backup upload returns backups" "backups" "$output"
 rm -f "$BACKUP_DL"
 
-output=$($CLI backup apply --id "$BACKUP_ID" 2>/dev/null)
-pass "backup apply completed (exit 0)"
+output=$($CLI backup apply --id "$BACKUP_ID" 2>/dev/null) && apply_rc=0 || apply_rc=$?
+if [ "$apply_rc" = "0" ]; then
+    pass "backup apply completed (exit 0)"
+else
+    fail "backup apply completed (exit 0)" "exit=$apply_rc"
+fi
+
+# Applying a backup disconnects ABS's database for as long as it takes to extract
+# the sqlite file and the metadata folders, and writing into /metadata wakes ABS's
+# own folder watcher, whose handler queries the DB while it is disconnected. That
+# unhandled rejection exits the process (see the note in docker-compose.yml, which
+# is why the stack has a restart policy). Wait for the server to answer again
+# before continuing, so one upstream race cannot cascade into every later
+# assertion.
+apply_wait_ok=0
+for i in $(seq 1 60); do
+    if curl -sf -m 3 "$ABS_URL/healthcheck" >/dev/null 2>&1; then
+        apply_wait_ok=1
+        [ "$i" -gt 1 ] && echo "  (server took ${i}s to answer after backup apply)"
+        break
+    fi
+    sleep 1
+done
+if [ "$apply_wait_ok" = "1" ]; then
+    pass "server responsive after backup apply"
+else
+    fail "server responsive after backup apply" "no healthcheck response within 60s"
+fi
 
 output=$($CLI backup delete --id "$BACKUP_ID" 2>/dev/null)
 assert_json_key "backup delete returns backups" "backups" "$output"


### PR DESCRIPTION
Both fragilities you asked me to look into. Each cost a full ~8-minute smoke cycle today.

## 1. The `backup apply` crash — root-caused, upstream

`BackupManager.requestApplyBackup` disconnects the database (`:214`), then spends seconds extracting the sqlite file, removing and moving the DB, and extracting `metadata-items/` and `metadata-authors/` before `Database.reconnect()` (`:253`).

Writing into `/metadata` wakes **ABS's own folder watcher**, whose handler queries the database while it is disconnected:

```
Error: ConnectionManager.getConnection was called after the connection manager was closed!
  at async library.findByPk (/app/node_modules/sequelize/lib/model.js:1221:12)
```

Node exits on the unhandled rejection, and with no `restart:` policy the container stayed dead — so the suite aborted mid-run under `set -euo pipefail` (exit 2, zero FAIL lines, output ending mid-section). It hit twice today, so it is timing-dependent on watcher debounce rather than rare.

Nothing here is fixable from our side — it is an upstream self-inflicted race, worth reporting to ABS separately. What is fixable is the blast radius:

- **`restart: unless-stopped`** on the dev stack, with the mechanism documented in a comment so the next person does not delete it as noise.
- **The suite waits for the server to answer again after `backup apply`** (60s budget, notes how long it took if more than a second) and asserts on it. Without the wait a restart would just move the failure to the next assertion.
- `backup apply`'s own exit code is now checked rather than assumed — it previously ran `pass` unconditionally, so a failing apply reported success.

Verified the policy does what I claim: killing ABS's main process the way its own crash does (`kill 1` in the container) previously left the stack dead; it now returns in ~2s, and the new health-wait absorbs the window.

## 2. The help flake — not reproducible, now diagnosable

`help+examples: abs-cli series get — no help text` fired once during the 2.33.1 run. `--help` touches no network, and I could not reproduce it:

- **400 consecutive invocations** in isolation — 0 failures
- **250 more under four concurrent `dotnet build` jobs** — 0 failures
- 16 GB with 7.5 GB free and no cgroup cap, so a plain OOM is implausible

So I am not claiming a root cause. The actionable defect is that the assertion **discarded the captured output**, unlike every sibling assertion — which is why the one occurrence taught us nothing. It now retries once and reports either way: a genuine break fails twice with the exit codes and output, a transient one leaves a visible `(passed on retry; …)` note instead of a red run that eats a cycle.

## Verification

- `bash -n docker/smoke-test.sh` and `docker compose config` — both clean
- Restart policy confirmed applied and effective (`kill 1` → back in 2s)
- Full smoke on a freshly seeded 2.36.0 stack — **339 passed, 0 failed, 0 skipped** (338 plus the new post-apply health assertion)

Shell and compose only; no CLI code touched.